### PR TITLE
Reduce number of bytecode instructions

### DIFF
--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -210,16 +210,12 @@ pub(crate) enum Instr<'a> {
     Close(Reg<Str<'a>>),
 
     // Map operations
-    LookupIntInt(Reg<Int>, Reg<runtime::IntMap<Int>>, Reg<Int>),
-    LookupIntStr(Reg<Str<'a>>, Reg<runtime::IntMap<Str<'a>>>, Reg<Int>),
-    LookupIntFloat(Reg<Float>, Reg<runtime::IntMap<Float>>, Reg<Int>),
-    LookupStrInt(Reg<Int>, Reg<runtime::StrMap<'a, Int>>, Reg<Str<'a>>),
-    LookupStrStr(
-        Reg<Str<'a>>,
-        Reg<runtime::StrMap<'a, Str<'a>>>,
-        Reg<Str<'a>>,
-    ),
-    LookupStrFloat(Reg<Float>, Reg<runtime::StrMap<'a, Float>>, Reg<Str<'a>>),
+    Lookup {
+        map_ty: Ty,
+        dst: NumTy,
+        map: NumTy,
+        key: NumTy,
+    },
     ContainsIntInt(Reg<Int>, Reg<runtime::IntMap<Int>>, Reg<Int>),
     ContainsIntStr(Reg<Int>, Reg<runtime::IntMap<Str<'a>>>, Reg<Int>),
     ContainsIntFloat(Reg<Int>, Reg<runtime::IntMap<Float>>, Reg<Int>),
@@ -720,35 +716,16 @@ impl<'a> Instr<'a> {
                 out.accum(&mut f)
             }
             Close(file) => file.accum(&mut f),
-            LookupIntInt(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            LookupIntStr(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            LookupIntFloat(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            LookupStrInt(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            LookupStrStr(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            LookupStrFloat(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
+            Lookup {
+                map_ty,
+                dst,
+                map,
+                key,
+            } => {
+                let (k, v) = (map_ty.key().unwrap(), map_ty.val().unwrap());
+                f(*dst, v);
+                f(*key, k);
+                f(*map, *map_ty);
             }
             ContainsIntInt(res, arr, k) => {
                 res.accum(&mut f);

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -232,16 +232,11 @@ pub(crate) enum Instr<'a> {
         dst: NumTy,
         map: NumTy,
     },
-
-    IterBeginIntInt(Reg<runtime::Iter<Int>>, Reg<runtime::IntMap<Int>>),
-    IterBeginIntStr(Reg<runtime::Iter<Int>>, Reg<runtime::IntMap<Str<'a>>>),
-    IterBeginIntFloat(Reg<runtime::Iter<Int>>, Reg<runtime::IntMap<Float>>),
-    IterBeginStrInt(Reg<runtime::Iter<Str<'a>>>, Reg<runtime::StrMap<'a, Int>>),
-    IterBeginStrStr(
-        Reg<runtime::Iter<Str<'a>>>,
-        Reg<runtime::StrMap<'a, Str<'a>>>,
-    ),
-    IterBeginStrFloat(Reg<runtime::Iter<Str<'a>>>, Reg<runtime::StrMap<'a, Float>>),
+    IterBegin {
+        map_ty: Ty,
+        dst: NumTy,
+        map: NumTy,
+    },
     IterHasNextInt(Reg<Int>, Reg<runtime::Iter<Int>>),
     IterHasNextStr(Reg<Int>, Reg<runtime::Iter<Str<'a>>>),
     IterGetNextInt(Reg<Int>, Reg<runtime::Iter<Int>>),
@@ -745,6 +740,10 @@ impl<'a> Instr<'a> {
                 f(*dst, Ty::Int);
                 f(*map, *map_ty);
             }
+            IterBegin { map_ty, map, dst } => {
+                f(*dst, map_ty.key_iter().unwrap());
+                f(*map, *map_ty);
+            }
             StoreIntInt(arr, k, v) => {
                 arr.accum(&mut f);
                 k.accum(&mut f);
@@ -802,30 +801,6 @@ impl<'a> Instr<'a> {
             StoreSlotStrFloat(src, _) => src.accum(&mut f),
             StoreSlotStrStr(src, _) => src.accum(&mut f),
 
-            IterBeginIntInt(dst, arr) => {
-                dst.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            IterBeginIntFloat(dst, arr) => {
-                dst.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            IterBeginIntStr(dst, arr) => {
-                dst.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            IterBeginStrInt(dst, arr) => {
-                dst.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            IterBeginStrFloat(dst, arr) => {
-                dst.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            IterBeginStrStr(dst, arr) => {
-                dst.accum(&mut f);
-                arr.accum(&mut f)
-            }
             IterHasNextInt(dst, iter) => {
                 dst.accum(&mut f);
                 iter.accum(&mut f)

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -76,23 +76,7 @@ pub(crate) enum Instr<'a> {
     StrToFloat(Reg<Float>, Reg<Str<'a>>),
 
     // Assignment
-    MovInt(Reg<Int>, Reg<Int>),
-    MovFloat(Reg<Float>, Reg<Float>),
-    MovStr(Reg<Str<'a>>, Reg<Str<'a>>),
-
-    MovMapIntInt(Reg<runtime::IntMap<Int>>, Reg<runtime::IntMap<Int>>),
-    MovMapIntFloat(Reg<runtime::IntMap<Float>>, Reg<runtime::IntMap<Float>>),
-    MovMapIntStr(Reg<runtime::IntMap<Str<'a>>>, Reg<runtime::IntMap<Str<'a>>>),
-
-    MovMapStrInt(Reg<runtime::StrMap<'a, Int>>, Reg<runtime::StrMap<'a, Int>>),
-    MovMapStrFloat(
-        Reg<runtime::StrMap<'a, Float>>,
-        Reg<runtime::StrMap<'a, Float>>,
-    ),
-    MovMapStrStr(
-        Reg<runtime::StrMap<'a, Str<'a>>>,
-        Reg<runtime::StrMap<'a, Str<'a>>>,
-    ),
+    Mov(Ty, NumTy, NumTy),
 
     AllocMapIntInt(Reg<runtime::IntMap<Int>>),
     AllocMapIntFloat(Reg<runtime::IntMap<Float>>),
@@ -946,41 +930,9 @@ impl<'a> Instr<'a> {
                 dst.accum(&mut f);
                 iter.accum(&mut f)
             }
-            MovInt(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovFloat(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovStr(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovMapIntInt(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovMapIntFloat(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovMapIntStr(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovMapStrInt(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovMapStrFloat(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
-            }
-            MovMapStrStr(dst, src) => {
-                dst.accum(&mut f);
-                src.accum(&mut f)
+            Mov(ty, dst, src) => {
+                f(*dst, *ty);
+                f(*src, *ty);
             }
             AllocMapIntInt(dst) => dst.accum(f),
             AllocMapIntFloat(dst) => dst.accum(f),

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -216,12 +216,13 @@ pub(crate) enum Instr<'a> {
         map: NumTy,
         key: NumTy,
     },
-    ContainsIntInt(Reg<Int>, Reg<runtime::IntMap<Int>>, Reg<Int>),
-    ContainsIntStr(Reg<Int>, Reg<runtime::IntMap<Str<'a>>>, Reg<Int>),
-    ContainsIntFloat(Reg<Int>, Reg<runtime::IntMap<Float>>, Reg<Int>),
-    ContainsStrInt(Reg<Int>, Reg<runtime::StrMap<'a, Int>>, Reg<Str<'a>>),
-    ContainsStrStr(Reg<Int>, Reg<runtime::StrMap<'a, Str<'a>>>, Reg<Str<'a>>),
-    ContainsStrFloat(Reg<Int>, Reg<runtime::StrMap<'a, Float>>, Reg<Str<'a>>),
+    Contains {
+        map_ty: Ty,
+        dst: NumTy,
+        map: NumTy,
+        key: NumTy,
+    },
+
     DeleteIntInt(Reg<runtime::IntMap<Int>>, Reg<Int>),
     DeleteIntStr(Reg<runtime::IntMap<Str<'a>>>, Reg<Int>),
     DeleteIntFloat(Reg<runtime::IntMap<Float>>, Reg<Int>),
@@ -727,35 +728,16 @@ impl<'a> Instr<'a> {
                 f(*key, k);
                 f(*map, *map_ty);
             }
-            ContainsIntInt(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            ContainsIntStr(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            ContainsIntFloat(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            ContainsStrInt(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            ContainsStrStr(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            ContainsStrFloat(res, arr, k) => {
-                res.accum(&mut f);
-                arr.accum(&mut f);
-                k.accum(&mut f)
+            Contains {
+                map_ty,
+                dst,
+                map,
+                key,
+            } => {
+                let k = map_ty.key().unwrap();
+                f(*dst, Ty::Int);
+                f(*key, k);
+                f(*map, *map_ty);
             }
             DeleteIntInt(arr, k) => {
                 arr.accum(&mut f);

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -232,6 +232,12 @@ pub(crate) enum Instr<'a> {
         dst: NumTy,
         map: NumTy,
     },
+    Store {
+        map_ty: Ty,
+        map: NumTy,
+        key: NumTy,
+        val: NumTy,
+    },
     IterBegin {
         map_ty: Ty,
         dst: NumTy,
@@ -247,17 +253,6 @@ pub(crate) enum Instr<'a> {
         dst: NumTy,
         iter: NumTy,
     },
-    StoreIntInt(Reg<runtime::IntMap<Int>>, Reg<Int>, Reg<Int>),
-    StoreIntStr(Reg<runtime::IntMap<Str<'a>>>, Reg<Int>, Reg<Str<'a>>),
-    StoreIntFloat(Reg<runtime::IntMap<Float>>, Reg<Int>, Reg<Float>),
-    StoreStrInt(Reg<runtime::StrMap<'a, Int>>, Reg<Str<'a>>, Reg<Int>),
-    StoreStrStr(
-        Reg<runtime::StrMap<'a, Str<'a>>>,
-        Reg<Str<'a>>,
-        Reg<Str<'a>>,
-    ),
-    StoreStrFloat(Reg<runtime::StrMap<'a, Float>>, Reg<Str<'a>>, Reg<Float>),
-
     // Special variables
     LoadVarStr(Reg<Str<'a>>, Variable),
     StoreVarStr(Variable, Reg<Str<'a>>),
@@ -750,35 +745,15 @@ impl<'a> Instr<'a> {
                 f(*dst, map_ty.key_iter().unwrap());
                 f(*map, *map_ty);
             }
-            StoreIntInt(arr, k, v) => {
-                arr.accum(&mut f);
-                k.accum(&mut f);
-                v.accum(&mut f)
-            }
-            StoreIntFloat(arr, k, v) => {
-                arr.accum(&mut f);
-                k.accum(&mut f);
-                v.accum(&mut f)
-            }
-            StoreIntStr(arr, k, v) => {
-                arr.accum(&mut f);
-                k.accum(&mut f);
-                v.accum(&mut f)
-            }
-            StoreStrInt(arr, k, v) => {
-                arr.accum(&mut f);
-                k.accum(&mut f);
-                v.accum(&mut f)
-            }
-            StoreStrFloat(arr, k, v) => {
-                arr.accum(&mut f);
-                k.accum(&mut f);
-                v.accum(&mut f)
-            }
-            StoreStrStr(arr, k, v) => {
-                arr.accum(&mut f);
-                k.accum(&mut f);
-                v.accum(&mut f)
+            Store {
+                map_ty,
+                map,
+                key,
+                val,
+            } => {
+                f(*map, *map_ty);
+                f(*key, map_ty.key().unwrap());
+                f(*val, map_ty.val().unwrap());
             }
             LoadVarStr(dst, _var) => dst.accum(&mut f),
             StoreVarStr(_var, src) => src.accum(&mut f),

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -261,25 +261,16 @@ pub(crate) enum Instr<'a> {
     LoadVarIntMap(Reg<runtime::IntMap<Str<'a>>>, Variable),
     StoreVarIntMap(Variable, Reg<runtime::IntMap<Str<'a>>>),
 
-    LoadSlotInt(Reg<Int>, Int),
-    LoadSlotFloat(Reg<Float>, Int),
-    LoadSlotStr(Reg<Str<'a>>, Int),
-    LoadSlotIntInt(Reg<runtime::IntMap<Int>>, Int),
-    LoadSlotIntFloat(Reg<runtime::IntMap<Float>>, Int),
-    LoadSlotIntStr(Reg<runtime::IntMap<Str<'a>>>, Int),
-    LoadSlotStrInt(Reg<runtime::StrMap<'a, Int>>, Int),
-    LoadSlotStrFloat(Reg<runtime::StrMap<'a, Float>>, Int),
-    LoadSlotStrStr(Reg<runtime::StrMap<'a, Str<'a>>>, Int),
-
-    StoreSlotInt(Reg<Int>, Int),
-    StoreSlotFloat(Reg<Float>, Int),
-    StoreSlotStr(Reg<Str<'a>>, Int),
-    StoreSlotIntInt(Reg<runtime::IntMap<Int>>, Int),
-    StoreSlotIntFloat(Reg<runtime::IntMap<Float>>, Int),
-    StoreSlotIntStr(Reg<runtime::IntMap<Str<'a>>>, Int),
-    StoreSlotStrInt(Reg<runtime::StrMap<'a, Int>>, Int),
-    StoreSlotStrFloat(Reg<runtime::StrMap<'a, Float>>, Int),
-    StoreSlotStrStr(Reg<runtime::StrMap<'a, Str<'a>>>, Int),
+    LoadSlot {
+        ty: Ty,
+        slot: Int,
+        dst: NumTy,
+    },
+    StoreSlot {
+        ty: Ty,
+        slot: Int,
+        src: NumTy,
+    },
 
     // Control
     JmpIf(Reg<Int>, Label),
@@ -762,25 +753,8 @@ impl<'a> Instr<'a> {
             LoadVarIntMap(dst, _var) => dst.accum(&mut f),
             StoreVarIntMap(_var, src) => src.accum(&mut f),
 
-            LoadSlotInt(dst, _) => dst.accum(&mut f),
-            LoadSlotFloat(dst, _) => dst.accum(&mut f),
-            LoadSlotStr(dst, _) => dst.accum(&mut f),
-            LoadSlotIntInt(dst, _) => dst.accum(&mut f),
-            LoadSlotIntFloat(dst, _) => dst.accum(&mut f),
-            LoadSlotIntStr(dst, _) => dst.accum(&mut f),
-            LoadSlotStrInt(dst, _) => dst.accum(&mut f),
-            LoadSlotStrFloat(dst, _) => dst.accum(&mut f),
-            LoadSlotStrStr(dst, _) => dst.accum(&mut f),
-
-            StoreSlotInt(src, _) => src.accum(&mut f),
-            StoreSlotFloat(src, _) => src.accum(&mut f),
-            StoreSlotStr(src, _) => src.accum(&mut f),
-            StoreSlotIntInt(src, _) => src.accum(&mut f),
-            StoreSlotIntFloat(src, _) => src.accum(&mut f),
-            StoreSlotIntStr(src, _) => src.accum(&mut f),
-            StoreSlotStrInt(src, _) => src.accum(&mut f),
-            StoreSlotStrFloat(src, _) => src.accum(&mut f),
-            StoreSlotStrStr(src, _) => src.accum(&mut f),
+            LoadSlot { ty, dst, .. } => f(*dst, *ty),
+            StoreSlot { ty, src, .. } => f(*src, *ty),
 
             IterHasNext { iter_ty, dst, iter } => {
                 f(*dst, Ty::Int);

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -222,13 +222,11 @@ pub(crate) enum Instr<'a> {
         map: NumTy,
         key: NumTy,
     },
-
-    DeleteIntInt(Reg<runtime::IntMap<Int>>, Reg<Int>),
-    DeleteIntStr(Reg<runtime::IntMap<Str<'a>>>, Reg<Int>),
-    DeleteIntFloat(Reg<runtime::IntMap<Float>>, Reg<Int>),
-    DeleteStrInt(Reg<runtime::StrMap<'a, Int>>, Reg<Str<'a>>),
-    DeleteStrStr(Reg<runtime::StrMap<'a, Str<'a>>>, Reg<Str<'a>>),
-    DeleteStrFloat(Reg<runtime::StrMap<'a, Float>>, Reg<Str<'a>>),
+    Delete {
+        map_ty: Ty,
+        map: NumTy,
+        key: NumTy,
+    },
     LenIntInt(Reg<Int>, Reg<runtime::IntMap<Int>>),
     LenIntFloat(Reg<Int>, Reg<runtime::IntMap<Float>>),
     LenIntStr(Reg<Int>, Reg<runtime::IntMap<Str<'a>>>),
@@ -739,29 +737,10 @@ impl<'a> Instr<'a> {
                 f(*key, k);
                 f(*map, *map_ty);
             }
-            DeleteIntInt(arr, k) => {
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            DeleteIntFloat(arr, k) => {
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            DeleteIntStr(arr, k) => {
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            DeleteStrInt(arr, k) => {
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            DeleteStrFloat(arr, k) => {
-                arr.accum(&mut f);
-                k.accum(&mut f)
-            }
-            DeleteStrStr(arr, k) => {
-                arr.accum(&mut f);
-                k.accum(&mut f)
+            Delete { map_ty, map, key } => {
+                let k = map_ty.key().unwrap();
+                f(*key, k);
+                f(*map, *map_ty);
             }
             LenIntInt(res, arr) => {
                 res.accum(&mut f);

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -237,10 +237,16 @@ pub(crate) enum Instr<'a> {
         dst: NumTy,
         map: NumTy,
     },
-    IterHasNextInt(Reg<Int>, Reg<runtime::Iter<Int>>),
-    IterHasNextStr(Reg<Int>, Reg<runtime::Iter<Str<'a>>>),
-    IterGetNextInt(Reg<Int>, Reg<runtime::Iter<Int>>),
-    IterGetNextStr(Reg<Str<'a>>, Reg<runtime::Iter<Str<'a>>>),
+    IterHasNext {
+        iter_ty: Ty,
+        dst: NumTy,
+        iter: NumTy,
+    },
+    IterGetNext {
+        iter_ty: Ty,
+        dst: NumTy,
+        iter: NumTy,
+    },
     StoreIntInt(Reg<runtime::IntMap<Int>>, Reg<Int>, Reg<Int>),
     StoreIntStr(Reg<runtime::IntMap<Str<'a>>>, Reg<Int>, Reg<Str<'a>>),
     StoreIntFloat(Reg<runtime::IntMap<Float>>, Reg<Int>, Reg<Float>),
@@ -801,21 +807,13 @@ impl<'a> Instr<'a> {
             StoreSlotStrFloat(src, _) => src.accum(&mut f),
             StoreSlotStrStr(src, _) => src.accum(&mut f),
 
-            IterHasNextInt(dst, iter) => {
-                dst.accum(&mut f);
-                iter.accum(&mut f)
+            IterHasNext { iter_ty, dst, iter } => {
+                f(*dst, Ty::Int);
+                f(*iter, *iter_ty);
             }
-            IterHasNextStr(dst, iter) => {
-                dst.accum(&mut f);
-                iter.accum(&mut f)
-            }
-            IterGetNextInt(dst, iter) => {
-                dst.accum(&mut f);
-                iter.accum(&mut f)
-            }
-            IterGetNextStr(dst, iter) => {
-                dst.accum(&mut f);
-                iter.accum(&mut f)
+            IterGetNext { iter_ty, dst, iter } => {
+                f(*dst, iter_ty.iter().unwrap());
+                f(*iter, *iter_ty);
             }
             Mov(ty, dst, src) => {
                 f(*dst, *ty);

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -227,12 +227,11 @@ pub(crate) enum Instr<'a> {
         map: NumTy,
         key: NumTy,
     },
-    LenIntInt(Reg<Int>, Reg<runtime::IntMap<Int>>),
-    LenIntFloat(Reg<Int>, Reg<runtime::IntMap<Float>>),
-    LenIntStr(Reg<Int>, Reg<runtime::IntMap<Str<'a>>>),
-    LenStrInt(Reg<Int>, Reg<runtime::StrMap<'a, Int>>),
-    LenStrFloat(Reg<Int>, Reg<runtime::StrMap<'a, Float>>),
-    LenStrStr(Reg<Int>, Reg<runtime::StrMap<'a, Str<'a>>>),
+    Len {
+        map_ty: Ty,
+        dst: NumTy,
+        map: NumTy,
+    },
 
     IterBeginIntInt(Reg<runtime::Iter<Int>>, Reg<runtime::IntMap<Int>>),
     IterBeginIntStr(Reg<runtime::Iter<Int>>, Reg<runtime::IntMap<Str<'a>>>),
@@ -742,29 +741,9 @@ impl<'a> Instr<'a> {
                 f(*key, k);
                 f(*map, *map_ty);
             }
-            LenIntInt(res, arr) => {
-                res.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            LenIntFloat(res, arr) => {
-                res.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            LenIntStr(res, arr) => {
-                res.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            LenStrInt(res, arr) => {
-                res.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            LenStrFloat(res, arr) => {
-                res.accum(&mut f);
-                arr.accum(&mut f)
-            }
-            LenStrStr(res, arr) => {
-                res.accum(&mut f);
-                arr.accum(&mut f)
+            Len { map_ty, map, dst } => {
+                f(*dst, Ty::Int);
+                f(*map, *map_ty);
             }
             StoreIntInt(arr, k, v) => {
                 arr.accum(&mut f);

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -76,16 +76,11 @@ pub(crate) enum Instr<'a> {
     StrToFloat(Reg<Float>, Reg<Str<'a>>),
 
     // Assignment
-    Mov(Ty, NumTy, NumTy),
-
-    AllocMapIntInt(Reg<runtime::IntMap<Int>>),
-    AllocMapIntFloat(Reg<runtime::IntMap<Float>>),
-    AllocMapIntStr(Reg<runtime::IntMap<Str<'a>>>),
-    AllocMapStrInt(Reg<runtime::StrMap<'a, Int>>),
-    AllocMapStrFloat(Reg<runtime::StrMap<'a, Float>>),
-    AllocMapStrStr(Reg<runtime::StrMap<'a, Str<'a>>>),
     // Note, for now we do not support iterator moves. Iterators own their own copy of an array,
     // and there is no reason we should be emitting movs for them.
+    Mov(Ty, NumTy, NumTy),
+
+    AllocMap(Ty, NumTy),
 
     // Math
     AddInt(Reg<Int>, Reg<Int>, Reg<Int>),
@@ -934,12 +929,7 @@ impl<'a> Instr<'a> {
                 f(*dst, *ty);
                 f(*src, *ty);
             }
-            AllocMapIntInt(dst) => dst.accum(f),
-            AllocMapIntFloat(dst) => dst.accum(f),
-            AllocMapIntStr(dst) => dst.accum(f),
-            AllocMapStrInt(dst) => dst.accum(f),
-            AllocMapStrFloat(dst) => dst.accum(f),
-            AllocMapStrStr(dst) => dst.accum(f),
+            AllocMap(ty, reg) => f(*reg, *ty),
             ReadErr(dst, file) => {
                 dst.accum(&mut f);
                 file.accum(&mut f)

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -391,12 +391,9 @@ fn push_var<'a>(instrs: &mut Vec<LL<'a>>, reg: NumTy, ty: Ty) -> Result<()> {
 fn alloc_local<'a>(dst_reg: NumTy, dst_ty: Ty) -> Option<LL<'a>> {
     use Ty::*;
     match dst_ty {
-        MapIntInt => Some(LL::AllocMapIntInt(dst_reg.into())),
-        MapIntFloat => Some(LL::AllocMapIntFloat(dst_reg.into())),
-        MapIntStr => Some(LL::AllocMapIntStr(dst_reg.into())),
-        MapStrInt => Some(LL::AllocMapStrInt(dst_reg.into())),
-        MapStrFloat => Some(LL::AllocMapStrFloat(dst_reg.into())),
-        MapStrStr => Some(LL::AllocMapStrStr(dst_reg.into())),
+        MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat | MapStrStr => {
+            Some(LL::AllocMap(dst_ty, dst_reg))
+        }
         _ => None,
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1410,25 +1410,18 @@ impl<'a, 'b> View<'a, 'b> {
                 self.pushl(LL::PrintStdout(conv_regs[0].into()));
                 return Ok(());
             }
+
             Delete => match &conv_tys[0] {
-                Ty::MapIntInt => {
-                    self.pushl(LL::DeleteIntInt(conv_regs[0].into(), conv_regs[1].into()))
-                }
-                Ty::MapIntStr => {
-                    self.pushl(LL::DeleteIntStr(conv_regs[0].into(), conv_regs[1].into()))
-                }
-                Ty::MapIntFloat => {
-                    self.pushl(LL::DeleteIntFloat(conv_regs[0].into(), conv_regs[1].into()))
-                }
-                Ty::MapStrInt => {
-                    self.pushl(LL::DeleteStrInt(conv_regs[0].into(), conv_regs[1].into()))
-                }
-                Ty::MapStrStr => {
-                    self.pushl(LL::DeleteStrStr(conv_regs[0].into(), conv_regs[1].into()))
-                }
-                Ty::MapStrFloat => {
-                    self.pushl(LL::DeleteStrFloat(conv_regs[0].into(), conv_regs[1].into()))
-                }
+                Ty::MapIntInt
+                | Ty::MapIntStr
+                | Ty::MapIntFloat
+                | Ty::MapStrInt
+                | Ty::MapStrStr
+                | Ty::MapStrFloat => self.pushl(LL::Delete {
+                    map_ty: conv_tys[0],
+                    map: conv_regs[0],
+                    key: conv_regs[1],
+                }),
                 _ => return err!("incorrect parameter types for Delete: {:?}", &conv_tys[..]),
             },
             Close => {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1124,17 +1124,18 @@ impl<'a, 'b> View<'a, 'b> {
 
         // Emit the corresponding instruction.
         use Ty::*;
-        self.pushl(match arr_ty {
-            MapIntInt => LL::LookupIntInt(load_reg.into(), arr_reg.into(), key_reg.into()),
-            MapIntFloat => LL::LookupIntFloat(load_reg.into(), arr_reg.into(), key_reg.into()),
-            MapIntStr => LL::LookupIntStr(load_reg.into(), arr_reg.into(), key_reg.into()),
-            MapStrInt => LL::LookupStrInt(load_reg.into(), arr_reg.into(), key_reg.into()),
-            MapStrFloat => LL::LookupStrFloat(load_reg.into(), arr_reg.into(), key_reg.into()),
-            MapStrStr => LL::LookupStrStr(load_reg.into(), arr_reg.into(), key_reg.into()),
+        match arr_ty {
+            MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat | MapStrStr => self
+                .pushl(LL::Lookup {
+                    map_ty: arr_ty,
+                    dst: load_reg,
+                    map: arr_reg,
+                    key: key_reg,
+                }),
             Null | Int | Float | Str | IterInt | IterStr => {
                 return err!("[load_map] expected map type, found {:?}", arr_ty)
             }
-        });
+        };
         // Convert the result: note that if we had load_reg == dst_reg, then this is a noop.
         self.convert(dst_reg, dst_ty, load_reg, arr_val_ty)
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1385,12 +1385,16 @@ impl<'a, 'b> View<'a, 'b> {
                 if res_reg != UNUSED {
                     self.pushl(match conv_tys[0] {
                         Ty::Null => LL::StoreConstInt(res_reg.into(), 0),
-                        Ty::MapIntInt => LL::LenIntInt(res_reg.into(), conv_regs[0].into()),
-                        Ty::MapIntStr => LL::LenIntStr(res_reg.into(), conv_regs[0].into()),
-                        Ty::MapIntFloat => LL::LenIntFloat(res_reg.into(), conv_regs[0].into()),
-                        Ty::MapStrInt => LL::LenStrInt(res_reg.into(), conv_regs[0].into()),
-                        Ty::MapStrStr => LL::LenStrStr(res_reg.into(), conv_regs[0].into()),
-                        Ty::MapStrFloat => LL::LenStrFloat(res_reg.into(), conv_regs[0].into()),
+                        Ty::MapIntInt
+                        | Ty::MapIntStr
+                        | Ty::MapIntFloat
+                        | Ty::MapStrInt
+                        | Ty::MapStrStr
+                        | Ty::MapStrFloat => LL::Len {
+                            map_ty: conv_tys[0],
+                            map: conv_regs[0],
+                            dst: res_reg.into(),
+                        },
                         Ty::Str => LL::LenStr(res_reg.into(), conv_regs[0].into()),
                         _ => return err!("invalid input type for length: {:?}", &conv_tys[..]),
                     })

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1675,13 +1675,15 @@ impl<'a, 'b> View<'a, 'b> {
                 let v_reg = self.regs.stats.reg_of_ty(v_ty);
                 self.expr(v_reg, v_ty, pe)?;
                 use Ty::*;
-                self.pushl(match a_ty {
-                    MapIntInt => LL::StoreIntInt(a_reg.into(), k_reg.into(), v_reg.into()),
-                    MapIntFloat => LL::StoreIntFloat(a_reg.into(), k_reg.into(), v_reg.into()),
-                    MapIntStr => LL::StoreIntStr(a_reg.into(), k_reg.into(), v_reg.into()),
-                    MapStrInt => LL::StoreStrInt(a_reg.into(), k_reg.into(), v_reg.into()),
-                    MapStrFloat => LL::StoreStrFloat(a_reg.into(), k_reg.into(), v_reg.into()),
-                    MapStrStr => LL::StoreStrStr(a_reg.into(), k_reg.into(), v_reg.into()),
+                match a_ty {
+                    MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat | MapStrStr => {
+                        self.pushl(LL::Store {
+                            map_ty: a_ty,
+                            map: a_reg,
+                            key: k_reg,
+                            val: v_reg,
+                        })
+                    }
                     Null | Int | Float | Str | IterInt | IterStr => {
                         return err!(
                             "in stmt {:?} computed type is non-map type {:?}",
@@ -1689,7 +1691,7 @@ impl<'a, 'b> View<'a, 'b> {
                             a_ty
                         )
                     }
-                });
+                };
             }
             PrimStmt::AsgnVar(id, pe) => {
                 let (dst_reg, dst_ty) = self.reg_of_ident(id);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -367,16 +367,9 @@ fn pop_var<'a>(instrs: &mut Vec<LL<'a>>, reg: NumTy, ty: Ty) -> Result<()> {
     use Ty::*;
     instrs.push(match ty {
         Null => return Ok(()),
-        Int => LL::PopInt(reg.into()),
-        Float => LL::PopFloat(reg.into()),
-        Str => LL::PopStr(reg.into()),
-        MapIntInt => LL::PopIntInt(reg.into()),
-        MapIntFloat => LL::PopIntFloat(reg.into()),
-        MapIntStr => LL::PopIntStr(reg.into()),
-        MapStrInt => LL::PopStrInt(reg.into()),
-        MapStrFloat => LL::PopStrFloat(reg.into()),
-        MapStrStr => LL::PopStrStr(reg.into()),
         IterInt | IterStr => return err!("invalid argument type: {:?}", ty),
+        Int | Float | Str | MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat
+        | MapStrStr => LL::Pop(ty, reg),
     });
     Ok(())
 }
@@ -385,15 +378,8 @@ fn push_var<'a>(instrs: &mut Vec<LL<'a>>, reg: NumTy, ty: Ty) -> Result<()> {
     use Ty::*;
     instrs.push(match ty {
         Null => return Ok(()),
-        Int => LL::PushInt(reg.into()),
-        Float => LL::PushFloat(reg.into()),
-        Str => LL::PushStr(reg.into()),
-        MapIntInt => LL::PushIntInt(reg.into()),
-        MapIntFloat => LL::PushIntFloat(reg.into()),
-        MapIntStr => LL::PushIntStr(reg.into()),
-        MapStrInt => LL::PushStrInt(reg.into()),
-        MapStrFloat => LL::PushStrFloat(reg.into()),
-        MapStrStr => LL::PushStrStr(reg.into()),
+        Int | Float | Str | MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat
+        | MapStrStr => LL::Push(ty, reg),
         IterInt | IterStr => return err!("invalid argument type: {:?}", ty),
     });
     Ok(())

--- a/src/cross_stage.rs
+++ b/src/cross_stage.rs
@@ -18,36 +18,30 @@ pub(crate) struct SlotOps {
 
 pub(crate) fn load_slot_instr<'a>(reg: NumTy, ty: Ty, slot: usize) -> Result<Option<LL<'a>>> {
     use Ty::*;
-    Ok(Some(match ty {
-        Int => LL::LoadSlotInt(reg.into(), slot as _),
-        Float => LL::LoadSlotFloat(reg.into(), slot as _),
-        Str => LL::LoadSlotStr(reg.into(), slot as _),
-        MapIntInt => LL::LoadSlotIntInt(reg.into(), slot as _),
-        MapIntFloat => LL::LoadSlotIntFloat(reg.into(), slot as _),
-        MapIntStr => LL::LoadSlotIntStr(reg.into(), slot as _),
-        MapStrInt => LL::LoadSlotStrInt(reg.into(), slot as _),
-        MapStrFloat => LL::LoadSlotStrFloat(reg.into(), slot as _),
-        MapStrStr => LL::LoadSlotStrStr(reg.into(), slot as _),
-        Null => return Ok(None),
-        IterInt | IterStr => return err!("unexpected slot type: {:?}", ty),
-    }))
+    match ty {
+        Int | Float | Str | MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat
+        | MapStrStr => Ok(Some(LL::LoadSlot {
+            ty,
+            dst: reg,
+            slot: slot as _,
+        })),
+        Null => Ok(None),
+        IterInt | IterStr => err!("unexpected slot type: {:?}", ty),
+    }
 }
 
 pub(crate) fn store_slot_instr<'a>(reg: NumTy, ty: Ty, slot: usize) -> Result<Option<LL<'a>>> {
     use Ty::*;
-    Ok(Some(match ty {
-        Int => LL::StoreSlotInt(reg.into(), slot as _),
-        Float => LL::StoreSlotFloat(reg.into(), slot as _),
-        Str => LL::StoreSlotStr(reg.into(), slot as _),
-        MapIntInt => LL::StoreSlotIntInt(reg.into(), slot as _),
-        MapIntFloat => LL::StoreSlotIntFloat(reg.into(), slot as _),
-        MapIntStr => LL::StoreSlotIntStr(reg.into(), slot as _),
-        MapStrInt => LL::StoreSlotStrInt(reg.into(), slot as _),
-        MapStrFloat => LL::StoreSlotStrFloat(reg.into(), slot as _),
-        MapStrStr => LL::StoreSlotStrStr(reg.into(), slot as _),
-        Null => return Ok(None),
-        IterInt | IterStr => return err!("unexpected slot type: {:?}", ty),
-    }))
+    match ty {
+        Int | Float | Str | MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat
+        | MapStrStr => Ok(Some(LL::StoreSlot {
+            ty,
+            src: reg,
+            slot: slot as _,
+        })),
+        Null => Ok(None),
+        IterInt | IterStr => err!("unexpected slot type: {:?}", ty),
+    }
 }
 
 fn compute_par(

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1294,30 +1294,8 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         *self.get_mut(dst) = res;
                     }
                     Mov(ty, dst, src) => self.mov(*ty, *dst, *src),
-                    AllocMapIntInt(dst) => {
-                        let dst = *dst;
-                        *self.get_mut(dst) = Default::default();
-                    }
-                    AllocMapIntFloat(dst) => {
-                        let dst = *dst;
-                        *self.get_mut(dst) = Default::default();
-                    }
-                    AllocMapIntStr(dst) => {
-                        let dst = *dst;
-                        *self.get_mut(dst) = Default::default();
-                    }
-                    AllocMapStrInt(dst) => {
-                        let dst = *dst;
-                        *self.get_mut(dst) = Default::default();
-                    }
-                    AllocMapStrFloat(dst) => {
-                        let dst = *dst;
-                        *self.get_mut(dst) = Default::default();
-                    }
-                    AllocMapStrStr(dst) => {
-                        let dst = *dst;
-                        *self.get_mut(dst) = Default::default();
-                    }
+                    AllocMap(ty, reg) => self.alloc_map(*ty, *reg),
+
                     // TODO add error logging for these errors perhaps?
                     ReadErr(dst, file) => {
                         let dst = *dst;
@@ -1510,6 +1488,23 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
             }
             Ty::Null | Ty::IterInt | Ty::IterStr => {
                 panic!("invalid type for move operation: {:?}", ty)
+            }
+        }
+    }
+    fn alloc_map(&mut self, ty: Ty, reg: NumTy) {
+        match ty {
+            Ty::MapIntInt => *index_mut(&mut self.maps_int_int, &reg.into()) = Default::default(),
+            Ty::MapIntFloat => {
+                *index_mut(&mut self.maps_int_float, &reg.into()) = Default::default()
+            }
+            Ty::MapIntStr => *index_mut(&mut self.maps_int_str, &reg.into()) = Default::default(),
+            Ty::MapStrInt => *index_mut(&mut self.maps_str_int, &reg.into()) = Default::default(),
+            Ty::MapStrFloat => {
+                *index_mut(&mut self.maps_str_float, &reg.into()) = Default::default()
+            }
+            Ty::MapStrStr => *index_mut(&mut self.maps_str_str, &reg.into()) = Default::default(),
+            Ty::Null | Ty::Int | Ty::Float | Ty::Str | Ty::IterInt | Ty::IterStr => {
+                panic!("non-map type for alloc operation: {:?}", ty)
             }
         }
     }

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1293,60 +1293,7 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         let dst = *dst;
                         *self.get_mut(dst) = res;
                     }
-                    MovInt(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovFloat(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovStr(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovMapIntInt(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovMapIntFloat(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovMapIntStr(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovMapStrInt(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovMapStrFloat(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
-                    MovMapStrStr(dst, src) => {
-                        let src = *src;
-                        let src_contents = self.get(src).clone();
-                        let dst = *dst;
-                        *self.get_mut(dst) = src_contents;
-                    }
+                    Mov(ty, dst, src) => self.mov(*ty, *dst, *src),
                     AllocMapIntInt(dst) => {
                         let dst = *dst;
                         *self.get_mut(dst) = Default::default();
@@ -1521,6 +1468,49 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                 };
                 break cur + 1;
             };
+        }
+    }
+    fn mov(&mut self, ty: Ty, dst: NumTy, src: NumTy) {
+        match ty {
+            Ty::Int => {
+                let src = *index(&self.ints, &src.into());
+                *index_mut(&mut self.ints, &dst.into()) = src;
+            }
+            Ty::Float => {
+                let src = *index(&self.floats, &src.into());
+                *index_mut(&mut self.floats, &dst.into()) = src;
+            }
+            Ty::Str => {
+                let src = index(&self.strs, &src.into()).clone();
+                *index_mut(&mut self.strs, &dst.into()) = src;
+            }
+            Ty::MapIntInt => {
+                let src = index(&self.maps_int_int, &src.into()).clone();
+                *index_mut(&mut self.maps_int_int, &dst.into()) = src;
+            }
+            Ty::MapIntFloat => {
+                let src = index(&self.maps_int_float, &src.into()).clone();
+                *index_mut(&mut self.maps_int_float, &dst.into()) = src;
+            }
+            Ty::MapIntStr => {
+                let src = index(&self.maps_int_str, &src.into()).clone();
+                *index_mut(&mut self.maps_int_str, &dst.into()) = src;
+            }
+            Ty::MapStrInt => {
+                let src = index(&self.maps_str_int, &src.into()).clone();
+                *index_mut(&mut self.maps_str_int, &dst.into()) = src;
+            }
+            Ty::MapStrFloat => {
+                let src = index(&self.maps_str_float, &src.into()).clone();
+                *index_mut(&mut self.maps_str_float, &dst.into()) = src;
+            }
+            Ty::MapStrStr => {
+                let src = index(&self.maps_str_str, &src.into()).clone();
+                *index_mut(&mut self.maps_str_str, &dst.into()) = src;
+            }
+            Ty::Null | Ty::IterInt | Ty::IterStr => {
+                panic!("invalid type for move operation: {:?}", ty)
+            }
         }
     }
 }

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1090,42 +1090,7 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         key,
                     } => self.contains(*map_ty, *dst, *map, *key),
                     Delete { map_ty, map, key } => self.delete(*map_ty, *map, *key),
-                    LenIntInt(res, arr) => {
-                        let arr = *arr;
-                        let len = self.get(arr).len();
-                        let res = *res;
-                        *self.get_mut(res) = len as Int;
-                    }
-                    LenIntFloat(res, arr) => {
-                        let arr = *arr;
-                        let len = self.get(arr).len();
-                        let res = *res;
-                        *self.get_mut(res) = len as Int;
-                    }
-                    LenIntStr(res, arr) => {
-                        let arr = *arr;
-                        let len = self.get(arr).len();
-                        let res = *res;
-                        *self.get_mut(res) = len as Int;
-                    }
-                    LenStrInt(res, arr) => {
-                        let arr = *arr;
-                        let len = self.get(arr).len();
-                        let res = *res;
-                        *self.get_mut(res) = len as Int;
-                    }
-                    LenStrFloat(res, arr) => {
-                        let arr = *arr;
-                        let len = self.get(arr).len();
-                        let res = *res;
-                        *self.get_mut(res) = len as Int;
-                    }
-                    LenStrStr(res, arr) => {
-                        let arr = *arr;
-                        let len = self.get(arr).len();
-                        let res = *res;
-                        *self.get_mut(res) = len as Int;
-                    }
+                    Len { map_ty, map, dst } => self.len(*map_ty, *map, *dst),
                     StoreIntInt(arr, k, v) => {
                         let arr = index(&self.maps_int_int, arr);
                         let k = index(&self.ints, k).clone();
@@ -1468,6 +1433,10 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
         map_regs!(map_ty, map, key, _v, {
             self.get(map).delete(self.get(key))
         });
+    }
+    fn len(&mut self, map_ty: Ty, map: NumTy, dst: NumTy) {
+        let len = map_regs!(map_ty, map, self.get(map).len() as Int);
+        *index_mut(&mut self.ints, &dst.into()) = len;
     }
 }
 

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1,5 +1,5 @@
 use crate::builtins::Variable;
-use crate::bytecode::{Get, Instr, Label, Pop, Reg};
+use crate::bytecode::{Get, Instr, Label, Reg};
 use crate::common::{NumTy, Result, Stage};
 use crate::compile::{self, Ty};
 use crate::pushdown::FieldSet;
@@ -1192,79 +1192,8 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                     Jmp(lbl) => {
                         break lbl.0 as usize;
                     }
-                    PushInt(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushFloat(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushStr(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushIntInt(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushIntFloat(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushIntStr(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushStrInt(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushStrFloat(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-                    PushStrStr(reg) => {
-                        let reg = *reg;
-                        self.push(reg)
-                    }
-
-                    PopInt(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopFloat(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopStr(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopIntInt(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopIntFloat(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopIntStr(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopStrInt(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopStrFloat(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
-                    PopStrStr(reg) => {
-                        let reg = *reg;
-                        self.pop(reg)
-                    }
+                    Push(ty, reg) => self.push_reg(*ty, *reg),
+                    Pop(ty, reg) => self.pop_reg(*ty, *reg),
                     Call(func) => {
                         self.stack.push((cur_fn, Label(cur + 1)));
                         cur_fn = *func;
@@ -1441,6 +1370,50 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
             Ty::MapStrFloat => do_store!(store_strfloat, maps_str_float),
             Ty::MapStrStr => do_store!(store_strstr, maps_str_str),
             Ty::Null | Ty::IterInt | Ty::IterStr => panic!("unsupported slot type: {:?}", ty),
+        }
+    }
+    fn push_reg(&mut self, ty: Ty, src: NumTy) {
+        match ty {
+            Ty::Int => push(&mut self.ints, &src.into()),
+            Ty::Float => push(&mut self.floats, &src.into()),
+            Ty::Str => push(&mut self.strs, &src.into()),
+            Ty::MapIntInt => push(&mut self.maps_int_int, &src.into()),
+            Ty::MapIntFloat => push(&mut self.maps_int_float, &src.into()),
+            Ty::MapIntStr => push(&mut self.maps_int_str, &src.into()),
+            Ty::MapStrInt => push(&mut self.maps_str_int, &src.into()),
+            Ty::MapStrFloat => push(&mut self.maps_str_float, &src.into()),
+            Ty::MapStrStr => push(&mut self.maps_str_str, &src.into()),
+            Ty::Null | Ty::IterInt | Ty::IterStr => {
+                panic!("unsupported register type for push operation: {:?}", ty)
+            }
+        }
+    }
+    fn pop_reg(&mut self, ty: Ty, dst: NumTy) {
+        match ty {
+            Ty::Int => *index_mut(&mut self.ints, &dst.into()) = pop(&mut self.ints),
+            Ty::Float => *index_mut(&mut self.floats, &dst.into()) = pop(&mut self.floats),
+            Ty::Str => *index_mut(&mut self.strs, &dst.into()) = pop(&mut self.strs),
+            Ty::MapIntInt => {
+                *index_mut(&mut self.maps_int_int, &dst.into()) = pop(&mut self.maps_int_int)
+            }
+            Ty::MapIntFloat => {
+                *index_mut(&mut self.maps_int_float, &dst.into()) = pop(&mut self.maps_int_float)
+            }
+            Ty::MapIntStr => {
+                *index_mut(&mut self.maps_int_str, &dst.into()) = pop(&mut self.maps_int_str)
+            }
+            Ty::MapStrInt => {
+                *index_mut(&mut self.maps_str_int, &dst.into()) = pop(&mut self.maps_str_int)
+            }
+            Ty::MapStrFloat => {
+                *index_mut(&mut self.maps_str_float, &dst.into()) = pop(&mut self.maps_str_float)
+            }
+            Ty::MapStrStr => {
+                *index_mut(&mut self.maps_str_float, &dst.into()) = pop(&mut self.maps_str_float)
+            }
+            Ty::Null | Ty::IterInt | Ty::IterStr => {
+                panic!("unsupported register type for pop operation: {:?}", ty)
+            }
         }
     }
 }

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1089,36 +1089,7 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         map,
                         key,
                     } => self.contains(*map_ty, *dst, *map, *key),
-                    DeleteIntInt(arr, k) => {
-                        let arr = index(&self.maps_int_int, arr);
-                        let k = index(&self.ints, k);
-                        arr.delete(k);
-                    }
-                    DeleteIntFloat(arr, k) => {
-                        let arr = index(&self.maps_int_float, arr);
-                        let k = index(&self.ints, k);
-                        arr.delete(k);
-                    }
-                    DeleteIntStr(arr, k) => {
-                        let arr = index(&self.maps_int_str, arr);
-                        let k = index(&self.ints, k);
-                        arr.delete(k);
-                    }
-                    DeleteStrInt(arr, k) => {
-                        let arr = index(&self.maps_str_int, arr);
-                        let k = index(&self.strs, k);
-                        arr.delete(k);
-                    }
-                    DeleteStrFloat(arr, k) => {
-                        let arr = index(&self.maps_str_float, arr);
-                        let k = index(&self.strs, k);
-                        arr.delete(k);
-                    }
-                    DeleteStrStr(arr, k) => {
-                        let arr = index(&self.maps_str_str, arr);
-                        let k = index(&self.strs, k);
-                        arr.delete(k);
-                    }
+                    Delete { map_ty, map, key } => self.delete(*map_ty, *map, *key),
                     LenIntInt(res, arr) => {
                         let arr = *arr;
                         let len = self.get(arr).len();
@@ -1490,6 +1461,12 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
         map_regs!(map_ty, map, key, _v, {
             let res = self.get(map).get(self.get(key)).is_some() as Int;
             *self.get_mut(dst) = res;
+        });
+    }
+    fn delete(&mut self, map_ty: Ty, map: NumTy, key: NumTy) {
+        let _v = 0u32;
+        map_regs!(map_ty, map, key, _v, {
+            self.get(map).delete(self.get(key))
         });
     }
 }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1862,12 +1862,7 @@ impl<'a> View<'a> {
             IterGetNext { iter_ty, dst, iter } => {
                 self.iter_getnext((*iter, *iter_ty), (*dst, iter_ty.iter()?))?
             }
-            PushInt(_) | PushFloat(_) | PushStr(_) | PushIntInt(_) | PushIntFloat(_)
-            | PushIntStr(_) | PushStrInt(_) | PushStrFloat(_) | PushStrStr(_) | PopInt(_)
-            | PopFloat(_) | PopStr(_) | PopIntInt(_) | PopIntFloat(_) | PopIntStr(_)
-            | PopStrInt(_) | PopStrFloat(_) | PopStrStr(_) => {
-                return err!("unexpected explicit push/pop in llvm")
-            }
+            Push(_, _) | Pop(_, _) => return err!("unexpected explicit push/pop in llvm"),
             AllocMap(_, _) => {
                 return err!("unexpected AllocMap (allocs are handled differently in LLVM)")
             }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1785,12 +1785,16 @@ impl<'a> View<'a> {
                 self.delete_map((*map, *map_ty), (*key, map_ty.key()?))?
             }
             Len { map_ty, map, dst } => self.len_map((*map, *map_ty), (*dst, Ty::Int))?,
-            StoreIntInt(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
-            StoreIntFloat(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
-            StoreIntStr(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
-            StoreStrInt(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
-            StoreStrFloat(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
-            StoreStrStr(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
+            Store {
+                map_ty,
+                map,
+                key,
+                val,
+            } => self.store_map(
+                (*map, *map_ty),
+                (*key, map_ty.key()?),
+                (*val, map_ty.val()?),
+            )?,
             LoadVarStr(dst, var) => {
                 let v = self.var_val(var);
                 let res = self.call("load_var_str", &mut [self.runtime_val(), v]);

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1775,24 +1775,12 @@ impl<'a> View<'a> {
                 (*key, map_ty.key()?),
                 (*dst, map_ty.val()?),
             )?,
-            ContainsIntInt(res, arr, k) => {
-                self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            ContainsIntStr(res, arr, k) => {
-                self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            ContainsIntFloat(res, arr, k) => {
-                self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            ContainsStrInt(res, arr, k) => {
-                self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            ContainsStrStr(res, arr, k) => {
-                self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            ContainsStrFloat(res, arr, k) => {
-                self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
+            Contains {
+                map_ty,
+                dst,
+                map,
+                key,
+            } => self.contains_map((*map, *map_ty), (*key, map_ty.key()?), (*dst, Ty::Int))?,
             DeleteIntInt(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
             DeleteIntFloat(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
             DeleteIntStr(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1765,24 +1765,16 @@ impl<'a> View<'a> {
             NextFile() => {
                 self.call("next_file", &mut [self.runtime_val()]);
             }
-            LookupIntInt(res, arr, k) => {
-                self.lookup_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            LookupIntStr(res, arr, k) => {
-                self.lookup_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            LookupIntFloat(res, arr, k) => {
-                self.lookup_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            LookupStrInt(res, arr, k) => {
-                self.lookup_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            LookupStrStr(res, arr, k) => {
-                self.lookup_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
-            LookupStrFloat(res, arr, k) => {
-                self.lookup_map(arr.reflect(), k.reflect(), res.reflect())?
-            }
+            Lookup {
+                map_ty,
+                dst,
+                map,
+                key,
+            } => self.lookup_map(
+                (*map, *map_ty),
+                (*key, map_ty.key()?),
+                (*dst, map_ty.val()?),
+            )?,
             ContainsIntInt(res, arr, k) => {
                 self.contains_map(arr.reflect(), k.reflect(), res.reflect())?
             }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1885,20 +1885,16 @@ impl<'a> View<'a> {
             StoreSlotStrFloat(src, slot) => self.store_slot(src.reflect(), *slot)?,
             StoreSlotStrStr(src, slot) => self.store_slot(src.reflect(), *slot)?,
 
-            MovInt(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovFloat(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovStr(dst, src) => {
-                let sv = self.get_local(src.reflect())?;
-                self.call("ref_str", &mut [sv]);
-                let loaded = LLVMBuildLoad(self.f.builder, sv, c_str!(""));
-                self.bind_reg(dst, loaded);
+            Mov(ty, dst, src) => {
+                if let Ty::Str = ty {
+                    let sv = self.get_local((*src, Ty::Str))?;
+                    self.call("ref_str", &mut [sv]);
+                    let loaded = LLVMBuildLoad(self.f.builder, sv, c_str!(""));
+                    self.bind_val((*dst, Ty::Str), loaded);
+                } else {
+                    self.bind_val((*dst, *ty), self.get_local((*src, *ty))?)
+                }
             }
-            MovMapIntInt(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovMapIntFloat(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovMapIntStr(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovMapStrInt(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovMapStrFloat(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
-            MovMapStrStr(dst, src) => self.bind_reg(dst, self.get_local(src.reflect())?),
             IterBeginIntInt(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
             IterBeginIntFloat(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
             IterBeginIntStr(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1781,12 +1781,9 @@ impl<'a> View<'a> {
                 map,
                 key,
             } => self.contains_map((*map, *map_ty), (*key, map_ty.key()?), (*dst, Ty::Int))?,
-            DeleteIntInt(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
-            DeleteIntFloat(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
-            DeleteIntStr(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
-            DeleteStrInt(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
-            DeleteStrFloat(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
-            DeleteStrStr(arr, k) => self.delete_map(arr.reflect(), k.reflect())?,
+            Delete { map_ty, map, key } => {
+                self.delete_map((*map, *map_ty), (*key, map_ty.key()?))?
+            }
             LenIntInt(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
             LenIntFloat(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
             LenIntStr(res, arr) => self.len_map(arr.reflect(), res.reflect())?,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1870,11 +1870,12 @@ impl<'a> View<'a> {
             IterBegin { map_ty, map, dst } => {
                 self.iter_begin((*dst, map_ty.key_iter()?), (*map, *map_ty))?
             }
-            IterHasNextInt(dst, iter) => self.iter_hasnext(iter.reflect(), dst.reflect())?,
-            IterHasNextStr(dst, iter) => self.iter_hasnext(iter.reflect(), dst.reflect())?,
-            IterGetNextInt(dst, iter) => self.iter_getnext(iter.reflect(), dst.reflect())?,
-            IterGetNextStr(dst, iter) => self.iter_getnext(iter.reflect(), dst.reflect())?,
-
+            IterHasNext { iter_ty, dst, iter } => {
+                self.iter_hasnext((*iter, *iter_ty), (*dst, Ty::Int))?
+            }
+            IterGetNext { iter_ty, dst, iter } => {
+                self.iter_getnext((*iter, *iter_ty), (*dst, iter_ty.iter()?))?
+            }
             PushInt(_) | PushFloat(_) | PushStr(_) | PushIntInt(_) | PushIntFloat(_)
             | PushIntStr(_) | PushStrInt(_) | PushStrFloat(_) | PushStrStr(_) | PopInt(_)
             | PopFloat(_) | PopStr(_) | PopIntInt(_) | PopIntFloat(_) | PopIntStr(_)

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1912,8 +1912,7 @@ impl<'a> View<'a> {
             | PopStrInt(_) | PopStrFloat(_) | PopStrStr(_) => {
                 return err!("unexpected explicit push/pop in llvm")
             }
-            AllocMapIntInt(_) | AllocMapIntFloat(_) | AllocMapIntStr(_) | AllocMapStrInt(_)
-            | AllocMapStrFloat(_) | AllocMapStrStr(_) => {
+            AllocMap(_, _) => {
                 return err!("unexpected AllocMap (allocs are handled differently in LLVM)")
             }
             Ret | Halt | Jmp(_) | JmpIf(_, _) | Call(_) => {

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1841,26 +1841,8 @@ impl<'a> View<'a> {
                 self.call("store_var_intmap", &mut [self.runtime_val(), v, sv]);
             }
 
-            LoadSlotInt(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotFloat(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotStr(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotIntInt(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotIntFloat(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotIntStr(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotStrInt(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotStrFloat(dst, slot) => self.load_slot(dst.reflect(), *slot),
-            LoadSlotStrStr(dst, slot) => self.load_slot(dst.reflect(), *slot),
-
-            StoreSlotInt(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotFloat(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotStr(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotIntInt(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotIntFloat(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotIntStr(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotStrInt(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotStrFloat(src, slot) => self.store_slot(src.reflect(), *slot)?,
-            StoreSlotStrStr(src, slot) => self.store_slot(src.reflect(), *slot)?,
-
+            LoadSlot { ty, dst, slot } => self.load_slot((*dst, *ty), *slot),
+            StoreSlot { ty, src, slot } => self.store_slot((*src, *ty), *slot)?,
             Mov(ty, dst, src) => {
                 if let Ty::Str = ty {
                     let sv = self.get_local((*src, Ty::Str))?;

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1862,17 +1862,14 @@ impl<'a> View<'a> {
                     let sv = self.get_local((*src, Ty::Str))?;
                     self.call("ref_str", &mut [sv]);
                     let loaded = LLVMBuildLoad(self.f.builder, sv, c_str!(""));
-                    self.bind_val((*dst, Ty::Str), loaded);
+                    self.bind_val((*dst, Ty::Str), loaded)
                 } else {
                     self.bind_val((*dst, *ty), self.get_local((*src, *ty))?)
                 }
             }
-            IterBeginIntInt(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
-            IterBeginIntFloat(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
-            IterBeginIntStr(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
-            IterBeginStrInt(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
-            IterBeginStrFloat(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
-            IterBeginStrStr(dst, arr) => self.iter_begin(dst.reflect(), arr.reflect())?,
+            IterBegin { map_ty, map, dst } => {
+                self.iter_begin((*dst, map_ty.key_iter()?), (*map, *map_ty))?
+            }
             IterHasNextInt(dst, iter) => self.iter_hasnext(iter.reflect(), dst.reflect())?,
             IterHasNextStr(dst, iter) => self.iter_hasnext(iter.reflect(), dst.reflect())?,
             IterGetNextInt(dst, iter) => self.iter_getnext(iter.reflect(), dst.reflect())?,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1784,12 +1784,7 @@ impl<'a> View<'a> {
             Delete { map_ty, map, key } => {
                 self.delete_map((*map, *map_ty), (*key, map_ty.key()?))?
             }
-            LenIntInt(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
-            LenIntFloat(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
-            LenIntStr(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
-            LenStrInt(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
-            LenStrFloat(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
-            LenStrStr(res, arr) => self.len_map(arr.reflect(), res.reflect())?,
+            Len { map_ty, map, dst } => self.len_map((*map, *map_ty), (*dst, Ty::Int))?,
             StoreIntInt(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
             StoreIntFloat(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,
             StoreIntStr(arr, k, v) => self.store_map(arr.reflect(), k.reflect(), v.reflect())?,


### PR DESCRIPTION
This PR cleans up the "flattened" representation of frawk's bytecode. This was getting very cumbersome to read and modify. The original reason for this was performance. Indeed, tight loops, particularly those involving maps, are a good deal slower on this branch (sometimes 20-40% slower). However, since I now anticipate compute-bound scripts will use the LLVM backend, I do not think this poses a huge problem. This moves the bytecode interpreter closer to the status of "reference implementation".