### PR TITLE
Simpler Buffer Handling

### DIFF
--- a/src/harness.rs
+++ b/src/harness.rs
@@ -68,7 +68,9 @@ fn simulate_stdin_csv(
     ifmt: InputFormat,
     inp: impl Into<String>,
 ) -> impl llvm::IntoRuntime + runtime::LineReader {
-    simulate_stdin(inp, |reader, name| CSVReader::new(reader, ifmt, name))
+    simulate_stdin(inp, |reader, name| {
+        CSVReader::new(reader, ifmt, runtime::CHUNK_SIZE, name)
+    })
 }
 
 fn simulate_stdin_regex(inp: impl Into<String>) -> impl llvm::IntoRuntime + runtime::LineReader {

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,12 @@ fn dump_bytecode(prog: &str, raw: &RawPrelude) -> String {
     let fake_out: Box<dyn io::Write> = Box::new(Cursor::new(vec![]));
     let interp = match compile::bytecode(
         &mut ctx,
-        chained(CSVReader::new(fake_inp, InputFormat::CSV, "unused")),
+        chained(CSVReader::new(
+            fake_inp,
+            InputFormat::CSV,
+            CHUNK_SIZE,
+            "unused",
+        )),
         fake_out,
     ) {
         Ok(ctx) => ctx,
@@ -401,7 +406,7 @@ fn main() {
                 let _reader: Box<dyn io::Read> = Box::new(io::stdin());
                 match (ifmt, $analysis) {
                     (Some(ifmt), _) => {
-                        let $inp = chained(CSVReader::new(_reader, ifmt, "-"));
+                        let $inp = chained(CSVReader::new(_reader, ifmt, CHUNK_SIZE, "-"));
                         $body
                     }
                     (
@@ -445,7 +450,7 @@ fn main() {
             } else if let Some(ifmt) = ifmt {
                 let iter = opts.input_files.iter().cloned().map(|file| {
                     let reader: Box<dyn io::Read> = Box::new(open_file_read(file.as_str()));
-                    CSVReader::new(reader, ifmt, file)
+                    CSVReader::new(reader, ifmt, CHUNK_SIZE, file)
                 });
                 let $inp = ChainedReader::new(iter);
                 $body

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -323,8 +323,7 @@ impl<'a> Stepper<'a> {
     fn get(&mut self, line_start: usize, j: usize, cur: usize) -> usize {
         self.off.start = cur;
         if self.field_set.get(0) {
-            let line = mem::replace(&mut self.line.raw, Str::default());
-            self.line.raw = Str::concat(line, unsafe { self.buf.slice_to_str(line_start, j) });
+            self.line.raw = unsafe { self.buf.slice_to_str(line_start, j) };
         }
         self.line.len += j - line_start;
         self.prev_ix

--- a/src/runtime/splitter/mod.rs
+++ b/src/runtime/splitter/mod.rs
@@ -478,10 +478,6 @@ impl<R: Read> Reader<R> {
         res
     }
 
-    fn remaining(&self) -> usize {
-        self.end - self.start
-    }
-
     pub(crate) fn is_eof(&self) -> bool {
         self.end == self.start && self.state == ReaderState::EOF
     }
@@ -518,23 +514,6 @@ impl<R: Read> Reader<R> {
         self.input_end = input_len;
         self.start = 0;
         Ok(false)
-    }
-
-    // TODO: get rid of advance()
-    fn advance(&mut self, n: usize) -> Result<()> {
-        let len = self.end - self.start;
-        if len > n {
-            self.start += n;
-            return Ok(());
-        }
-        if self.is_eof() {
-            return Ok(());
-        }
-
-        self.start = self.end;
-        let residue = n - len;
-        self.reset()?;
-        self.advance(residue)
     }
 
     fn get_next_buf(

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -834,6 +834,15 @@ impl DynamicBufHeap {
     fn size(&self) -> usize {
         unsafe { (*self.data.0).size }
     }
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        self.data.as_mut_bytes()
+    }
+    pub fn write_head(&self) -> usize {
+        self.write_head
+    }
+    pub fn into_buf(self) -> Buf {
+        self.data.into_buf()
+    }
     pub unsafe fn into_str<'a>(mut self) -> Str<'a> {
         // Shrink the buffer to fit.
         self.realloc(self.write_head);

--- a/src/test_string_constants.rs
+++ b/src/test_string_constants.rs
@@ -83,8 +83,7 @@ will dance with you at the next ball.”
 
 The rest of the evening was spent in conjecturing how soon he would return Mr. Bennet’s visit, and
 determining when they should ask him to dinner."#;
-pub const VIRGIL: &'static str = r#"
-Arms, and the man I sing, who, forc'd by fate,
+pub const VIRGIL: &'static str = r#"Arms, and the man I sing, who, forc'd by fate,
 And haughty Juno's unrelenting hate,
 Expell'd and exil'd, left the Trojan shore.
 Long labors, both by sea and land, he bore,


### PR DESCRIPTION
This PR includes a refactor of some of the existing buffer management code in the "splitters" module.

We fetch data from standard input in chunks. Before this PR, splitters had to handle records that cross chunk boundaries. This has a few drawbacks

* Handing cross-chunk records complicates many of the invariants that splitters must maintain.
* Cross-chunk records have to be concatenated, which is a relatively slow operation compared with slicing into a contiguous buffer.

This PR prepends any "trailing" content from a buffer to the next buffer, and only feeds the splitters buffers that contain a complete record. It also includes increased test coverage, some bug fixes, and (anecdotally) improved performance. Lastly, this change will make some future features much easier to implement.