### PR TITLE
Add benchmark results for Linux

### DIFF
--- a/info/performance.md
+++ b/info/performance.md
@@ -71,17 +71,17 @@ section makes clear, the versions of the tools I used are all slightly
 different. Comparisons within the same configuration should be safe while
 comparisons across configurations are less so.
 
-**MacOS** This is a 16-inch Macbook Pro running MacOS Catalina 10.15.4 with an
-8-core i9 clocked at 2.3GHz, boosting up to 4.8GHz. One thing to keep in mind
-about newer Apple hardware is that the SSDs are very fast: read throughput can
-top 2.5GB/s. None of these benchmarks are IO-bound on this machine, although
-various portions of the input files might be cached by the OS.
+**MacOS (Newer Hardware)** This is a 16-inch Macbook Pro running MacOS Catalina
+10.15.4 with an 8-core i9 clocked at 2.3GHz, boosting up to 4.8GHz. One thing to
+keep in mind about newer Apple hardware is that the SSDs are very fast: read
+throughput can top 2.5GB/s. None of these benchmarks are IO-bound on this machine,
+although various portions of the input files might be cached by the OS.
 
-**Linux** This is a dual-socket workstation with 2 8-core Xeon 2620v4 CPUs
-clocked at 2.2 GHz or so and boosting up to 2.9GHz on a single core, with 64GB
-of RAM. Reads are serviced from an NVMe SSD that is pretty fast, but not as fast
-as the SSD in the Mac. I do not think any of the benchmarks are IO-bound on this
-machine.
+**Linux (Older Hardware)** This is a dual-socket workstation with 2 8-core Xeon
+2620v4 CPUs clocked at 2.2 GHz or so and boosting up to 2.9GHz on a single core,
+with 64GB of RAM. Reads are serviced from an NVMe SSD that is pretty fast, but
+not as fast as the SSD in the Mac. I do not think any of the benchmarks are IO-bound
+on this machine. The machine is running Ubuntu 18.04 with a 4.15 kernel.
 
 While the results are varied from benchmark to benchmark, I tend to find that
 while frawk has good performance overall, it does noticeably better on the

--- a/info/performance.md
+++ b/info/performance.md
@@ -22,12 +22,12 @@ larger files are usually in CSV, TSV, or some similar standardized format).
 
 ## Benchmark Setup
 
-All benchmark numbers report the minimum wall time across 5 iterations, along
-with the composite system and user times for that invocation as reported by the
-`time` command. A computation running with wall time of 2.5 seconds, and CPU
-time of 10.2s for user and 3.4s for system is reported as "2.5s (10.2s + 3.4s)".
-We also report throughput numbers, which are computed as wall time divided by
-input file size.
+All benchmark numbers report the minimum wall time across 5 iterations per
+hardware configuration, along with the composite system and user times for that
+invocation as reported by the `time` command. A computation running with wall
+time of 2.5 seconds, and CPU time of 10.2s for user and 3.4s for system is
+reported as "2.5s (10.2s + 3.4s)".  We also report throughput numbers, which
+are computed as wall time divided by input file size.
 
 This doc includes measurements for both parallel and serial invocations of
 frawk. The parallel invocations launch 4 workers. XSV supports parallelism but I
@@ -62,11 +62,35 @@ These benchmarks run on CSV and TSV versions of two data-sets:
 
 ### Hardware
 
-Numbers are reported from a 16-inch Macbook Pro running MacOS Catalina 10.15.4
-with an 8-core i9 clocked at 2.3GHz, boosting up to 4.8GHz. One thing to keep
-in mind about newer Apple hardware is that the SSDs are very fast: read
-throughput can top 2.5GB/s. None of these benchmarks are IO-bound on this
-machine, although various portions of the input files might be cached by the OS.
+This doc reports performance numbers from two machines, a new (late 2019) MacOS
+laptop, and an older (mid-2016, Broadwell-based) workstation running Ubuntu.
+They're called out as "MacOS" and "Linux" not because I take these numbers to be
+benchmarks of those operating systems, but as a shorthand for the whole
+configuration, software and hardware, used in those benchmarks. As the Tools
+section makes clear, the versions of the tools I used are all slightly
+different. Comparisons within the same configuration should be safe while
+comparisons across configurations are less so.
+
+**MacOS** This is a 16-inch Macbook Pro running MacOS Catalina 10.15.4 with an
+8-core i9 clocked at 2.3GHz, boosting up to 4.8GHz. One thing to keep in mind
+about newer Apple hardware is that the SSDs are very fast: read throughput can
+top 2.5GB/s. None of these benchmarks are IO-bound on this machine, although
+various portions of the input files might be cached by the OS.
+
+**Linux** This is a dual-socket workstation with 2 8-core Xeon 2620v4 CPUs
+clocked at 2.2 GHz or so and boosting up to 2.9GHz on a single core, with 64GB
+of RAM. Reads are serviced from an NVMe SSD that is pretty fast, but not as fast
+as the SSD in the Mac. I do not think any of the benchmarks are IO-bound on this
+machine.
+
+While the results are varied from benchmark to benchmark, I tend to find that
+while frawk has good performance overall, it does noticeably better the newer
+hardware running MacOS. The absolute difference in these numbers are probably
+due to having a newer CPU with a much higher boost clock, but I am less sure
+about the relative  performance differences between frawk and tsv-utils. One
+contributing factor might be frawk's use of AVX2 driving the clock rate down to
+a greater degree on the Broadwell-E CPU in Linux than the more recent CPU on the
+Mac configuration.
 
 ### Tools
 These benchmarks report values for a number of tools, each with slightly
@@ -77,17 +101,18 @@ benchmarks. All benchmarks include `frawk`, of course; in this case both the
 
 * [`mawk`](https://invisible-island.net/mawk/) is an Awk implementation due to
   Mike Brennan. It is focused on the "Awk book" semantics for the language, and
-  on efficiency. I used mawk v1.3.4.
+  on efficiency. I used mawk v1.3.4 on MacOS and v1.3.3 on Linux.
 * [`gawk`](https://www.gnu.org/software/gawk/manual/) is GNU's Awk. It is
   actively maintained and includes several extensions to the Awk language (such
   as multidimensional arrays). It is the default Awk on many Linux machines. I
-  used gawk v5.0.1.
+  used gawk v5.0.1 on MacOS and v4.1.4 on Linux.
 * [`xsv`](https://github.com/BurntSushi/xsv) is a command-line utility for
   performing common computations and transformations on CSV data. I used xsv
-  v0.13.0.
+  v0.13.0 on both platforms
 * [`tsv-utils`](https://github.com/eBay/tsv-utils) is a set of command-line
   utilities offering a similar feature-set to xsv, but with a focus on TSV data. I
-  used tsv-utils `v1.6.1_osx-x86_64_ldc2`, downloaded from the repo.
+  used tsv-utils `v1.6.1_osx-x86_64_ldc2` and `v2.1.1_linux-x86_64_ldc2`
+  downloaded from the repo for MacOS and Linux, respectively.
 
 There are plenty of other tools I could put here (see the benchmarks referenced
 on xsv and tsv-utils' pages for more), but I chose a small set of tools that
@@ -111,7 +136,8 @@ possible configurations, for example:
 Scripts and output for these benchmarks are
 [here](https://github.com/ezrosent/frawk/blob/master/info/scripts). They do not
 include the raw data or the various binaries in question, but they should be
-straightforward to adapt for a given set of installs on another machine.
+straightforward to adapt for a given set of installs on another machine. Outputs
+from the Linux configuration lives are in the ".2" files.
 
 ## Ad-hoc number-crunching
 Before we start benchmarking purpose-built tools, I want to emphasize the power
@@ -207,6 +233,7 @@ this either is or isn't important. We'll leave it out for now, but keep in mind
 that frawk's and python's runtimes include the time it takes to compile a
 program.
 
+**MacOS**
 | Program | Running Time (TREE_GRM_ESTN.csv) | Throughput |
 | -- | -- | -- |
 | Python | 2m47.3s (2m45.9s + 1.4s) | 53.5 MB/s |
@@ -214,11 +241,19 @@ program.
 | frawk | 19.6s (18.4s + 1.1s) | 456.4 MB/s |
 | frawk (parallel) | 4.8s (22.6s + 1.2s) | 1863.6 MB/s |
 
-frawk is a good deal faster than the other options, particularly when run in
-parallel. Now, the Rust script could of course be optimized substantially (frawk
-is implemented in Rust, after all).  But if you need to do exploratory, ad-hoc
-computations like this, a frawk script is probably going to be faster than the
-first few Rust programs you write.
+**Linux**
+| Program | Running Time | Throughput |
+| -- | -- | -- |
+| Python | CSV | 2m15.2s (2m13.5s + 1.7s) | 66.15 MB/s |
+| Rust | CSV | 30.1s (28.8s + 1.3s) | 297.25 MB/s |
+| frawk | CSV | 28.0s (25.7s + 2.2s) | 319.84 MB/s |
+| frawk (parallel) | CSV | 9.7s (34.3s + 3.9s) | 922.30 MB/s |
+
+frawk is a good deal faster than the other options, particularly on the newer
+hardware, or when run in parallel. Now, the Rust script could of course be
+optimized substantially (frawk is implemented in Rust, after all).  But if you
+need to do exploratory, ad-hoc computations like this, a frawk script is
+probably going to be faster than the first few Rust programs you write.
 
 With that said, for many tasks you do not need a full programming language,
 and there are purpose-built tools for computing the particular value or
@@ -226,7 +261,7 @@ transformation on the dataset. The rest of these benchmarks compare frawk and
 Awk to some of those.
 
 ## Sum two columns
-_Sum columns 4 and 5 from TREE_GRM_ESTN and columns 6 and 18 for all_train_
+_Sum columns 4 and 5 from `TREE_GRM_ESTN` and columns 6 and 18 for `all_train`_
 
 Programs:
 * Awk: `-F{,\t} {sum1 += ${6,4}; sum2 += ${18,5};} END { print sum1,sum2}`
@@ -237,10 +272,12 @@ Awk was only run on the TSV version of TREE_GRM_ESTN, as it has quote-escaped
 columns, tsv-utils was only run on TSV versions of both files, and xsv was not
 included because there is no way to persuade it to _just_ compute a sum.
 
-As can be seen below, frawk in parallel mode was the fastest utility in terms of
-wall-time, and on a per-core basis frawk was faster than mawk and gawk but
-slower than tsv-utils.
+As can be seen below, frawk in parallel mode was the fastest utility in terms
+of wall-time on MacOS, but it is slightly slower on the Linux hardware; on a
+per-core basis frawk was faster than mawk and gawk but slower than tsv-utils on
+both configurations.
 
+**MacOS**
 | Program | Format | Running Time (TREE_GRM_ESTN) | Throughput (TREE_GRM_ESTN) | Running Time (all_train) | Throughput (all_train) |
 | -- | -- | -- | -- | -- | -- |
 | mawk | TSV | 42.5s (41.0s + 1.5s) | 185.7 MB/s | 10.9s (9.9s + 1.1s) | 477.1 MB/s |
@@ -252,6 +289,19 @@ slower than tsv-utils.
 | frawk | CSV | 17.3s (16.2s + 1.1s) | 517.1 MB/s | 7.6s (7.0s + 0.7s) | 684.2 MB/s |
 | frawk (parallel) | TSV | 3.5s (16.5s + 1.1s) | 2254.8 MB/s | 1.8s (8.2s + 0.7s) | 2888.9 MB/s |
 | frawk (parallel) | CSV | 4.8s (22.6s + 1.3s) | 1863.6 MB/s | 2.0s (9.0s + 0.7s) | 2600.0 MB/s |
+
+**Linux**
+| Program | Running Time (TREE_GRM_ESTN) | Throughput (TREE_GRM_ESTN) | Running Time (all_train) | Throughput (all_train) |
+| -- | -- | -- | -- | -- |
+| mawk | TSV | 50.6s (49.0s + 1.6s) | 155.90 MB/s | 10.1s (8.9s + 1.3s) | 510.34 MB/s |
+| mawk | CSV | NA | NA | 9.9s (9.0s + 1.0s) | 521.76 MB/s |
+| gawk | TSV | 1m3.7s (1m2.2s + 1.5s) | 123.87 MB/s | 1m8.9s (1m7.8s + 1.1s) | 75.17 MB/s |
+| gawk | CSV | NA | NA | 1m8.9s (1m7.8s + 1.2s) | 75.14 MB/s |
+| tsv-utils | TSV | 7.4s (6.4s + 1.0s) | 1067.88 MB/s | 3.7s (2.9s + 0.8s) | 1408.71 MB/s |
+| frawk | TSV | 20.0s (18.6s + 1.4s) | 393.79 MB/s | 7.7s (6.7s + 0.9s) | 673.57 MB/s |
+| frawk | CSV | 25.4s (23.6s + 1.9s) | 351.88 MB/s | 7.7s (6.8s + 0.9s) | 669.48 MB/s |
+| frawk (parallel) | TSV | 6.8s (24.1s + 2.8s) | 1168.78 MB/s | 4.2s (13.0s + 2.8s) | 1237.97 MB/s |
+| frawk (parallel) | CSV | 10.0s (32.9s + 5.4s) | 891.96 MB/s | 4.7s (13.6s + 3.5s) | 1096.66 MB/s |
 
 
 ## Statistics
@@ -397,14 +447,16 @@ END {
 }
 ```
 
-The numeric portion of this benchmark took a little over 10 seconds using
-tsv-utils, but I am omitting it from the table because it does not support
-the given summary statistics on string fields. All numbers are reported for
-TREE_GRM_ESTN.
+The numeric portion of this benchmark took a little over 10 seconds on MacOS,
+and 15 seconds on Linux using tsv-utils, but I am omitting it from the table
+because it does not support the given summary statistics on string fields. All
+numbers are reported for TREE_GRM_ESTN.
 
 As can be seen below, frawk performed this task more quickly than any of the
-other benchmark programs:
+other benchmark programs, though the race is pretty with xsv on the Linux
+desktop using a single core and CSV format.
 
+**MacOS**
 | Program | Format | Running Time | Throughput |
 | -- | -- | -- | -- |
 | mawk | TSV | 1m12.9s (1m11.4s + 1.5s) | 108.3 MB/s |
@@ -415,6 +467,18 @@ other benchmark programs:
 | frawk | CSV | 19.2s (18.1s + 1.1s) | 465.9 MB/s |
 | frawk (parallel) | TSV | 4.0s (18.4s + 1.0s) | 1972.9 MB/s |
 | frawk (parallel) | CSV | 4.9s (22.8s + 1.2s) | 1825.6 MB/s |
+
+**Linux**
+| Program | Running Time | Throughput |
+| -- | -- | -- |
+| mawk | TSV | 1m17.0s (1m14.9s + 2.0s) | 102.53 MB/s |
+| gawk | TSV | 2m11.1s (2m9.2s + 1.9s) | 60.19 MB/s |
+| xsv | TSV | 31.6s (30.5s + 1.1s) | 249.40 MB/s |
+| xsv | CSV | 34.2s (32.8s + 1.4s) | 261.85 MB/s |
+| frawk | TSV | 22.8s (21.2s + 1.6s) | 345.97 MB/s |
+| frawk | CSV | 28.1s (26.2s + 1.9s) | 317.86 MB/s |
+| frawk (parallel) | TSV | 7.1s (25.7s + 2.0s) | 1112.12 MB/s |
+| frawk (parallel) | CSV | 9.6s (33.9s + 3.8s) | 928.53 MB/s |
 
 ## Select
 _Select 3 fields from the all_train dataset._
@@ -435,9 +499,11 @@ all times surely underestimate the true running time of such an operation.
 
 frawk performs this task slower than tsv-utils and faster than the other
 benchmark programs. While the gap between frawk in parallel mode and tsv-utils
-is probably in the noise, tsv-utils unquestionably performs better per core than
-frawk, while preserving the input's row ordering.
+is probably in the noise on MacOS (it's still pretty large for the Linux
+configuration), tsv-utils unquestionably performs better per core than frawk,
+while preserving the input's row ordering.
 
+**MacOS**
 | Program | Format | Running Time | Throughput |
 | -- | -- | -- | -- |
 | mawk | TSV | 8.5s (7.5s + 1.0s) | 611.8 MB/s |
@@ -451,6 +517,21 @@ frawk, while preserving the input's row ordering.
 | frawk | CSV | 3.9s (4.0s + 0.9s) | 1333.3 MB/s |
 | frawk (parallel) | TSV | 2.1s (10.1s + 1.1s) | 2476.2 MB/s |
 | frawk (parallel) | CSV | 2.3s (11.0s + 1.1s) | 2260.9 MB/s |
+
+**Linux**
+| Program | Running Time | Throughput |
+| -- | -- | -- |
+| mawk | TSV | 7.8s (6.6s + 1.2s) | 660.43 MB/s |
+| mawk | CSV | 8.0s (6.8s + 1.3s) | 643.76 MB/s |
+| gawk | TSV | 1m10.8s (1m9.8s + 1.0s) | 73.18 MB/s |
+| gawk | CSV | 1m11.1s (1m9.8s + 1.3s) | 72.82 MB/s |
+| xsv | TSV | 8.1s (7.2s + 0.9s) | 641.29 MB/s |
+| xsv | CSV | 8.1s (7.3s + 0.7s) | 642.73 MB/s |
+| tsv-utils | TSV | 3.0s (2.1s + 0.9s) | 1718.70 MB/s |
+| frawk | TSV | 5.2s (4.8s + 1.6s) | 1005.33 MB/s |
+| frawk | CSV | 5.3s (5.3s + 1.6s) | 980.02 MB/s |
+| frawk (parallel) | TSV | 4.6s (12.8s + 4.9s) | 1114.12 MB/s |
+| frawk (parallel) | CSV | 5.4s (13.8s + 5.4s) | 958.97 MB/s |
 
 ## Filter
 _Print out all records from the `all_train` dataset matching a simple numeric
@@ -470,8 +551,9 @@ does not support numeric filters, so it was omitted from this benchmark.
 
 Again, frawk is slower than tsv-utils and faster than everything else when
 running serially. In parallel, frawk is slightly faster than tsv-utils in terms
-of wall time.
+of wall time on MacOS, and a still good deal slower in the Linux configuration.
 
+**MacOS**
 | Program | Format | Running Time | Thoughput |
 | -- | -- | -- | -- |
 | mawk | TSV | 10.3s (9.2s + 1.1s) | 504.9 MB/s |
@@ -483,6 +565,19 @@ of wall time.
 | frawk | CSV | 7.1s (7.7s + 1.0s) | 732.4 MB/s |
 | frawk (parallel) | TSV | 2.4s (12.0s + 1.2s) | 2166.7 MB/s |
 | frawk (parallel) | CSV | 2.2s (10.8s + 1.1s) | 2363.6 MB/s |
+
+**Linux**
+| Program | Running Time | Throughput |
+| -- | -- | -- |
+| mawk | TSV | 9.8s (8.6s + 1.2s) | 530.69 MB/s |
+| mawk | CSV | 9.8s (8.6s + 1.1s) | 531.12 MB/s |
+| gawk | TSV | 41.5s (40.4s + 1.1s) | 124.82 MB/s |
+| gawk | CSV | 41.5s (40.6s + 0.8s) | 124.86 MB/s |
+| tsv-utils | TSV | 3.4s (2.6s + 0.8s) | 1508.43 MB/s |
+| frawk | TSV | 7.3s (7.6s + 2.1s) | 709.57 MB/s |
+| frawk | CSV | 7.5s (8.0s + 2.0s) | 689.08 MB/s |
+| frawk (parallel) | TSV | 4.2s (13.3s + 3.9s) | 1243.02 MB/s |
+| frawk (parallel) | CSV | 4.7s (14.8s + 4.1s) | 1099.69 MB/s |
 
 ## Group By Key
 _Print the mean of field 2 grouped by the value in field 6 for TREE_GRM_ESTN_
@@ -500,10 +595,11 @@ END {
 }
 ```
 
-Once again, tsv-utils is substantially faster than a single-threaded frawk, but
-is slower than frawk in parallel mode. frawk, in either configuration, is faster
-at this task than mawk or gawk.
+Once again, tsv-utils is substantially faster than a single-threaded frawk and
+parallel frawk on Linux, but is slower than frawk in parallel mode on MacOS.
+frawk, in all configurations, is faster at this task than mawk or gawk.
 
+**MacOS**
 | Program | Format | Running Time | Throughput |
 | -- | -- | -- | -- |
 | mawk | TSV | 43.5s (42.0s + 1.5s) | 181.4 MB/s |
@@ -513,3 +609,14 @@ at this task than mawk or gawk.
 | frawk | CSV | 19.4s (18.3s + 1.1s) | 461.1 MB/s |
 | frawk (parallel) | TSV | 3.8s (17.6s + 1.1s) | 2076.7 MB/s |
 | frawk (parallel) | CSV | 4.9s (23.3s + 1.2s) | 1825.6 MB/s |
+
+**Linux**
+| Program | Running Time | Throughput |
+| -- | -- | -- |
+| mawk | TSV | 48.0s (45.9s + 2.1s) | 164.46 MB/s |
+| gawk | TSV | 1m11.3s (1m9.7s + 1.6s) | 110.66 MB/s |
+| tsv-utils | TSV | 5.7s (4.6s + 1.1s) | 1390.35 MB/s |
+| frawk | TSV | 24.0s (22.5s + 1.6s) | 328.59 MB/s |
+| frawk | CSV | 27.6s (26.0s + 1.6s) | 324.45 MB/s |
+| frawk (parallel) | TSV | 7.0s (26.0s + 1.8s) | 1128.18 MB/s |
+| frawk (parallel) | CSV | 9.4s (33.8s + 3.3s) | 953.57 MB/s |

--- a/info/performance.md
+++ b/info/performance.md
@@ -30,13 +30,13 @@ reported as "2.5s (10.2s + 3.4s)".  We also report throughput numbers, which
 are computed as wall time divided by input file size.
 
 This doc includes measurements for both parallel and serial invocations of
-frawk. The parallel invocations launch 4 workers. XSV supports parallelism but I
-noticed no performance benefit from this feature without first building an index
-of the underlying CSV file (a process which can take longer than the benchmark
-task itself without amortizing the cost over multiple runs). Similarly, I do not
-believe it is  possible to parallelize the other programs using generic tools
-like `gnu parallel` without first partitioning the data-set into multiple
-sub-files.
+frawk. The parallel invocations launch 4 workers on MacOS and 3 workers on
+Linux. XSV supports parallelism but I noticed no performance benefit from this
+feature without first building an index of the underlying CSV file (a process
+which can take longer than the benchmark task itself without amortizing the
+cost over multiple runs). Similarly, I do not believe it is  possible to
+parallelize the other programs using generic tools like `gnu parallel` without
+first partitioning the data-set into multiple sub-files.
 
 ## UTF8
 
@@ -454,7 +454,7 @@ because it does not support the given summary statistics on string fields. All
 numbers are reported for TREE_GRM_ESTN.
 
 As can be seen below, frawk performed this task more quickly than any of the
-other benchmark programs, though the race is pretty with xsv on the Linux
+other benchmark programs, though the race is pretty close with xsv on the Linux
 desktop using a single core and CSV format.
 
 **MacOS**

--- a/info/performance.md
+++ b/info/performance.md
@@ -84,18 +84,19 @@ as the SSD in the Mac. I do not think any of the benchmarks are IO-bound on this
 machine.
 
 While the results are varied from benchmark to benchmark, I tend to find that
-while frawk has good performance overall, it does noticeably better the newer
-hardware running MacOS. The absolute difference in these numbers are probably
-due to having a newer CPU with a much higher boost clock, but I am less sure
-about the relative  performance differences between frawk and tsv-utils. One
-contributing factor might be frawk's use of AVX2 driving the clock rate down to
-a greater degree on the Broadwell-E CPU in Linux than the more recent CPU on the
-Mac configuration.
+while frawk has good performance overall, it does noticeably better on the
+newer hardware running MacOS. The absolute difference in these numbers are
+probably due to having a newer CPU with a much higher boost clock, but I am
+less sure about the relative  performance differences between frawk and
+tsv-utils. One contributing factor might be frawk's use of AVX2 driving the
+clock rate down to a greater degree on the Broadwell-E CPU in Linux than the
+more recent CPU on the Mac configuration.
 
 ### Tools
+
 These benchmarks report values for a number of tools, each with slightly
-different intended use-cases and strengths. Not all of the tools are set up well
-to handle each intended task, but each makes an appearance in some subset of the
+different intended use-cases and strengths. Not all of the tools are set up
+well to handle each task, but each makes an appearance in some subset of the
 benchmarks. All benchmarks include `frawk`, of course; in this case both the
 `use_jemalloc` and `allow_avx2` features were enabled.
 
@@ -244,10 +245,10 @@ program.
 **Linux**
 | Program | Running Time | Throughput |
 | -- | -- | -- |
-| Python | CSV | 2m15.2s (2m13.5s + 1.7s) | 66.15 MB/s |
-| Rust | CSV | 30.1s (28.8s + 1.3s) | 297.25 MB/s |
-| frawk | CSV | 28.0s (25.7s + 2.2s) | 319.84 MB/s |
-| frawk (parallel) | CSV | 9.7s (34.3s + 3.9s) | 922.30 MB/s |
+| Python | 2m15.2s (2m13.5s + 1.7s) | 66.15 MB/s |
+| Rust | 30.1s (28.8s + 1.3s) | 297.25 MB/s |
+| frawk | 28.0s (25.7s + 2.2s) | 319.84 MB/s |
+| frawk (parallel) | 9.7s (34.3s + 3.9s) | 922.30 MB/s |
 
 frawk is a good deal faster than the other options, particularly on the newer
 hardware, or when run in parallel. Now, the Rust script could of course be
@@ -291,8 +292,8 @@ both configurations.
 | frawk (parallel) | CSV | 4.8s (22.6s + 1.3s) | 1863.6 MB/s | 2.0s (9.0s + 0.7s) | 2600.0 MB/s |
 
 **Linux**
-| Program | Running Time (TREE_GRM_ESTN) | Throughput (TREE_GRM_ESTN) | Running Time (all_train) | Throughput (all_train) |
-| -- | -- | -- | -- | -- |
+| Program | Format | Running Time (TREE_GRM_ESTN) | Throughput (TREE_GRM_ESTN) | Running Time (all_train) | Throughput (all_train) |
+| -- | -- | -- | -- | -- | -- |
 | mawk | TSV | 50.6s (49.0s + 1.6s) | 155.90 MB/s | 10.1s (8.9s + 1.3s) | 510.34 MB/s |
 | mawk | CSV | NA | NA | 9.9s (9.0s + 1.0s) | 521.76 MB/s |
 | gawk | TSV | 1m3.7s (1m2.2s + 1.5s) | 123.87 MB/s | 1m8.9s (1m7.8s + 1.1s) | 75.17 MB/s |
@@ -469,8 +470,8 @@ desktop using a single core and CSV format.
 | frawk (parallel) | CSV | 4.9s (22.8s + 1.2s) | 1825.6 MB/s |
 
 **Linux**
-| Program | Running Time | Throughput |
-| -- | -- | -- |
+| Program | Format | Running Time | Throughput |
+| -- | -- | -- | -- |
 | mawk | TSV | 1m17.0s (1m14.9s + 2.0s) | 102.53 MB/s |
 | gawk | TSV | 2m11.1s (2m9.2s + 1.9s) | 60.19 MB/s |
 | xsv | TSV | 31.6s (30.5s + 1.1s) | 249.40 MB/s |
@@ -519,8 +520,8 @@ while preserving the input's row ordering.
 | frawk (parallel) | CSV | 2.3s (11.0s + 1.1s) | 2260.9 MB/s |
 
 **Linux**
-| Program | Running Time | Throughput |
-| -- | -- | -- |
+| Program | Format | Running Time | Throughput |
+| -- | -- | -- | -- |
 | mawk | TSV | 7.8s (6.6s + 1.2s) | 660.43 MB/s |
 | mawk | CSV | 8.0s (6.8s + 1.3s) | 643.76 MB/s |
 | gawk | TSV | 1m10.8s (1m9.8s + 1.0s) | 73.18 MB/s |
@@ -567,8 +568,8 @@ of wall time on MacOS, and a still good deal slower in the Linux configuration.
 | frawk (parallel) | CSV | 2.2s (10.8s + 1.1s) | 2363.6 MB/s |
 
 **Linux**
-| Program | Running Time | Throughput |
-| -- | -- | -- |
+| Program | Format | Running Time | Throughput |
+| -- | -- | -- | -- |
 | mawk | TSV | 9.8s (8.6s + 1.2s) | 530.69 MB/s |
 | mawk | CSV | 9.8s (8.6s + 1.1s) | 531.12 MB/s |
 | gawk | TSV | 41.5s (40.4s + 1.1s) | 124.82 MB/s |
@@ -611,8 +612,8 @@ frawk, in all configurations, is faster at this task than mawk or gawk.
 | frawk (parallel) | CSV | 4.9s (23.3s + 1.2s) | 1825.6 MB/s |
 
 **Linux**
-| Program | Running Time | Throughput |
-| -- | -- | -- |
+| Program | Format | Running Time | Throughput |
+| -- | -- | -- | -- |
 | mawk | TSV | 48.0s (45.9s + 2.1s) | 164.46 MB/s |
 | gawk | TSV | 1m11.3s (1m9.7s + 1.6s) | 110.66 MB/s |
 | tsv-utils | TSV | 5.7s (4.6s + 1.1s) | 1390.35 MB/s |

--- a/info/scripts/complex_sum.sh.out.2
+++ b/info/scripts/complex_sum.sh.out.2
@@ -1,0 +1,125 @@
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m30.692s
+user	0m28.976s
+sys	0m1.716s
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
+
+real	2m15.232s
+user	2m13.482s
+sys	0m1.749s
++ frawk -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m28.025s
+user	0m25.905s
+sys	0m2.121s
++ frawk -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563443e18
+
+real	0m9.796s
+user	0m34.502s
+sys	0m4.010s
++ set +x
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m30.590s
+user	0m28.806s
+sys	0m1.784s
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
+
+real	2m15.423s
+user	2m13.329s
+sys	0m2.092s
++ frawk -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m28.162s
+user	0m26.082s
+sys	0m2.080s
++ frawk -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563339e18
+
+real	0m9.699s
+user	0m34.252s
+sys	0m3.915s
++ set +x
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m30.094s
+user	0m28.761s
+sys	0m1.332s
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
+
+real	2m17.145s
+user	2m15.337s
+sys	0m1.800s
++ frawk -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m28.123s
+user	0m26.035s
+sys	0m2.088s
++ frawk -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563324e18
+
+real	0m9.735s
+user	0m34.543s
+sys	0m3.702s
++ set +x
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m30.654s
+user	0m28.773s
+sys	0m1.880s
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
+
+real	2m20.172s
+user	2m18.150s
+sys	0m2.020s
++ frawk -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m28.128s
+user	0m26.048s
+sys	0m2.080s
++ frawk -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563315e18
+
+real	0m10.012s
+user	0m34.772s
+sys	0m4.362s
++ set +x
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m30.508s
+user	0m28.692s
+sys	0m1.816s
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
+
+real	2m15.318s
+user	2m13.013s
+sys	0m2.304s
++ frawk -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m27.968s
+user	0m25.728s
+sys	0m2.240s
++ frawk -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563339e18
+
+real	0m9.977s
+user	0m34.554s
+sys	0m4.437s
++ set +x

--- a/info/scripts/filter.sh.out.2
+++ b/info/scripts/filter.sh.out.2
@@ -1,0 +1,230 @@
++ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m10.043s
+user	0m8.614s
+sys	0m1.429s
++ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m9.815s
+user	0m8.647s
+sys	0m1.168s
++ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m41.876s
+user	0m40.539s
+sys	0m1.336s
++ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m41.782s
+user	0m40.641s
+sys	0m1.140s
++ frawk -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.742s
+user	0m7.977s
+sys	0m2.309s
++ frawk -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.298s
+user	0m7.649s
+sys	0m2.129s
++ frawk -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m4.883s
+user	0m15.149s
+sys	0m4.257s
++ frawk -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.166s
+user	0m13.318s
+sys	0m3.901s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.702s
+user	0m2.665s
+sys	0m1.037s
++ set +x
++ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m9.850s
+user	0m8.613s
+sys	0m1.237s
++ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m10.166s
+user	0m8.699s
+sys	0m1.464s
++ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m42.316s
+user	0m41.258s
+sys	0m1.056s
++ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m41.767s
+user	0m40.494s
+sys	0m1.272s
++ frawk -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.690s
+user	0m8.108s
+sys	0m2.111s
++ frawk -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.839s
+user	0m7.898s
+sys	0m2.472s
++ frawk -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m4.957s
+user	0m15.171s
+sys	0m4.350s
++ frawk -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.611s
+user	0m14.322s
+sys	0m4.333s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.433s
+user	0m2.629s
+sys	0m0.805s
++ set +x
++ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m10.014s
+user	0m8.570s
+sys	0m1.444s
++ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m9.758s
+user	0m8.570s
+sys	0m1.189s
++ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m42.079s
+user	0m40.866s
+sys	0m1.212s
++ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m41.488s
+user	0m40.436s
+sys	0m1.052s
++ frawk -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m8.341s
+user	0m8.556s
+sys	0m2.408s
++ frawk -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.496s
+user	0m8.042s
+sys	0m1.977s
++ frawk -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m4.829s
+user	0m14.694s
+sys	0m4.472s
++ frawk -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.363s
+user	0m14.155s
+sys	0m3.805s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.753s
+user	0m2.761s
+sys	0m0.993s
++ set +x
++ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m9.750s
+user	0m8.622s
+sys	0m1.129s
++ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m10.013s
+user	0m8.616s
+sys	0m1.396s
++ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m41.475s
+user	0m40.639s
+sys	0m0.837s
++ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m41.761s
+user	0m40.364s
+sys	0m1.396s
++ frawk -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.515s
+user	0m8.027s
+sys	0m1.994s
++ frawk -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.519s
+user	0m7.682s
+sys	0m2.343s
++ frawk -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m5.041s
+user	0m15.036s
+sys	0m4.517s
++ frawk -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.680s
+user	0m14.315s
+sys	0m4.448s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.659s
+user	0m2.695s
+sys	0m0.964s
++ set +x
++ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m10.134s
+user	0m8.733s
+sys	0m1.401s
++ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m9.772s
+user	0m8.611s
+sys	0m1.161s
++ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m41.876s
+user	0m40.535s
+sys	0m1.341s
++ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m41.599s
+user	0m40.547s
+sys	0m1.052s
++ frawk -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.740s
+user	0m7.857s
+sys	0m2.441s
++ frawk -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.366s
+user	0m7.530s
+sys	0m2.354s
++ frawk -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m4.709s
+user	0m14.753s
+sys	0m4.108s
++ frawk -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.575s
+user	0m14.121s
+sys	0m4.308s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.679s
+user	0m2.650s
+sys	0m1.029s
++ set +x

--- a/info/scripts/groupby.sh.out.2
+++ b/info/scripts/groupby.sh.out.2
@@ -1,0 +1,255 @@
++ mawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m47.985s
+user	0m45.928s
+sys	0m2.056s
++ gawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	1m12.371s
+user	1m10.682s
+sys	0m1.688s
++ frawk -itsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.322s
+user	0m22.554s
+sys	0m1.768s
++ frawk -icsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m28.172s
+user	0m26.253s
+sys	0m1.917s
++ frawk -itsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m6.995s
+user	0m25.968s
+sys	0m1.804s
++ frawk -icsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m9.381s
+user	0m33.836s
+sys	0m3.308s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m5.676s
+user	0m4.568s
+sys	0m1.108s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m48.687s
+user	0m46.571s
+sys	0m2.116s
++ gawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	1m11.317s
+user	1m9.700s
+sys	0m1.616s
++ frawk -itsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.121s
+user	0m22.373s
+sys	0m1.748s
++ frawk -icsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m27.571s
+user	0m25.995s
+sys	0m1.576s
++ frawk -itsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m7.268s
+user	0m26.770s
+sys	0m2.061s
++ frawk -icsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m9.939s
+user	0m34.517s
+sys	0m4.276s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m5.881s
+user	0m4.669s
+sys	0m1.212s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m48.506s
+user	0m46.489s
+sys	0m2.016s
++ gawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	1m12.751s
+user	1m10.983s
+sys	0m1.768s
++ frawk -itsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.422s
+user	0m22.686s
+sys	0m1.736s
++ frawk -icsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m28.031s
+user	0m26.187s
+sys	0m1.844s
++ frawk -itsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m7.295s
+user	0m26.938s
+sys	0m1.985s
++ frawk -icsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m9.777s
+user	0m34.489s
+sys	0m4.007s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m6.026s
+user	0m4.505s
+sys	0m1.521s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m49.024s
+user	0m47.191s
+sys	0m1.832s
++ gawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	1m11.582s
+user	1m9.821s
+sys	0m1.760s
++ frawk -itsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.468s
+user	0m22.904s
+sys	0m1.564s
++ frawk -icsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m28.282s
+user	0m26.170s
+sys	0m2.113s
++ frawk -itsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m7.399s
+user	0m27.176s
+sys	0m2.129s
++ frawk -icsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m9.791s
+user	0m34.636s
+sys	0m3.785s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m6.062s
+user	0m4.573s
+sys	0m1.489s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m48.467s
+user	0m46.582s
+sys	0m1.884s
++ gawk '-F\t' -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	1m13.438s
+user	1m11.738s
+sys	0m1.700s
++ frawk -itsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.017s
+user	0m22.457s
+sys	0m1.560s
++ frawk -icsv -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m28.127s
+user	0m25.947s
+sys	0m2.180s
++ frawk -itsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m7.355s
+user	0m27.012s
+sys	0m2.156s
++ frawk -icsv -pr -j3 -f /tmp/tmp.V9887g044R ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180712732725496
+
+real	0m9.878s
+user	0m34.405s
+sys	0m4.269s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m5.877s
+user	0m4.613s
+sys	0m1.264s
++ set +x

--- a/info/scripts/select.sh.out.2
+++ b/info/scripts/select.sh.out.2
@@ -1,0 +1,280 @@
++ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.159s
+user	0m6.792s
+sys	0m1.368s
++ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m8.094s
+user	0m6.802s
+sys	0m1.292s
++ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	1m11.138s
+user	1m9.796s
+sys	0m1.337s
++ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	1m11.084s
+user	1m10.051s
+sys	0m1.032s
++ frawk -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.517s
+user	0m5.071s
+sys	0m2.013s
++ frawk -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.392s
+user	0m5.191s
+sys	0m1.781s
++ frawk -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.434s
+user	0m13.998s
+sys	0m5.328s
++ frawk -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.648s
+user	0m12.808s
+sys	0m4.895s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.335s
+user	0m7.255s
+sys	0m1.080s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.254s
+user	0m7.197s
+sys	0m1.057s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m3.065s
+user	0m1.984s
+sys	0m1.081s
++ set +x
++ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.413s
+user	0m7.152s
+sys	0m1.260s
++ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m8.077s
+user	0m6.764s
+sys	0m1.312s
++ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	1m13.657s
+user	1m12.359s
+sys	0m1.296s
++ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	1m10.787s
+user	1m9.610s
+sys	0m1.176s
++ frawk -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.503s
+user	0m5.192s
+sys	0m1.868s
++ frawk -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.189s
+user	0m5.126s
+sys	0m1.631s
++ frawk -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.411s
+user	0m13.907s
+sys	0m5.311s
++ frawk -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.998s
+user	0m13.025s
+sys	0m5.175s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.316s
+user	0m7.195s
+sys	0m1.120s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.336s
+user	0m7.256s
+sys	0m1.080s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m3.065s
+user	0m2.064s
+sys	0m1.000s
++ set +x
++ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.044s
+user	0m6.791s
+sys	0m1.252s
++ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m8.106s
+user	0m6.665s
+sys	0m1.441s
++ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	1m11.187s
+user	1m10.210s
+sys	0m0.977s
++ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	1m11.490s
+user	1m10.204s
+sys	0m1.280s
++ frawk -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.284s
+user	0m5.257s
+sys	0m1.595s
++ frawk -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.401s
+user	0m5.109s
+sys	0m1.865s
++ frawk -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.454s
+user	0m13.962s
+sys	0m5.171s
++ frawk -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.913s
+user	0m13.281s
+sys	0m4.811s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.272s
+user	0m7.259s
+sys	0m1.012s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.327s
+user	0m7.130s
+sys	0m1.196s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m3.013s
+user	0m2.072s
+sys	0m0.941s
++ set +x
++ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.119s
+user	0m6.646s
+sys	0m1.473s
++ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m7.841s
+user	0m6.628s
+sys	0m1.213s
++ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	1m11.255s
+user	1m9.942s
+sys	0m1.312s
++ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	1m11.311s
+user	1m10.234s
+sys	0m1.076s
++ frawk -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.531s
+user	0m5.181s
+sys	0m1.930s
++ frawk -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.237s
+user	0m5.003s
+sys	0m1.806s
++ frawk -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.501s
+user	0m14.224s
+sys	0m5.262s
++ frawk -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.837s
+user	0m12.887s
+sys	0m5.158s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.328s
+user	0m7.204s
+sys	0m1.124s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.279s
+user	0m7.311s
+sys	0m0.968s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m3.058s
+user	0m2.093s
+sys	0m0.965s
++ set +x
++ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.168s
+user	0m6.851s
+sys	0m1.316s
++ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m8.237s
+user	0m6.768s
+sys	0m1.468s
++ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	1m11.109s
+user	1m9.824s
+sys	0m1.284s
++ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	1m10.762s
+user	1m9.765s
+sys	0m0.996s
++ frawk -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.513s
+user	0m5.250s
+sys	0m1.834s
++ frawk -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.151s
+user	0m4.781s
+sys	0m1.629s
++ frawk -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.400s
+user	0m13.810s
+sys	0m5.354s
++ frawk -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.846s
+user	0m13.223s
+sys	0m4.770s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.057s
+user	0m7.328s
+sys	0m0.728s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.075s
+user	0m7.206s
+sys	0m0.868s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m3.093s
+user	0m2.061s
+sys	0m1.033s
++ set +x

--- a/info/scripts/stat_2.sh.out.2
+++ b/info/scripts/stat_2.sh.out.2
@@ -1,0 +1,360 @@
++ mawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m16.968s
+user	1m14.923s
+sys	0m2.044s
++ gawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	2m11.137s
+user	2m9.239s
+sys	0m1.896s
++ frawk -itsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m22.810s
+user	0m21.210s
+sys	0m1.600s
++ frawk -icsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m28.151s
+user	0m26.123s
+sys	0m2.028s
++ frawk -pr -j3 -itsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851608e21 2222953010690.0 733769247290487.0 13 15 248282826052433.72 180596235717831.56
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.270s
+user	0m26.366s
+sys	0m2.063s
++ frawk -pr -j3 -icsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202386885127e21 2222953010690.0 733769247290487.0 13 15 248282826052424.4 180596235717829.4
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.910s
+user	0m35.204s
+sys	0m3.512s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.927s
+user	0m33.524s
+sys	0m1.408s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m31.642s
+user	0m30.523s
+sys	0m1.112s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.748s
+user	0m14.356s
+sys	0m1.392s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m20.226s
+user	1m18.272s
+sys	0m1.944s
++ gawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	2m13.750s
+user	2m11.750s
+sys	0m1.996s
++ frawk -itsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.684s
+user	0m22.199s
+sys	0m1.484s
++ frawk -icsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m28.388s
+user	0m26.136s
+sys	0m2.252s
++ frawk -pr -j3 -itsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851398e21 2222953010690.0 733769247290487.0 13 15 248282826052427.94 180596235718839.9
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.148s
+user	0m25.712s
+sys	0m2.249s
++ frawk -pr -j3 -icsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851537e21 2222953010690.0 733769247290487.0 13 15 248282826052431.75 180596235718018.75
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.869s
+user	0m34.752s
+sys	0m3.624s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m35.887s
+user	0m34.280s
+sys	0m1.612s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m32.812s
+user	0m31.536s
+sys	0m1.280s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.671s
+user	0m14.139s
+sys	0m1.532s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m17.171s
+user	1m15.307s
+sys	0m1.864s
++ gawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	2m11.398s
+user	2m9.384s
+sys	0m2.012s
++ frawk -itsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.037s
+user	0m21.313s
+sys	0m1.724s
++ frawk -icsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m28.143s
+user	0m26.208s
+sys	0m1.936s
++ frawk -pr -j3 -itsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851457e21 2222953010690.0 733769247290487.0 13 15 248282826052429.56 180596235717930.84
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.096s
+user	0m25.706s
+sys	0m2.031s
++ frawk -pr -j3 -icsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202386885119e21 2222953010690.0 733769247290487.0 13 15 248282826052422.22 180596235717812.62
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.634s
+user	0m33.868s
+sys	0m3.781s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.163s
+user	0m32.765s
+sys	0m1.404s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m32.003s
+user	0m30.762s
+sys	0m1.244s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.513s
+user	0m13.888s
+sys	0m1.624s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m18.075s
+user	1m16.230s
+sys	0m1.844s
++ gawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	2m16.348s
+user	2m14.278s
+sys	0m2.072s
++ frawk -itsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.808s
+user	0m22.083s
+sys	0m1.716s
++ frawk -icsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m28.205s
+user	0m26.202s
+sys	0m2.004s
++ frawk -pr -j3 -itsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851688e21 2222953010690.0 733769247290487.0 13 15 248282826052435.9 180596235717056.1
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.355s
+user	0m26.358s
+sys	0m2.369s
++ frawk -pr -j3 -icsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851207e21 2222953010690.0 733769247290487.0 13 15 248282826052422.7 180596235717821.4
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.985s
+user	0m34.961s
+sys	0m3.876s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.965s
+user	0m33.108s
+sys	0m1.864s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m32.359s
+user	0m30.861s
+sys	0m1.504s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.583s
+user	0m14.100s
+sys	0m1.484s
++ set +x
++ mawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m17.737s
+user	1m15.830s
+sys	0m1.908s
++ gawk '-F\t' -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	2m11.118s
+user	2m9.175s
+sys	0m1.944s
++ frawk -itsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.101s
+user	0m21.393s
+sys	0m1.708s
++ frawk -icsv -f /tmp/tmp.XwrAGIWJf7 ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m28.291s
+user	0m26.055s
+sys	0m2.236s
++ frawk -pr -j3 -itsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851337e21 2222953010690.0 733769247290487.0 13 15 248282826052426.28 180596235717834.4
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.171s
+user	0m25.631s
+sys	0m2.464s
++ frawk -pr -j3 -icsv -f /tmp/tmp.r2Fk8uSkIw ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851431e21 2222953010690.0 733769247290487.0 13 15 248282826052428.84 180596235718130.22
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.867s
+user	0m34.459s
+sys	0m3.798s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.322s
+user	0m32.867s
+sys	0m1.460s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m32.302s
+user	0m30.792s
+sys	0m1.516s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.340s
+user	0m14.216s
+sys	0m1.124s
++ set +x

--- a/info/scripts/sum2.sh.out.2
+++ b/info/scripts/sum2.sh.out.2
@@ -1,0 +1,495 @@
++ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.333s
+user	0m9.021s
+sys	0m1.313s
++ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m52.611s
+user	0m50.606s
+sys	0m2.004s
++ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.316s
+user	0m9.028s
+sys	0m1.288s
++ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	1m8.956s
+user	1m7.802s
+sys	0m1.153s
++ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	1m9.183s
+user	1m8.074s
+sys	0m1.108s
++ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	1m3.919s
+user	1m2.005s
+sys	0m1.912s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m3.902s
+user	0m2.885s
+sys	0m1.017s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.885s
+user	0m6.336s
+sys	0m1.549s
++ frawk -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.735s
+user	0m6.811s
+sys	0m0.924s
++ frawk -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.515s
+user	0m23.495s
+sys	0m2.020s
++ frawk -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.357s
+user	0m7.277s
+sys	0m1.081s
++ frawk -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.644s
+user	0m18.932s
+sys	0m1.712s
++ frawk -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446387 -3875.3246569558305
+
+real	0m4.952s
+user	0m14.344s
+sys	0m3.528s
++ frawk -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759015169e21 9.022023868851404e21
+
+real	0m10.029s
+user	0m32.945s
+sys	0m5.357s
++ frawk -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446394 -3875.3246569558305
+
+real	0m4.183s
+user	0m13.007s
+sys	0m2.819s
++ frawk -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013491e21 9.022023868851339e21
+
+real	0m6.756s
+user	0m24.146s
+sys	0m2.734s
++ set +x
++ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.363s
+user	0m9.031s
+sys	0m1.332s
++ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m51.011s
+user	0m48.910s
+sys	0m2.101s
++ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.351s
+user	0m9.087s
+sys	0m1.264s
++ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	1m9.123s
+user	1m7.834s
+sys	0m1.288s
++ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	1m9.622s
+user	1m8.417s
+sys	0m1.204s
++ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	1m4.108s
+user	1m2.187s
+sys	0m1.920s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m3.906s
+user	0m2.925s
+sys	0m0.980s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.769s
+user	0m6.472s
+sys	0m1.296s
++ frawk -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.034s
+user	0m7.255s
+sys	0m0.780s
++ frawk -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.472s
+user	0m23.576s
+sys	0m1.896s
++ frawk -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.954s
+user	0m6.845s
+sys	0m1.109s
++ frawk -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.040s
+user	0m18.609s
+sys	0m1.432s
++ frawk -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446385 -3875.3246569558305
+
+real	0m4.996s
+user	0m13.933s
+sys	0m3.686s
++ frawk -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759016367e21 9.02202386885093e21
+
+real	0m10.102s
+user	0m33.499s
+sys	0m5.191s
++ frawk -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446387 -3875.32465695583
+
+real	0m4.408s
+user	0m13.116s
+sys	0m3.225s
++ frawk -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013927e21 9.022023868851371e21
+
+real	0m7.109s
+user	0m25.079s
+sys	0m3.032s
++ set +x
++ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.303s
+user	0m9.075s
+sys	0m1.228s
++ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m51.380s
+user	0m49.556s
+sys	0m1.824s
++ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.237s
+user	0m8.989s
+sys	0m1.248s
++ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	1m10.941s
+user	1m9.622s
+sys	0m1.320s
++ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	1m9.666s
+user	1m8.646s
+sys	0m1.020s
++ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	1m3.711s
+user	1m2.235s
+sys	0m1.476s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m3.683s
+user	0m2.970s
+sys	0m0.713s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.390s
+user	0m6.422s
+sys	0m0.968s
++ frawk -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.943s
+user	0m6.932s
+sys	0m1.012s
++ frawk -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.509s
+user	0m23.674s
+sys	0m1.815s
++ frawk -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.784s
+user	0m6.780s
+sys	0m1.004s
++ frawk -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.070s
+user	0m18.648s
+sys	0m1.396s
++ frawk -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446387 -3875.3246569558305
+
+real	0m5.141s
+user	0m13.910s
+sys	0m3.956s
++ frawk -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759017761e21 9.022023868851119e21
+
+real	0m10.084s
+user	0m33.144s
+sys	0m5.336s
++ frawk -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446391 -3875.324656955831
+
+real	0m4.518s
+user	0m13.282s
+sys	0m3.301s
++ frawk -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013721e21 9.022023868851318e21
+
+real	0m7.085s
+user	0m24.704s
+sys	0m3.330s
++ set +x
++ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.335s
+user	0m8.851s
+sys	0m1.484s
++ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m51.102s
+user	0m48.958s
+sys	0m2.144s
++ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.217s
+user	0m8.881s
+sys	0m1.336s
++ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	1m8.920s
+user	1m7.751s
+sys	0m1.168s
++ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	1m9.426s
+user	1m8.205s
+sys	0m1.220s
++ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	1m3.857s
+user	1m2.009s
+sys	0m1.848s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m3.968s
+user	0m3.004s
+sys	0m0.964s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.853s
+user	0m6.428s
+sys	0m1.425s
++ frawk -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.636s
+user	0m7.400s
+sys	0m1.236s
++ frawk -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.677s
+user	0m23.589s
+sys	0m2.088s
++ frawk -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m9.143s
+user	0m7.852s
+sys	0m1.288s
++ frawk -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.285s
+user	0m18.388s
+sys	0m1.897s
++ frawk -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m4.722s
+user	0m13.594s
+sys	0m3.468s
++ frawk -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759014531e21 9.022023868851249e21
+
+real	0m10.067s
+user	0m33.294s
+sys	0m5.285s
++ frawk -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446386 -3875.3246569558314
+
+real	0m4.477s
+user	0m13.147s
+sys	0m3.469s
++ frawk -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013563e21 9.022023868851258e21
+
+real	0m6.752s
+user	0m24.054s
+sys	0m2.795s
++ set +x
++ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m9.925s
+user	0m8.952s
+sys	0m0.972s
++ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m50.619s
+user	0m49.039s
+sys	0m1.580s
++ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.147s
+user	0m8.856s
+sys	0m1.292s
++ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	1m9.266s
+user	1m7.990s
+sys	0m1.276s
++ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	1m8.886s
+user	1m7.829s
+sys	0m1.056s
++ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	1m5.269s
+user	1m3.617s
+sys	0m1.652s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m3.676s
+user	0m2.911s
+sys	0m0.765s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.445s
+user	0m6.356s
+sys	0m1.088s
++ frawk -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.001s
+user	0m6.953s
+sys	0m1.048s
++ frawk -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.422s
+user	0m23.558s
+sys	0m1.864s
++ frawk -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.688s
+user	0m6.741s
+sys	0m0.948s
++ frawk -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.057s
+user	0m18.744s
+sys	0m1.312s
++ frawk -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446391 -3875.3246569558296
+
+real	0m4.959s
+user	0m13.979s
+sys	0m3.557s
++ frawk -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759015883e21 9.022023868851696e21
+
+real	0m10.044s
+user	0m32.884s
+sys	0m5.440s
++ frawk -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446387 -3875.3246569558305
+
+real	0m4.437s
+user	0m13.220s
+sys	0m3.157s
++ frawk -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013764e21 9.022023868851484e21
+
+real	0m7.218s
+user	0m25.108s
+sys	0m3.385s
++ set +x


### PR DESCRIPTION
When I posted about frawk on reddit, some folks found frawk performed pretty well, but not as well as the benchmarks suggested. One factor that I noticed was that this seemed to be happening on a few-year-old CPU with some older hardware. I did a quick re-run of the benchmark scripts on an Ubuntu workstation with CPUs from mid-2016, and I think I've reproduced those more-tepid results. This PR adds those results to the benchmarks doc alongside the existing ones from my laptop.

At some point it would be worth re-running the Linux benchmarks on a newer gawk, and re-running the Mac benchmarks on a newer tsv-utils. I hope these initial numbers are still helpful for now.