### PR TITLE
Make UTF-8 Optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ crossbeam-channel = "0.4"
 crossbeam = "0.7.3"
 num_cpus = "1.13.0"
 cfg-if = "0.1"
+memchr = "2.3.3"
 
 [features]
 default = ["use_jemalloc", "allow_avx2", "llvm_backend"]

--- a/info/overview.md
+++ b/info/overview.md
@@ -296,14 +296,9 @@ if you find that the following are a serious hindrance:
   to integers. For example `if (0) { x = 5 }; printf "[%s]", x;` will print `[]`
   in Awk and will print `[0]` in frawk. This is the main pattern in which
   frawk's approach to types can "leak" into actual programs.
-* *UTF-8* frawk validates all input data as UTF-8. This makes it incomparable to
-  some Awk implementations in terms of what input it accepts. For example in
-  mawk, NUL characters are disallowed, but otherwise arbitrary byte sequences
-  can be provided as input. I did this early-on because it fit my use-cases and
-  allowed for UTF-8 in regex patterns, but I now think this functionality should
-  have been optional. However, refactoring the code to support arbitrary
-  byte-streams would be a lot of work, as the implementation uses Rust strings
-  throughout.
+* *UTF-8* frawk can accept arbitrary bytes, but regular expressions and printf
+  are UTF-8 aware. frawk does not validate input by default, but the `--utf8`
+  flag enables frawk's efficient UTF-8 validation on all input.
 * *Batching* frawk batches reading and writing data fairly aggressively compared
   with most Awk implementations that I have come across. This is done largely for
   performance reasons, and reflects the intended use-case of "batch" data-

--- a/info/performance.md
+++ b/info/performance.md
@@ -38,6 +38,16 @@ believe it is  possible to parallelize the other programs using generic tools
 like `gnu parallel` without first partitioning the data-set into multiple
 sub-files.
 
+## UTF8
+
+All of the frawk numbers in this document include UTF-8 validation on all input.
+frawk has since been refactored to support non-UTF-8 data, with this validation
+made optional and not enabled by default. I have not re-run the benchmarks with
+UTF-8 validation turned off, but I'll just note that rerunning a subset of the
+benchmark commands suggests that frawk runs perhaps 0.2-0.4 seconds faster. That
+sort of difference should not substantially change the relative ordering or
+magnitude of the benchmark results.
+
 ### Test Data
 These benchmarks run on CSV and TSV versions of two data-sets:
 

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -814,6 +814,8 @@ print w,z;
         "1 3 5 7 9 11 13 15 17 19\n"
     );
 
+    // NB: this test is "correct" if the lines are printed in either order. If this shows up too
+    // often we can consider making it possible to mark tests as "order independent".
     test_program!(
         mixed_map,
         r#"BEGIN {
@@ -823,7 +825,7 @@ m["hi"]=5
 for (k in m) {
     print k,k+0,  m[k]
 }}"#,
-        "1 1.0 3\nhi 0.0 5\n",
+        "hi 0.0 5\n1 1.0 3\n",
         @input "",
         @types [ m :: MapStrInt, k :: Str ]
     );

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -62,21 +62,21 @@ cfg_if! {
             inp: impl Into<String>,
             strat: ExecutionStrategy,
         ) -> impl llvm::IntoRuntime + runtime::LineReader {
-            CSVReader::new(split_stdin(inp.into()), ifmt, runtime::CHUNK_SIZE, strat)
+            CSVReader::new(split_stdin(inp.into()), ifmt, runtime::CHUNK_SIZE, /*check_utf8=*/ true,strat)
         }
 
         fn simulate_stdin_regex(
             inp: impl Into<String>
         ) -> impl llvm::IntoRuntime + runtime::LineReader {
             simulate_stdin(inp, |reader, name| {
-                RegexSplitter::new(reader, runtime::CHUNK_SIZE, name)
+                RegexSplitter::new(reader, runtime::CHUNK_SIZE, name, /*check_utf8=*/false )
             })
         }
 
         fn simulate_stdin_whitespace(
             inp: impl Into<String>,
         ) -> impl llvm::IntoRuntime + runtime::LineReader {
-            ByteReader::new_whitespace(split_stdin(inp.into()), runtime::CHUNK_SIZE, ExecutionStrategy::Serial)
+            ByteReader::new_whitespace(split_stdin(inp.into()), runtime::CHUNK_SIZE, /*check_utf8=*/true, ExecutionStrategy::Serial)
         }
 
         fn simulate_stdin_singlechar(
@@ -89,6 +89,7 @@ cfg_if! {
                 field_sep,
                 record_sep,
                 runtime::CHUNK_SIZE,
+                /*check_utf8=*/true,
                 ExecutionStrategy::Serial,
             )
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,7 @@ fn dump_bytecode(prog: &str, raw: &RawPrelude) -> String {
             once((fake_inp, String::from("unused"))),
             InputFormat::CSV,
             CHUNK_SIZE,
+            /*check_utf8=*/ false,
             ExecutionStrategy::Serial,
         )),
         runtime::writers::default_factory(),
@@ -266,6 +267,7 @@ fn main() {
              .about("the optimization level for the program. Positive levels determine the optimization level for LLVM. Level -1 forces bytecode interpretation")
              .possible_values(&["-1", "0", "1", "2", "3"]))
         .arg("--out-file=[FILE] 'the output file used in place of standard input'")
+        .arg("--utf8 'validate all input as UTF-8, returning an error if it is invalid'")
         .arg("--dump-cfg 'print untyped SSA form for input program'")
         .arg("--dump-bytecode 'print bytecode for input program'")
         .arg(Arg::new("input-format")
@@ -416,6 +418,7 @@ fn main() {
     if skip_output {
         return;
     }
+    let check_utf8 = matches.is_present("utf8");
 
     // This horrid macro is here because all of the different ways of reading input are different
     // types, making functions hard to write. Still, there must be something to be done to clean
@@ -430,6 +433,7 @@ fn main() {
                             once((_reader, String::from("-"))),
                             ifmt,
                             CHUNK_SIZE,
+                            check_utf8,
                             exec_strategy,
                         );
                         $body
@@ -448,6 +452,7 @@ fn main() {
                                 let $inp = ByteReader::new_whitespace(
                                     once((_reader, String::from("-"))),
                                     CHUNK_SIZE,
+                                    check_utf8,
                                     exec_strategy,
                                 );
                                 $body
@@ -457,17 +462,20 @@ fn main() {
                                     field_sep.as_bytes()[0],
                                     record_sep.as_bytes()[0],
                                     CHUNK_SIZE,
+                                    check_utf8,
                                     exec_strategy,
                                 );
                                 $body
                             }
                         } else {
-                            let $inp = chained(RegexSplitter::new(_reader, CHUNK_SIZE, "-"));
+                            let $inp =
+                                chained(RegexSplitter::new(_reader, CHUNK_SIZE, "-", check_utf8));
                             $body
                         }
                     }
                     (None, cfg::SepAssign::Unsure) => {
-                        let $inp = chained(RegexSplitter::new(_reader, CHUNK_SIZE, "-"));
+                        let $inp =
+                            chained(RegexSplitter::new(_reader, CHUNK_SIZE, "-", check_utf8));
                         $body
                     }
                 }
@@ -477,8 +485,13 @@ fn main() {
                     .cloned()
                     .map(|file| (open_file_read(file.as_str()), file))
                     .collect();
-                let $inp =
-                    CSVReader::new(file_handles.into_iter(), ifmt, CHUNK_SIZE, exec_strategy);
+                let $inp = CSVReader::new(
+                    file_handles.into_iter(),
+                    ifmt,
+                    CHUNK_SIZE,
+                    check_utf8,
+                    exec_strategy,
+                );
                 $body
             } else {
                 match $analysis {
@@ -498,6 +511,7 @@ fn main() {
                                 let $inp = ByteReader::new_whitespace(
                                     file_handles.into_iter(),
                                     CHUNK_SIZE,
+                                    check_utf8,
                                     exec_strategy,
                                 );
                                 $body
@@ -507,6 +521,7 @@ fn main() {
                                     field_sep.as_bytes()[0],
                                     record_sep.as_bytes()[0],
                                     CHUNK_SIZE,
+                                    check_utf8,
                                     exec_strategy,
                                 );
                                 $body
@@ -515,7 +530,7 @@ fn main() {
                             let iter = input_files.iter().cloned().map(|file| {
                                 let reader: Box<dyn io::Read + Send> =
                                     Box::new(open_file_read(file.as_str()));
-                                RegexSplitter::new(reader, CHUNK_SIZE, file)
+                                RegexSplitter::new(reader, CHUNK_SIZE, file, check_utf8)
                             });
                             let $inp = ChainedReader::new(iter);
                             $body
@@ -525,7 +540,7 @@ fn main() {
                         let iter = input_files.iter().cloned().map(|file| {
                             let reader: Box<dyn io::Read + Send> =
                                 Box::new(open_file_read(file.as_str()));
-                            RegexSplitter::new(reader, CHUNK_SIZE, file)
+                            RegexSplitter::new(reader, CHUNK_SIZE, file, check_utf8)
                         });
                         let $inp = ChainedReader::new(iter);
                         $body

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ extern crate lazy_static;
 extern crate libc;
 #[cfg(feature = "llvm_backend")]
 extern crate llvm_sys;
+extern crate memchr;
 extern crate num_cpus;
 extern crate petgraph;
 extern crate rand;

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -330,9 +330,9 @@ BaseTerm: &'a Expr<'a,'a, &'a str> = {
   Ident,
   Index,
   StrLit,
-  "INT" => arena.alloc_v(Expr::ILit(strtoi(<>))),
-  "HEX" => arena.alloc_v(Expr::ILit(hextoi(<>))),
-  "FLOAT" => arena.alloc_v(Expr::FLit(strtod(<>))),
+  "INT" => arena.alloc_v(Expr::ILit(strtoi(<>.as_bytes()))),
+  "HEX" => arena.alloc_v(Expr::ILit(hextoi(<>.as_bytes()))),
+  "FLOAT" => arena.alloc_v(Expr::FLit(strtod(<>.as_bytes()))),
   "PATLIT" => arena.alloc_v(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf))),
   <i:"CALLSTART"> <args:Args?> ")" =>
         arena.alloc_v(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),

--- a/src/runtime/float_parse/slow_path.rs
+++ b/src/runtime/float_parse/slow_path.rs
@@ -7,25 +7,25 @@
 // things a good amount to support the "partial parses" behavior.
 
 use lazy_static::lazy_static;
-use regex::Regex;
+use regex::bytes::Regex;
 use smallvec::SmallVec;
 
 #[allow(unused)]
-pub(crate) fn strtoi(s: &str) -> i64 {
+pub(crate) fn strtoi(s: &[u8]) -> i64 {
     strtoi_libc(s)
 }
-pub(crate) fn strtod(s: &str) -> f64 {
+pub(crate) fn strtod(s: &[u8]) -> f64 {
     strtod_libc(s)
 }
 
-fn strtoi_libc(s: &str) -> i64 {
-    let cstr = SmallCString::from_str(s);
+fn strtoi_libc(s: &[u8]) -> i64 {
+    let cstr = SmallCString::from_bytes(s);
     unsafe { libc::strtol(cstr.as_ptr(), std::ptr::null_mut(), 10) as i64 }
 }
 
 #[allow(unused)]
-fn strtod_libc(s: &str) -> f64 {
-    let cstr = SmallCString::from_str(s);
+fn strtod_libc(s: &[u8]) -> f64 {
+    let cstr = SmallCString::from_bytes(s);
     unsafe { libc::strtod(cstr.as_ptr(), std::ptr::null_mut()) as f64 }
 }
 
@@ -33,25 +33,31 @@ fn strtod_libc(s: &str) -> f64 {
 // are portability issues with using libc.
 
 #[allow(unused)]
-fn strtoi_regex(s: &str) -> i64 {
+fn strtoi_regex(s: &[u8]) -> i64 {
     lazy_static! {
         static ref INT_PATTERN: Regex = Regex::new(r"^[+-]?\d+").unwrap();
     };
     if let Some(num) = INT_PATTERN.captures(s).and_then(|c| c.get(0)) {
-        num.as_str().parse().unwrap_or(0)
+        std::str::from_utf8(num.as_bytes())
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0)
     } else {
         0
     }
 }
 
 #[allow(unused)]
-fn strtod_regex(s: &str) -> f64 {
+fn strtod_regex(s: &[u8]) -> f64 {
     lazy_static! {
         // Adapted from https://www.regular-expressions.info/floatingpoint.html
         static ref FLOAT_PATTERN: Regex = Regex::new(r"^[-+]?\d*\.?\d+([eE][-+]?\d+)?").unwrap();
     };
     if let Some(num) = FLOAT_PATTERN.captures(s).and_then(|c| c.get(0)) {
-        num.as_str().parse().unwrap_or(0.0)
+        std::str::from_utf8(num.as_bytes())
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0)
     } else {
         0.0
     }
@@ -64,9 +70,9 @@ fn strtod_regex(s: &str) -> f64 {
 /// Because we never use the length of the string, some of these operations can be faster as well.
 struct SmallCString(SmallVec<[u8; 32]>);
 impl SmallCString {
-    fn from_str(s: &str) -> SmallCString {
-        let mut res = SmallCString(SmallVec::with_capacity(s.len() + 1));
-        res.0.extend_from_slice(s.as_bytes());
+    fn from_bytes(bs: &[u8]) -> SmallCString {
+        let mut res = SmallCString(SmallVec::with_capacity(bs.len() + 1));
+        res.0.extend_from_slice(bs);
         res.0.push(0);
         res
     }
@@ -81,14 +87,14 @@ mod tests {
     use super::*;
     extern crate test;
     use test::{black_box, Bencher};
-    fn test_strtoi(mut f: impl FnMut(&str) -> i64) {
-        assert_eq!(f("0"), 0);
-        assert_eq!(f("012345678910"), 12345678910);
-        assert_eq!(f("12345678910"), 12345678910);
-        assert_eq!(f("1.9245"), 1);
-        assert_eq!(f("567hello there 8910"), 567);
-        assert_eq!(f("+2037 there 8910"), 2037);
-        assert_eq!(f("-99999 there 8910"), -99999);
+    fn test_strtoi(mut f: impl FnMut(&[u8]) -> i64) {
+        assert_eq!(f(b"0"), 0);
+        assert_eq!(f(b"012345678910"), 12345678910);
+        assert_eq!(f(b"12345678910"), 12345678910);
+        assert_eq!(f(b"1.9245"), 1);
+        assert_eq!(f(b"567hello there 8910"), 567);
+        assert_eq!(f(b"+2037 there 8910"), 2037);
+        assert_eq!(f(b"-99999 there 8910"), -99999);
         // NOTE these two have different behavior on {under,over}flow.
         // This shouldn't be that big of a deal for most cases, as most strings will be parsed as
         // floats first.
@@ -99,7 +105,7 @@ mod tests {
         // assert_eq!(f("1180591620717411303424"), i64::max_value());
     }
 
-    fn test_strtod(mut f: impl FnMut(&str) -> f64) {
+    fn test_strtod(mut f: impl FnMut(&[u8]) -> f64) {
         macro_rules! assert_near {
             ($x:expr, $y:expr) => {{
                 let x: f64 = $x;
@@ -116,14 +122,14 @@ mod tests {
                 }
             }};
         }
-        assert_eq!(f("0"), 0.0);
-        assert_near!(f("1234"), 1234.0);
-        assert_near!(f("12.34"), 12.34);
-        assert_near!(f("12.34e9"), 12.34e9);
-        assert_near!(f("12.34e9 hello there"), 12.34e9);
-        assert_near!(f("-12.34e9 hello there"), -12.34e9);
-        assert_near!(f("+92.34e9 hello there"), 92.34e9);
-        assert_near!(f("-1."), -1.0);
+        assert_eq!(f(b"0"), 0.0);
+        assert_near!(f(b"1234"), 1234.0);
+        assert_near!(f(b"12.34"), 12.34);
+        assert_near!(f(b"12.34e9"), 12.34e9);
+        assert_near!(f(b"12.34e9 hello there"), 12.34e9);
+        assert_near!(f(b"-12.34e9 hello there"), -12.34e9);
+        assert_near!(f(b"+92.34e9 hello there"), 92.34e9);
+        assert_near!(f(b"-1."), -1.0);
     }
 
     #[test]
@@ -147,39 +153,39 @@ mod tests {
     fn test_strtod_libc() {
         test_strtod(strtod_libc);
     }
-    fn bench_strtoi_long(b: &mut Bencher, mut f: impl FnMut(&str) -> i64) {
-        const INPUT: &str = "9514590998633183616833425126589570467868 some more data after that";
+    fn bench_strtoi_long(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> i64) {
+        const INPUT: &[u8] = b"9514590998633183616833425126589570467868 some more data after that";
         b.iter(|| {
             black_box(f(INPUT));
         })
     }
-    fn bench_strtoi_medium(b: &mut Bencher, mut f: impl FnMut(&str) -> i64) {
-        const INPUT: &str = "951459099863318361";
+    fn bench_strtoi_medium(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> i64) {
+        const INPUT: &[u8] = b"951459099863318361";
         b.iter(|| {
             black_box(f(INPUT));
         })
     }
-    fn bench_strtoi_short(b: &mut Bencher, mut f: impl FnMut(&str) -> i64) {
-        const INPUT: &str = "19503609";
+    fn bench_strtoi_short(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> i64) {
+        const INPUT: &[u8] = b"19503609";
         b.iter(|| {
             black_box(f(INPUT));
         })
     }
-    fn bench_strtod_long(b: &mut Bencher, mut f: impl FnMut(&str) -> f64) {
-        const INPUT: &str =
-            "9514590.998633183616833425126589570467868E22 some more data after that";
+    fn bench_strtod_long(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> f64) {
+        const INPUT: &[u8] =
+            b"9514590.998633183616833425126589570467868E22 some more data after that";
         b.iter(|| {
             black_box(f(INPUT));
         })
     }
-    fn bench_strtod_medium(b: &mut Bencher, mut f: impl FnMut(&str) -> f64) {
-        const INPUT: &str = "9514005346590.99863E10";
+    fn bench_strtod_medium(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> f64) {
+        const INPUT: &[u8] = b"9514005346590.99863E10";
         b.iter(|| {
             black_box(f(INPUT));
         })
     }
-    fn bench_strtod_short(b: &mut Bencher, mut f: impl FnMut(&str) -> f64) {
-        const INPUT: &str = "1950360.9";
+    fn bench_strtod_short(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> f64) {
+        const INPUT: &[u8] = b"1950360.9";
         b.iter(|| {
             black_box(f(INPUT));
         })
@@ -187,32 +193,32 @@ mod tests {
 
     #[bench]
     fn bench_strtoi_long_regex(b: &mut Bencher) {
-        let _ = strtoi_regex("0");
+        let _ = strtoi_regex(b"0");
         bench_strtoi_long(b, strtoi_regex)
     }
     #[bench]
     fn bench_strtoi_medium_regex(b: &mut Bencher) {
-        let _ = strtoi_regex("0");
+        let _ = strtoi_regex(b"0");
         bench_strtoi_medium(b, strtoi_regex)
     }
     #[bench]
     fn bench_strtoi_short_regex(b: &mut Bencher) {
-        let _ = strtoi_regex("0");
+        let _ = strtoi_regex(b"0");
         bench_strtoi_short(b, strtoi_regex)
     }
     #[bench]
     fn bench_strtod_long_regex(b: &mut Bencher) {
-        let _ = strtod_regex("0");
+        let _ = strtod_regex(b"0");
         bench_strtod_long(b, strtod_regex)
     }
     #[bench]
     fn bench_strtod_medium_regex(b: &mut Bencher) {
-        let _ = strtod_regex("0");
+        let _ = strtod_regex(b"0");
         bench_strtod_medium(b, strtod_regex)
     }
     #[bench]
     fn bench_strtod_short_regex(b: &mut Bencher) {
-        let _ = strtod_regex("0");
+        let _ = strtod_regex(b"0");
         bench_strtod_short(b, strtod_regex)
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -417,10 +417,16 @@ impl<LR: LineReader> FileRead<LR> {
         path: &Str<'a>,
         f: impl FnMut(&mut RegexSplitter<File>) -> Result<R>,
     ) -> Result<R> {
+        let check_utf8 = self.stdin.check_utf8();
         self.files.get_fallible(
             path,
             |s| match File::open(s) {
-                Ok(f) => Ok(RegexSplitter::new(f, CHUNK_SIZE, path.clone().unmoor())),
+                Ok(f) => Ok(RegexSplitter::new(
+                    f,
+                    CHUNK_SIZE,
+                    path.clone().unmoor(),
+                    check_utf8,
+                )),
                 Err(e) => err!("failed to open file '{}': {}", s, e),
             },
             f,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -7,11 +7,13 @@ use std::hash::Hash;
 use std::io;
 use std::iter::FromIterator;
 use std::rc::Rc;
+use std::str;
 
 pub mod float_parse;
 pub mod printf;
 pub mod splitter;
 pub mod str_impl;
+pub mod string_search;
 pub mod utf8;
 pub mod writers;
 
@@ -290,7 +292,7 @@ impl RegexCache {
         use crate::builtins::Variable;
         // We use the awk semantics for `match`. If we match
         let (start, len) = self.with_regex(pat, |re| {
-            s.with_str(|s| match re.find(s.as_bytes()) {
+            s.with_bytes(|bs| match re.find(bs) {
                 Some(m) => {
                     let start = m.start() as Int;
                     let end = m.end() as Int;
@@ -305,7 +307,7 @@ impl RegexCache {
     }
 
     pub(crate) fn is_regex_match(&mut self, pat: &Str, s: &Str) -> Result<bool> {
-        self.with_regex(pat, |re| s.with_str(|s| re.is_match(s.as_bytes())))
+        self.with_regex(pat, |re| s.with_bytes(|bs| re.is_match(bs)))
     }
 }
 
@@ -320,10 +322,10 @@ impl Default for FileWrite {
 
 impl FileWrite {
     pub(crate) fn flush_stdout(&mut self) -> Result<()> {
-        self.0.get_handle(None).flush()
+        self.0.get_handle(None)?.flush()
     }
     pub(crate) fn close(&mut self, path: &Str) -> Result<()> {
-        self.0.get_handle(Some(path)).close()
+        self.0.get_handle(Some(path))?.close()
     }
     pub(crate) fn new(ff: impl writers::FileFactory) -> FileWrite {
         FileWrite(writers::Registry::from_factory(ff))
@@ -340,22 +342,22 @@ impl FileWrite {
         pa: &[printf::FormatArg],
     ) -> Result<()> {
         let (handle, append) = if let Some((out_file, append)) = path {
-            (self.0.get_handle(Some(out_file)), append)
+            (self.0.get_handle(Some(out_file))?, append)
         } else {
-            (self.0.get_handle(None), true)
+            (self.0.get_handle(None)?, true)
         };
         let mut text = str_impl::DynamicBuf::default();
-        spec.with_str(|spec| printf::printf(&mut text, spec, pa))?;
+        spec.with_bytes(|spec| printf::printf(&mut text, spec, pa))?;
         let s = unsafe { text.into_str() };
         handle.write(&s, append)
     }
 
     pub(crate) fn write_str_stdout(&mut self, s: &Str) -> Result<()> {
-        self.0.get_handle(None).write(s, /*append=*/ true)
+        self.0.get_handle(None)?.write(s, /*append=*/ true)
     }
 
     pub(crate) fn write_str(&mut self, path: &Str, s: &Str, append: bool) -> Result<()> {
-        self.0.get_handle(Some(path)).write(s, append)
+        self.0.get_handle(Some(path))?.write(s, append)
     }
 }
 
@@ -466,8 +468,12 @@ impl<T> Registry<T> {
         match self.cached.entry(k_str) {
             Entry::Occupied(mut o) => getter(o.get_mut()),
             Entry::Vacant(v) => {
-                let (val, res) = v.key().with_str(|raw_str| {
-                    let mut val = new(raw_str)?;
+                let (val, res) = v.key().with_bytes(|raw_str| {
+                    let s = match str::from_utf8(raw_str) {
+                        Ok(s) => s,
+                        Err(e) => return err!("invalid UTF-8 for file or regex: {}", e),
+                    };
+                    let mut val = new(s)?;
                     let res = getter(&mut val);
                     Ok((val, res))
                 })?;
@@ -508,22 +514,22 @@ impl<'a> Convert<Float, Str<'a>> for _Carrier {
 }
 impl<'a> Convert<Str<'a>, Float> for _Carrier {
     fn convert(s: Str<'a>) -> Float {
-        s.with_str(strtod)
+        s.with_bytes(strtod)
     }
 }
 impl<'a> Convert<Str<'a>, Int> for _Carrier {
     fn convert(s: Str<'a>) -> Int {
-        s.with_str(strtoi)
+        s.with_bytes(strtoi)
     }
 }
 impl<'b, 'a> Convert<&'b Str<'a>, Float> for _Carrier {
     fn convert(s: &'b Str<'a>) -> Float {
-        s.with_str(strtod)
+        s.with_bytes(strtod)
     }
 }
 impl<'b, 'a> Convert<&'b Str<'a>, Int> for _Carrier {
     fn convert(s: &'b Str<'a>) -> Int {
-        s.with_str(strtoi)
+        s.with_bytes(strtoi)
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,6 +1,6 @@
 use crate::common::{Either, Result};
 use hashbrown::HashMap;
-use regex::Regex;
+use regex::bytes::Regex;
 use std::cell::{Cell, RefCell};
 use std::fs::File;
 use std::hash::Hash;
@@ -290,7 +290,7 @@ impl RegexCache {
         use crate::builtins::Variable;
         // We use the awk semantics for `match`. If we match
         let (start, len) = self.with_regex(pat, |re| {
-            s.with_str(|s| match re.find(s) {
+            s.with_str(|s| match re.find(s.as_bytes()) {
                 Some(m) => {
                     let start = m.start() as Int;
                     let end = m.end() as Int;
@@ -305,7 +305,7 @@ impl RegexCache {
     }
 
     pub(crate) fn is_regex_match(&mut self, pat: &Str, s: &Str) -> Result<bool> {
-        self.with_regex(pat, |re| s.with_str(|s| re.is_match(s)))
+        self.with_regex(pat, |re| s.with_str(|s| re.is_match(s.as_bytes())))
     }
 }
 

--- a/src/runtime/printf.rs
+++ b/src/runtime/printf.rs
@@ -2,6 +2,16 @@
 ///
 /// We lean heavily on ryu and the std::fmt machinery; as such, most of the work is parsing
 /// awk-style format strings and translating them to individual calls to write!.
+///
+/// TODO: Originally, frawk enforced that all Strs contained valid UTF-8. We have since allowed
+/// strings to contain arbitrary byte sequences, but this module still only works with valid UTF-8
+/// because of the underlying dependence on the fmt module. We could try and implement printf "from
+/// scratch," but note that there are good reasons for fmt to assume UTF-8. For questions of
+/// "width" and "alignment," it's a little vague exactly what nonprintable or invalid UTF8
+/// sequences should have. I can see possible improvements we might explore in the future:
+///
+/// * Use some sort of "lossy" conversion for non-UTF8 byte sequences to UTF8.
+/// *
 use crate::common::Result;
 use crate::runtime::{convert, strtoi, Float, Int, Str};
 
@@ -30,7 +40,19 @@ impl Write for StackWriter {
         Ok(())
     }
 }
-#[derive(Clone)]
+
+struct DisplayBytes<'a>(&'a [u8]);
+impl<'a> fmt::Display for DisplayBytes<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&*std::string::String::from_utf8_lossy(self.0), fmt)
+        // match std::str::from_utf8(self.0) {
+        //     Ok(s) => fmt::Display::fmt(s, fmt),
+        //     Err(_) => fmt.write_str("<invalid UTF-8>"),
+        // }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(crate) enum FormatArg<'a> {
     S(Str<'a>),
     F(Float),
@@ -46,6 +68,12 @@ impl<'a> From<Str<'a>> for FormatArg<'a> {
 impl<'a> From<&'a str> for FormatArg<'a> {
     fn from(s: &'a str) -> FormatArg<'a> {
         FormatArg::S(s.into())
+    }
+}
+
+impl<'a> From<&'a [u8]> for FormatArg<'a> {
+    fn from(bs: &'a [u8]) -> FormatArg<'a> {
+        FormatArg::S(bs.into())
     }
 }
 
@@ -78,14 +106,14 @@ impl<'a> FormatArg<'a> {
             I(i) => *i,
         }
     }
-    fn with_str<R>(&self, f: impl FnOnce(&str) -> R) -> R {
+    fn with_bytes<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
         use FormatArg::*;
         let s: Str<'a> = match self {
             S(s) => s.clone(),
             F(f) => convert::<_, Str>(*f),
             I(i) => convert::<_, Str>(*i),
         };
-        s.with_str(f)
+        s.with_bytes(f)
     }
 }
 
@@ -115,9 +143,9 @@ impl Default for FormatSpec {
     }
 }
 
-fn is_spec(c: char) -> bool {
+fn is_spec(c: u8) -> bool {
     match c {
-        'f' | 'c' | 'd' | 'e' | 'g' | 'o' | 's' | 'x' => true,
+        b'f' | b'c' | b'd' | b'e' | b'g' | b'o' | b's' | b'x' => true,
         _ => false,
     }
 }
@@ -166,8 +194,8 @@ fn process_spec(mut w: impl Write, fspec: &mut FormatSpec, arg: &FormatArg) -> R
             }
         };
     }
-    let res = match fspec.spec as char {
-        'f' => {
+    let res = match fspec.spec {
+        b'f' => {
             if !fspec.leading_zeros && fspec.lnum == 0 && fspec.rnum == usize::max_value() {
                 // Fast path: use Ryu, which today is more efficient than the standard library.
                 // NB Ryu prints some things a bit differently than most awk implementations.
@@ -178,8 +206,8 @@ fn process_spec(mut w: impl Write, fspec: &mut FormatSpec, arg: &FormatArg) -> R
                 match_for_spec!("", arg.to_float())
             }
         }
-        'e' => match_for_spec!("e", arg.to_float()),
-        'g' => {
+        b'e' => match_for_spec!("e", arg.to_float()),
+        b'g' => {
             let mut buf = StackWriter::default();
             // %g means "pick the shorter of standard and scientific notation". We do the obvious
             // thing of computing both and writing out the smaller one.
@@ -189,45 +217,44 @@ fn process_spec(mut w: impl Write, fspec: &mut FormatSpec, arg: &FormatArg) -> R
             fspec.spec = b'e';
             process_spec(&mut buf, fspec, arg)?;
             let l2 = buf.len() - l1;
-            if l1 < l2 {
-                write!(w, "{}", unsafe { str::from_utf8_unchecked(&buf.0[0..l1]) })
+            let bytes = if l1 < l2 {
+                &buf.0[0..l1]
             } else {
-                write!(w, "{}", unsafe {
-                    str::from_utf8_unchecked(&buf.0[l1..(l1 + l2)])
-                })
+                &buf.0[l1..(l1 + l2)]
+            };
+            return write_bytes(&mut w, bytes);
+        }
+        b'd' => match_for_spec!("", arg.to_int()),
+        b'o' => match_for_spec!("o", arg.to_int()),
+        b'x' => match_for_spec!("x", arg.to_int()),
+        b'c' => {
+            // First, see if we have something ascii/UTF8 here
+            match char::try_from(arg.to_int() as u32) {
+                Ok(ch) => match_for_spec!("", ch),
+                // TODO: Unclear what we should do here, write out the raw bytes? write out the
+                // character code? Awk may just write the raw bytes out, but it's hard to say
+                // (different behavior across implementations)
+                _ => match_for_spec!("", "?"),
             }
         }
-        'd' => match_for_spec!("", arg.to_int()),
-        'o' => match_for_spec!("o", arg.to_int()),
-        'x' => match_for_spec!("x", arg.to_int()),
-        'c' => match char::try_from(arg.to_int() as u32) {
-            Ok(ch) if ch.is_ascii() => match_for_spec!("", ch),
-            _ => arg.with_str(|s| {
-                if let Some(ch) = s.chars().next() {
-                    match_for_spec!("", ch)
-                } else {
-                    Ok(())
-                }
-            }),
-        },
-        's' => arg.with_str(|s| match_for_spec!("", s)),
+        b's' => arg.with_bytes(|bs| match_for_spec!("", DisplayBytes(bs))),
         x => return err!("unsupported format specifier: {}", x),
     };
     wrap_result(res)
 }
 
-fn wrap_result(r: std::result::Result<(), impl fmt::Display>) -> Result<()> {
+fn wrap_result<T>(r: std::result::Result<T, impl fmt::Display>) -> Result<()> {
     match r {
-        Ok(()) => Ok(()),
+        Ok(_) => Ok(()),
         Err(e) => err!("formatter: {}", e),
     }
 }
 
-fn write_str(mut w: impl Write, s: &str) -> Result<()> {
-    wrap_result(write!(w, "{}", s))
+fn write_bytes(mut w: impl Write, bs: &[u8]) -> Result<()> {
+    wrap_result(w.write(bs))
 }
 
-pub(crate) fn printf(mut w: impl Write, spec: &str, mut args: &[FormatArg]) -> Result<()> {
+pub(crate) fn printf(mut w: impl Write, spec: &[u8], mut args: &[FormatArg]) -> Result<()> {
     #[derive(Copy, Clone)]
     enum State {
         // Byte index of start of string
@@ -237,11 +264,11 @@ pub(crate) fn printf(mut w: impl Write, spec: &str, mut args: &[FormatArg]) -> R
     }
 
     use State::*;
-    let mut iter = spec.char_indices();
+    let mut iter = spec.iter().cloned().enumerate();
     macro_rules! next_state {
         ($e:expr) => {
             match $e {
-                Some((_, '%')) => Format(0),
+                Some((_, b'%')) => Format(0),
                 Some(_) => Raw(0),
                 None => return Ok(()),
             }
@@ -263,13 +290,13 @@ pub(crate) fn printf(mut w: impl Write, spec: &str, mut args: &[FormatArg]) -> R
         match state {
             Raw(start) => {
                 while let Some((ix, ch)) = iter.next() {
-                    if ch == '%' {
-                        write_str(&mut w, &spec[start..ix])?;
+                    if ch == b'%' {
+                        write_bytes(&mut w, &spec[start..ix])?;
                         state = Format(ix);
                         continue 'outer;
                     }
                 }
-                write_str(&mut w, &spec[start..])?;
+                write_bytes(&mut w, &spec[start..])?;
                 break 'outer;
             }
             Format(start) => {
@@ -293,7 +320,7 @@ pub(crate) fn printf(mut w: impl Write, spec: &str, mut args: &[FormatArg]) -> R
                         break;
                     }
                     match (ch, stage) {
-                        ('%', Begin) => {
+                        (b'%', Begin) => {
                             fs.spec = b'%';
                             process_spec(&mut w, &mut fs, next_arg())?;
                             state = Raw(ix + 1);
@@ -305,33 +332,33 @@ pub(crate) fn printf(mut w: impl Write, spec: &str, mut args: &[FormatArg]) -> R
                             state = Raw(ix + 1);
                             continue 'outer;
                         }
-                        ('-', Begin) => {
+                        (b'-', Begin) => {
                             stage = Lnum;
                             fs.minus = true;
                         }
-                        ('-', _) | ('%', _) => break,
+                        (b'-', _) | (b'%', _) => break,
                         (ch, Lnum) | (ch, Begin) => {
                             if fs.lnum != 0 {
                                 break;
                             }
                             buf.clear();
-                            if ch == '0' {
+                            if ch == b'0' {
                                 fs.leading_zeros = true;
-                            } else if ch == '.' {
+                            } else if ch == b'.' {
                                 stage = Rnum;
                                 continue;
                             } else {
-                                buf.push(ch as u8);
+                                buf.push(ch);
                             };
                             next = None;
                             while let Some((ix, ch)) = iter.next() {
-                                if !ch.is_digit(/*radix=*/ 10) {
+                                if !matches!(ch, b'0'..=b'9') {
                                     next = Some((ix, ch));
                                     break;
                                 }
-                                buf.push(ch as u8);
+                                buf.push(ch);
                             }
-                            let num = strtoi(str::from_utf8(&buf[..]).unwrap());
+                            let num = strtoi(&buf[..]);
                             if num < 0 {
                                 break;
                             }
@@ -343,20 +370,19 @@ pub(crate) fn printf(mut w: impl Write, spec: &str, mut args: &[FormatArg]) -> R
                             if fs.rnum != usize::max_value() {
                                 break;
                             }
-                            if ch != '.' {
+                            if ch != b'.' {
                                 break;
                             }
                             buf.clear();
                             next = None;
                             while let Some((ix, ch)) = iter.next() {
-                                if !ch.is_digit(/*radix=*/ 10) {
+                                if !matches!(ch, b'0'..=b'9') {
                                     next = Some((ix, ch));
                                     break;
                                 }
-                                buf.push(ch as u8);
+                                buf.push(ch);
                             }
-                            let buf_str = str::from_utf8(&buf[..]).unwrap();
-                            let num = strtoi(buf_str);
+                            let num = strtoi(&buf[..]);
                             if num < 0 {
                                 break;
                             }
@@ -399,7 +425,7 @@ mod tests {
         // We don't use the macro here to test the truncation semantics here.
         printf(
             w,
-            "Hi %s, to my %d friends %f percent of the time: %g!",
+            b"Hi %s, to my %d friends %f percent of the time: %g!",
             &[S("there".into()), F(2.5), I(1), F(1.25369E23)],
         )
         .expect("printf failed");
@@ -409,23 +435,23 @@ mod tests {
             "Hi there, to my 2 friends 1.0 percent of the time: 1.25369e23!"
         );
 
-        let s2 = sprintf!("%e %d ~~ %s", 12535, 3, "hi");
+        let s2 = sprintf!(b"%e %d ~~ %s", 12535, 3, "hi");
         assert_eq!(s2.as_str(), "1.2535e4 3 ~~ hi");
     }
 
     #[test]
     fn truncation_padding() {
-        let s1 = sprintf!("%06o |%-10.3s|", 98, "February");
+        let s1 = sprintf!(b"%06o |%-10.3s|", 98, "February");
         assert_eq!(s1.as_str(), "000142 |Feb       |");
-        let s2 = sprintf!("|%-10.");
+        let s2 = sprintf!(b"|%-10.");
         assert_eq!(s2.as_str(), "|%-10.");
     }
 
     #[test]
     fn float_rounding() {
-        let s1 = sprintf!("%02.2f", 2.375);
+        let s1 = sprintf!(b"%02.2f", 2.375);
         assert_eq!(s1.as_str(), "2.38");
-        let s2 = sprintf!("%.2f", 2.375);
+        let s2 = sprintf!(b"%.2f", 2.375);
         assert_eq!(s2.as_str(), "2.38");
     }
 }

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -402,7 +402,7 @@ impl<'a> Stepper<'a> {
     fn get(&mut self, line_start: usize, j: usize, cur: usize) -> usize {
         self.off.start = cur;
         if self.field_set.get(0) {
-            self.line.raw = unsafe { self.buf.slice_to_str(line_start, j) };
+            self.line.raw = self.buf.slice_to_str(line_start, j);
         }
         self.line.len += j - line_start;
         self.prev_ix

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -25,7 +25,7 @@ use std::mem;
 use std::str;
 
 use lazy_static::lazy_static;
-use regex::{bytes, Regex};
+use regex::{bytes, bytes::Regex};
 
 use crate::common::{ExecutionStrategy, Result};
 use crate::pushdown::FieldSet;

--- a/src/runtime/splitter/regex.rs
+++ b/src/runtime/splitter/regex.rs
@@ -99,11 +99,10 @@ impl<R: Read> RegexSplitter<R> {
                 // We need this check in case the regex matches across a chunk boundary.
                 Some((start, end)) if end + self.reader.start < self.reader.end => {
                     // Valid offsets guaranteed by correctness of regex `find`.
-                    let res = unsafe {
-                        self.reader
-                            .buf
-                            .slice_to_str(self.reader.start, self.reader.start + start)
-                    };
+                    let res = self
+                        .reader
+                        .buf
+                        .slice_to_str(self.reader.start, self.reader.start + start);
                     self.reader.start += end;
                     return (res, end);
                 }
@@ -112,11 +111,10 @@ impl<R: Read> RegexSplitter<R> {
                     return match self.reader.reset() {
                         Ok(true) => {
                             // EOF: yield the rest of the buffer
-                            let line = unsafe {
-                                self.reader
-                                    .buf
-                                    .slice_to_str(self.reader.start, self.reader.end)
-                            };
+                            let line = self
+                                .reader
+                                .buf
+                                .slice_to_str(self.reader.start, self.reader.end);
                             self.reader.start = self.reader.end;
                             (line, consumed)
                         }
@@ -150,11 +148,11 @@ impl<R: Read> RegexSplitter<R> {
                     return match self.reader.reset() {
                         Ok(true) => {
                             // Valid offsets guaranteed by correctness of regex `find`.
-                            let res = unsafe {
+                            let res =
                                 self.reader
                                     .buf
                                     .slice_to_str(self.reader.start, self.reader.start + start)
-                            };
+                                    ;
                             self.reader.start += end;
                             (res, end)
                         }

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -410,10 +410,10 @@ impl<'a> Str<'a> {
         if self.is_empty() {
             return;
         }
-        self.with_str(|s| {
+        self.with_bytes(|s| {
             let mut prev = 0;
             let mut cur_field = 1;
-            for m in pat.find_iter(s.as_bytes()) {
+            for m in pat.find_iter(s) {
                 let is_empty = prev == m.start();
                 cur_field += if used_fields.get(cur_field) {
                     push(self.slice(prev, m.start()), is_empty)
@@ -444,13 +444,13 @@ impl<'a> Str<'a> {
     }
 
     pub fn subst_first(&self, pat: &Regex, subst: &Str<'a>) -> (Str<'a>, bool) {
-        self.with_str(|s| {
-            subst.with_str(|subst| {
-                if let Some(m) = pat.find(s.as_bytes()) {
+        self.with_bytes(|s| {
+            subst.with_bytes(|subst| {
+                if let Some(m) = pat.find(s) {
                     let mut buf = DynamicBuf::new(s.len());
-                    buf.write(&s.as_bytes()[0..m.start()]).unwrap();
-                    buf.write(subst.as_bytes()).unwrap();
-                    buf.write(&s.as_bytes()[m.end()..s.len()]).unwrap();
+                    buf.write(&s[0..m.start()]).unwrap();
+                    buf.write(subst).unwrap();
+                    buf.write(&s[m.end()..s.len()]).unwrap();
                     (unsafe { buf.into_str() }, true)
                 } else {
                     (self.clone(), false)
@@ -460,21 +460,21 @@ impl<'a> Str<'a> {
     }
 
     pub fn subst_all(&self, pat: &Regex, subst: &Str<'a>) -> (Str<'a>, Int) {
-        self.with_str(|s| {
-            subst.with_str(|subst| {
+        self.with_bytes(|s| {
+            subst.with_bytes(|subst| {
                 let mut buf = DynamicBuf::new(0);
                 let mut prev = 0;
                 let mut count = 0;
-                for m in pat.find_iter(s.as_bytes()) {
-                    buf.write(&s.as_bytes()[prev..m.start()]).unwrap();
-                    buf.write(subst.as_bytes()).unwrap();
+                for m in pat.find_iter(s) {
+                    buf.write(&s[prev..m.start()]).unwrap();
+                    buf.write(subst).unwrap();
                     prev = m.end();
                     count += 1;
                 }
                 if count == 0 {
                     (self.clone(), count)
                 } else {
-                    buf.write(&s.as_bytes()[prev..s.len()]).unwrap();
+                    buf.write(&s[prev..s.len()]).unwrap();
                     (unsafe { buf.into_str() }, count)
                 }
             })
@@ -621,7 +621,6 @@ impl<'a> Str<'a> {
     pub fn slice(&self, from: usize, to: usize) -> Str<'a> {
         // TODO: consider returning a result here so we can error out in a more graceful way.
         {
-            use super::utf8::is_char_boundary;
             let bs = unsafe { &*self.get_bytes() };
             assert!(
                 (from == to && to == bs.len()) || from < bs.len(),
@@ -631,31 +630,23 @@ impl<'a> Str<'a> {
                 to,
             );
             assert!(to <= bs.len(), "internal error: invalid index");
-            assert!(
-                (from == to) || is_char_boundary(bs[from]),
-                "must take substring at char boundary"
-            );
-            assert!(
-                to == bs.len() || is_char_boundary(bs[to]),
-                "must take substring at char boundary"
-            );
         }
         unsafe { self.slice_internal(from, to) }
     }
 
-    // Why is [with_str] safe and [force] unsafe? Let's go case-by-case for the state of `self`
+    // Why is [with_bytes] safe and [force] unsafe? Let's go case-by-case for the state of `self`
     // EMPTY:  no data is passed into `f`.
     // BOXED:  The function signature ensures that no string references can "escape" `f`, and `self`
     //         will persist for the function body, which will keep the underlying buffer alive.
     // CONCAT: We `force` these strings, so they will be BOXED.
     // SHARED: This one is tricky. It may seem to be covered by the BOXED case, but the difference
     //         is that shared strings give up there references to the underlying buffer if they get
-    //         forced. So if we did s.with_str(|x| { /* force s */; *x}), then *x is a
+    //         forced. So if we did s.with_bytes(|x| { /* force s */; *x}), then *x is a
     //         use-after-free!
     //
     //         This is why [force] is unsafe. As written, no safe method will force a SHARED Str.
     //         If we add force to a public API (e.g. for garbage collection), we'll need to ensure
-    //         that we don't call with_str around it, or clone the string before forcing.
+    //         that we don't call with_bytes around it, or clone the string before forcing.
 
     unsafe fn force(&self) {
         let (tag, len) = {
@@ -741,14 +732,12 @@ impl<'a> Str<'a> {
             }
         }
     }
-    pub fn get_raw_str(&self) -> *const str {
-        unsafe { str::from_utf8_unchecked(&*self.get_bytes()) }
-    }
 
-    pub fn with_str<R>(&self, f: impl FnOnce(&str) -> R) -> R {
-        let raw = self.get_raw_str();
+    pub fn with_bytes<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
+        let raw = self.get_bytes();
         unsafe { f(&*raw) }
     }
+
     pub fn unmoor(self) -> Str<'static> {
         let rep = unsafe { self.rep_mut() };
         let tag = rep.get_tag();
@@ -788,7 +777,7 @@ impl<'a> PartialEq for Str<'a> {
             return true;
         }
         // TODO: we could intern these strings if they wind up equal.
-        self.with_str(|s1| other.with_str(|s2| s1 == s2))
+        self.with_bytes(|bs1| other.with_bytes(|bs2| bs1 == bs2))
     }
 }
 
@@ -796,30 +785,34 @@ impl<'a> Eq for Str<'a> {}
 
 impl<'a> Hash for Str<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.with_str(|s| s.hash(state))
+        self.with_bytes(|bs| bs.hash(state))
     }
 }
-
 impl<'a> From<&'a str> for Str<'a> {
     fn from(s: &'a str) -> Str<'a> {
-        if s.len() == 0 {
+        s.as_bytes().into()
+    }
+}
+impl<'a> From<&'a [u8]> for Str<'a> {
+    fn from(bs: &'a [u8]) -> Str<'a> {
+        if bs.len() == 0 {
             Default::default()
-        } else if s.len() <= MAX_INLINE_SIZE {
-            Str::from_rep(unsafe { Inline::from_raw(s.as_ptr(), s.len()).into() })
-        } else if s.as_ptr() as usize & 0x7 != 0 {
+        } else if bs.len() <= MAX_INLINE_SIZE {
+            Str::from_rep(unsafe { Inline::from_raw(bs.as_ptr(), bs.len()).into() })
+        } else if bs.as_ptr() as usize & 0x7 != 0 {
             // Strings are not guaranteed to be word aligned. Copy over strings that aren't. This
             // is more important for tests; most of the places that literals can come from in an
             // awk program will hand out aligned pointers.
-            let buf = Buf::read_from_str(s);
+            let buf = Buf::read_from_bytes(bs);
             let boxed = Boxed {
-                len: s.len() as u64,
+                len: bs.len() as u64,
                 buf,
             };
             Str::from_rep(boxed.into())
         } else {
             let literal = Literal {
-                len: s.len() as u64,
-                ptr: s.as_ptr(),
+                len: bs.len() as u64,
+                ptr: bs.as_ptr(),
                 _marker: PhantomData,
             };
             Str::from_rep(literal.into())
@@ -832,7 +825,7 @@ impl<'a> From<String> for Str<'a> {
         if s.len() == 0 {
             return Default::default();
         }
-        let buf = Buf::read_from_str(s.as_str());
+        let buf = Buf::read_from_bytes(s.as_bytes());
         let boxed = Boxed {
             len: s.len() as u64,
             buf,
@@ -1097,8 +1090,7 @@ impl UniqueBuf {
 }
 
 impl Buf {
-    // Unsafe because it assumes valid utf8.
-    pub unsafe fn into_str<'a>(self) -> Str<'a> {
+    pub fn into_str<'a>(self) -> Str<'a> {
         Str::from_rep(
             Boxed {
                 len: self.len() as u64,
@@ -1127,7 +1119,7 @@ impl Buf {
     }
 
     // Unsafe because `from` and `to` must point to the start of characters.
-    pub unsafe fn slice_to_str<'a>(&self, from: usize, to: usize) -> Str<'a> {
+    pub fn slice_to_str<'a>(&self, from: usize, to: usize) -> Str<'a> {
         debug_assert!(from <= self.len());
         debug_assert!(to <= self.len());
         debug_assert!(from <= to, "invalid slice [{}, {})", from, to);
@@ -1135,7 +1127,12 @@ impl Buf {
         if len == 0 {
             Str::default()
         } else if len <= MAX_INLINE_SIZE {
-            Str::from_rep(Inline::from_raw(self.as_ptr().offset(from as isize), len).into())
+            unsafe {
+                Str::from_rep(
+                    Inline::from_raw(self.as_ptr().offset(std::cmp::max(0, from as isize)), len)
+                        .into(),
+                )
+            }
         } else if std::intrinsics::likely(
             from <= u32::max_value() as usize && to <= u32::max_value() as usize,
         ) {
@@ -1158,9 +1155,8 @@ impl Buf {
         ubuf.into_buf()
     }
 
-    pub fn read_from_str(s: &str) -> Buf {
-        let res = unsafe { Buf::read_from_raw(s.as_ptr(), s.len()) };
-        res
+    pub fn read_from_bytes(s: &[u8]) -> Buf {
+        unsafe { Buf::read_from_raw(s.as_ptr(), s.len()) }
     }
     pub fn try_unique(self) -> Result<UniqueBuf, Buf> {
         if self.refcount() == 1 {
@@ -1191,24 +1187,24 @@ mod tests {
         assert_eq!(unsafe { s.rep().get_tag() }, StrTag::Inline);
         let s1 = s.slice(0, 1);
         assert_eq!(unsafe { s1.rep().get_tag() }, StrTag::Inline);
-        s1.with_str(|s1| assert_eq!(s1, "h"));
+        s1.with_bytes(|bs1| assert_eq!(bs1, b"h"));
     }
 
     #[test]
     fn basic_behavior() {
-        let base_1 = "hi there fellow";
-        let base_2 = "how are you?";
-        let base_3 = "hi there fellowhow are you?";
-        let s1 = Str::from(base_1);
-        let s2 = Str::from(base_2);
-        let s3 = Str::from(base_3);
-        s1.with_str(|s| assert_eq!(s, base_1));
-        s2.with_str(|s| assert_eq!(s, base_2, "{:?}", s2));
-        s3.with_str(|s| assert_eq!(s, base_3));
+        let base_1 = b"hi there fellow";
+        let base_2 = b"how are you?";
+        let base_3 = b"hi there fellowhow are you?";
+        let s1 = Str::from(&base_1[..]);
+        let s2 = Str::from(&base_2[..]);
+        let s3 = Str::from(&base_3[..]);
+        s1.with_bytes(|bs| assert_eq!(bs, base_1));
+        s2.with_bytes(|bs| assert_eq!(bs, base_2, "{:?}", s2));
+        s3.with_bytes(|bs| assert_eq!(bs, base_3));
 
         let s4 = Str::concat(s1, s2.clone());
         assert_eq!(s3, s4);
-        s4.with_str(|s| assert_eq!(s, base_3));
+        s4.with_bytes(|bs| assert_eq!(bs, base_3));
         let s5 = Str::concat(
             Str::concat(Str::from("hi"), Str::from(" there")),
             Str::concat(
@@ -1216,17 +1212,17 @@ mod tests {
                 Str::concat(Str::from("fel"), Str::from("low")),
             ),
         );
-        s5.with_str(|s| assert_eq!(s, base_1));
+        s5.with_bytes(|bs| assert_eq!(bs, base_1));
 
         // Do this multiple times to play with the refcount.
         assert_eq!(s2.slice(1, 4), s3.slice(16, 19));
         assert_eq!(s2.slice(2, 6), s3.slice(17, 21));
     }
 
-    fn test_str_split(pat: &Regex, base: &str) {
+    fn test_str_split(pat: &Regex, base: &[u8]) {
         let s = Str::from(base);
         let want = pat
-            .split(base.as_bytes())
+            .split(base)
             .skip_while(|x| x.len() == 0)
             .collect::<Vec<_>>();
         let mut got = Vec::new();
@@ -1256,15 +1252,18 @@ mod tests {
     #[test]
     fn basic_splitting() {
         let pat0 = Regex::new(",").unwrap();
-        test_str_split(&pat0, "what,is,,,up,");
+        test_str_split(&pat0, b"what,is,,,up,");
         let pat = Regex::new(r#"[ \t]"#).unwrap();
-        test_str_split(&pat, "what is \t up ");
+        test_str_split(&pat, b"what is \t up ");
     }
 
     #[test]
     fn split_long_string() {
         let pat = Regex::new(r#"[ \t]"#).unwrap();
-        test_str_split(&pat, crate::test_string_constants::PRIDE_PREJUDICE_CH2);
+        test_str_split(
+            &pat,
+            crate::test_string_constants::PRIDE_PREJUDICE_CH2.as_bytes(),
+        );
     }
 
     #[test]
@@ -1278,10 +1277,10 @@ mod tests {
         .unwrap();
         write!(&mut d, "And this is the second part").unwrap();
         let s = unsafe { d.into_str() };
-        s.with_str(|s| {
+        s.with_bytes(|bs| {
             assert_eq!(
-                s,
-                r#"This is the first part of the string with formatting and everything!
+                bs,
+                br#"This is the first part of the string with formatting and everything!
 And this is the second part"#
             )
         });
@@ -1294,7 +1293,7 @@ And this is the second part"#
         let re1 = Regex::new("n").unwrap();
         let (s3, n1) = s1.subst_all(&re1, &s2);
         assert_eq!(n1, 3);
-        s3.with_str(|s| assert_eq!(s, "Strimg mumber ome"));
+        s3.with_bytes(|bs| assert_eq!(bs, b"Strimg mumber ome"));
 
         let re2 = Regex::new("xxyz").unwrap();
         let (s4, n2) = s3.subst_all(&re2, &s2);
@@ -1308,7 +1307,7 @@ And this is the second part"#
 
         let s6: Str = "xxyz substituted into another xxyz".into();
         let (s7, subbed) = s6.subst_first(&re2, &s1);
-        s7.with_str(|s| assert_eq!(s, "String number one substituted into another xxyz"));
+        s7.with_bytes(|bs| assert_eq!(bs, b"String number one substituted into another xxyz"));
         assert!(subbed);
     }
 
@@ -1377,7 +1376,10 @@ mod formatting {
 
     impl<'a> Display for Str<'a> {
         fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-            self.with_str(|s| write!(f, "{}", s))
+            self.with_bytes(|bs| match std::str::from_utf8(bs) {
+                Ok(s) => write!(f, "{}", s),
+                Err(_) => write!(f, "{:?}", bs),
+            })
         }
     }
 

--- a/src/runtime/string_search.rs
+++ b/src/runtime/string_search.rs
@@ -1,0 +1,79 @@
+//! Implementation of substring searches.
+//!
+//! Back when frawk strings were guaranteed to be UTF8, we just used str::find from the standard
+//! library. Now, we implement string searching in terms of memchr. For extremely long strings,
+//! something like Teddy would probably work better, but this has fewer runtime requirements and
+//! won't have much overhead for the common case use-caes of small strings.
+use super::{Int, Str};
+use memchr::{memchr, memchr_iter};
+
+// 1-indexed, 0 on failure
+pub fn index_substr<'a, 'b>(needle: &Str<'a>, haystack: &Str<'a>) -> Int {
+    needle
+        .with_bytes(|n| haystack.with_bytes(|h| index(n, h)))
+        .map(|x| x as Int + 1)
+        .unwrap_or(0)
+}
+
+fn index(needle: &[u8], haystack: &[u8]) -> Option<usize> {
+    let (needle, first) = match needle.len() {
+        0 => return Some(0),
+        1 => return memchr(needle[0], haystack),
+        _ => (&needle[1..], needle[0]),
+    };
+    for ix in memchr_iter(first, haystack) {
+        let upto = needle.len() + ix + 1;
+        if haystack.len() < upto {
+            break;
+        }
+        if &haystack[ix + 1..upto] == needle {
+            return Some(ix);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oracle(needle: &str, haystack: &str) {
+        let expected = haystack.find(needle);
+        let got = index(needle.as_bytes(), haystack.as_bytes());
+        assert_eq!(
+            got, expected,
+            "searching for {:?} in {:?}, expected {:?}, got {:?}",
+            needle, haystack, expected, got
+        );
+    }
+
+    #[test]
+    fn small_strings() {
+        oracle("", "");
+        oracle("", "any string");
+        oracle("x", "pattern not found");
+        oracle("x", "this string has an x in it");
+        oracle("x", "this string has an x in it");
+        oracle("ab", "asdfabcde as;dlfkjas ekdbd");
+        oracle("ab", "ab");
+        oracle("ab", "xxozoiuoba");
+        oracle("jkl", "adfwqer;flkasjdfas;lk");
+        oracle("jkl", "ajklqer;flkasjdfas;lk");
+        oracle("jkl", "jkllqer;flkasjdfas;lk");
+    }
+
+    #[test]
+    fn longer_strings() {
+        oracle("hello", "I say there, hello and good day to you");
+        oracle(
+            "hello",
+            "xadf;a asdfl;kasjdfasdlk;fjasdfas;alou ad/.,k'poqasewrq    ",
+        );
+        oracle(
+            "hello",
+            "helloa asdfl;kasjdfasdlk;fjasdfas;alou ad/.,k'poqasewrq    ",
+        );
+        oracle("medium length string", "medium length string");
+        oracle("longer needle than", "haystack");
+    }
+}


### PR DESCRIPTION
This PR.removes the invariant that frawk strings can only contain valid UTF-8. It keeps the existing machinery for validating UTF-8, but places it behind a flag. Most of the internal string routines have been updated to operate on byte slices. Strings are (re)validated for UTF-8 where necessary (e.g. file opens, regex construction, printf, the first two of which are cached).