### PR TITLE
Parsing Fixes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -68,6 +68,20 @@ pub struct Prog<'a, 'b, I> {
 }
 
 impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
+    pub(crate) fn from_stage(stage: Stage<()>) -> Self {
+        Prog {
+            field_sep: None,
+            prelude_vardecs: Default::default(),
+            output_sep: None,
+            output_record_sep: None,
+            decs: Default::default(),
+            begin: None,
+            prepare: None,
+            end: None,
+            pats: Default::default(),
+            stage,
+        }
+    }
     pub(crate) fn desugar_stage<'outer>(
         &self,
         arena: &'a Arena<'outer>,

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -271,8 +271,8 @@ pub(crate) fn parse_program<'a, 'inp, 'outer>(
     let lexer = lexer::Tokenizer::new(prog);
     let mut buf = Vec::new();
     let mut program = ast::Prog::from_stage(strat.stage());
-    let parser = syntax::Prog2Parser::new();
-    match parser.parse(a, &mut buf, &strat.stage(), &mut program, lexer) {
+    let parser = syntax::ProgParser::new();
+    match parser.parse(a, &mut buf, &mut program, lexer) {
         Ok(()) => {
             match esc {
                 Escaper::CSV => program.output_sep = Some(","),

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -270,9 +270,10 @@ pub(crate) fn parse_program<'a, 'inp, 'outer>(
     let prog = a.alloc_str(prog);
     let lexer = lexer::Tokenizer::new(prog);
     let mut buf = Vec::new();
-    let parser = syntax::ProgParser::new();
-    match parser.parse(a, &mut buf, &strat.stage(), lexer) {
-        Ok(mut program) => {
+    let mut program = ast::Prog::from_stage(strat.stage());
+    let parser = syntax::Prog2Parser::new();
+    match parser.parse(a, &mut buf, &strat.stage(), &mut program, lexer) {
+        Ok(()) => {
             match esc {
                 Escaper::CSV => program.output_sep = Some(","),
                 Escaper::TSV => program.output_sep = Some("\t"),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -464,6 +464,15 @@ pub struct Error {
     pub desc: &'static str,
 }
 
+impl From<&'static str> for Error {
+    fn from(s: &'static str) -> Error {
+        Error {
+            location: Default::default(),
+            desc: s,
+        }
+    }
+}
+
 impl<'a> Tokenizer<'a> {
     pub fn new(text: &'a str) -> Tokenizer<'a> {
         Tokenizer {
@@ -557,8 +566,10 @@ impl<'a> Iterator for Tokenizer<'a> {
                     }
                 }
             }
-        } else {
+        } else if let Some(Tok::Newline) = self.prev_tok {
             return None;
+        } else {
+            self.spanned(self.cur, self.cur, Tok::Newline)
         };
         self.prev_tok = Some(span.1.clone());
         Some(Ok(span))
@@ -660,7 +671,8 @@ and the third"#;
                 Ident("z"),
                 Semi,
                 Newline,
-                RBrace
+                RBrace,
+                Newline,
             ]
         );
     }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -722,8 +722,8 @@ impl<'a, 'b> Generator<'a, 'b> {
                         view.gen_hl_inst(hl)?;
                         match hl {
                             Ret(_, _) => exits.push((i, j)),
-                            Phi(_, _, _) => phis.push((i, j)),
-                            DropIter(_, _) | Call { .. } => {}
+                            Phi(_, ty, _) if ty != &Ty::Null => phis.push((i, j)),
+                            Phi(_,_,_) | DropIter(_, _) | Call { .. } => {}
                         }
                     }
                 }
@@ -1938,6 +1938,9 @@ impl<'a> View<'a> {
                 self.bind_val((*dst_reg, *dst_ty), resv);
             }
             Phi(reg, ty, _preds) => {
+                if let Ty::Null = ty {
+                    return Ok(());
+                }
                 self.f.skip_drop.insert((*reg, *ty));
                 let res = LLVMBuildPhi(
                     self.f.builder,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -723,7 +723,7 @@ impl<'a, 'b> Generator<'a, 'b> {
                         match hl {
                             Ret(_, _) => exits.push((i, j)),
                             Phi(_, ty, _) if ty != &Ty::Null => phis.push((i, j)),
-                            Phi(_,_,_) | DropIter(_, _) | Call { .. } => {}
+                            Phi(_, _, _) | DropIter(_, _) | Call { .. } => {}
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,8 @@ fn get_vars<'a, 'b>(
         let var = a.alloc_str(var);
         let lexer = lexer::Tokenizer::new(var);
         let parser = parsing::syntax::VarDefParser::new();
-        match parser.parse(a, buf, &Stage::Main(()), lexer) {
+        let mut _prog = ast::Prog::from_stage(Stage::Main(()));
+        match parser.parse(a, buf, &Stage::Main(()), &mut _prog, lexer) {
             Ok(stmt) => stmts.push(stmt),
             Err(e) => fail!(
                 "failed to parse var at index {}:\n{}\nerror:{:?}",
@@ -161,14 +162,15 @@ fn get_context<'a>(
     let prog = a.alloc_str(prog);
     let lexer = lexer::Tokenizer::new(prog);
     let mut buf = Vec::new();
-    let parser = parsing::syntax::ProgParser::new();
-    let stmt = match parser.parse(a, &mut buf, &prelude.stage, lexer) {
-        Ok(mut program) => {
-            program.field_sep = prelude.field_sep;
-            program.prelude_vardecs = prelude.var_decs;
-            program.output_sep = prelude.output_sep;
-            program.output_record_sep = prelude.output_record_sep;
-            a.alloc_v(program)
+    let parser = parsing::syntax::Prog2Parser::new();
+    let mut prog = ast::Prog::from_stage(prelude.stage.clone());
+    let stmt = match parser.parse(a, &mut buf, &prelude.stage, &mut prog, lexer) {
+        Ok(()) => {
+            prog.field_sep = prelude.field_sep;
+            prog.prelude_vardecs = prelude.var_decs;
+            prog.output_sep = prelude.output_sep;
+            prog.output_record_sep = prelude.output_record_sep;
+            a.alloc_v(prog)
         }
         Err(e) => {
             fail!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn get_vars<'a, 'b>(
         let lexer = lexer::Tokenizer::new(var);
         let parser = parsing::syntax::VarDefParser::new();
         let mut _prog = ast::Prog::from_stage(Stage::Main(()));
-        match parser.parse(a, buf, &Stage::Main(()), &mut _prog, lexer) {
+        match parser.parse(a, buf, &mut _prog, lexer) {
             Ok(stmt) => stmts.push(stmt),
             Err(e) => fail!(
                 "failed to parse var at index {}:\n{}\nerror:{:?}",
@@ -162,9 +162,9 @@ fn get_context<'a>(
     let prog = a.alloc_str(prog);
     let lexer = lexer::Tokenizer::new(prog);
     let mut buf = Vec::new();
-    let parser = parsing::syntax::Prog2Parser::new();
+    let parser = parsing::syntax::ProgParser::new();
     let mut prog = ast::Prog::from_stage(prelude.stage.clone());
-    let stmt = match parser.parse(a, &mut buf, &prelude.stage, &mut prog, lexer) {
+    let stmt = match parser.parse(a, &mut buf, &mut prog, lexer) {
         Ok(()) => {
             prog.field_sep = prelude.field_sep;
             prog.prelude_vardecs = prelude.var_decs;

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -213,9 +213,9 @@ LeafStmt: &'a Stmt<'a, 'a, &'a str> = {
         arena.alloc_v(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
     "print(" "\n"* <pa:(<Args?>)> ")" <re:Redirect?> =>
         arena.alloc_v(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
-    "printf" <spec:PrecAdd> <pa: ("," <PrintArgs>)?> <re:Redirect?> =>
+    "printf" <spec:PrecAdd> <pa: ("," "\n"* <PrintArgs>)?> <re:Redirect?> =>
         arena.alloc_v(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
-    "printf(" "\n"* <spec:Expr> <pa: ("," <Args>)?> ")" <re:Redirect?> =>
+    "printf(" "\n"* <spec:(<Expr> "\n"*)> <pa: ("," "\n"* <Args>)?> ")" <re:Redirect?> =>
         arena.alloc_v(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
     "break" => arena.alloc_v(Stmt::Break),
     "continue" => arena.alloc_v(Stmt::Continue),
@@ -414,8 +414,6 @@ Index: &'a Expr<'a,'a,&'a str> = {
 IndexBase: (&'a Expr<'a,'a,&'a str>, &'a Expr<'a,'a,&'a str>) = {
   <arr:BaseTerm> "[" <e:Expr> "]" => (arr, e),
 }
-
-
 
 BaseTerm: &'a Expr<'a,'a, &'a str> = {
   LeafTerm,

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -263,7 +263,7 @@ Args: Vec<&'a Expr<'a,'a,&'a str>> = {
 }
 
 Expr: &'a Expr<'a,'a,&'a str> = {
-    "getline" <into:BaseTerm?> <from:("<" <BaseTerm>)?> => arena.alloc_v(Expr::Getline{ into, from}),
+    "getline" <into:BaseTerm?> <from:("<" <Expr>)?> => arena.alloc_v(Expr::Getline{ into, from}),
     PrecAsgn
 };
 

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -5,7 +5,7 @@ use crate::{
   arena::Arena,
   ast::{Pattern, Expr, Stmt, Binop, Unop, Prog, FunDec},
   builtins::Function,
-  common::{Either, Stage},
+  common::Either,
   runtime::{strtoi,strtod,hextoi},
   lexer::{self, Tok},
 };
@@ -14,7 +14,6 @@ use lalrpop_util::ParseError;
 grammar<'a, 'outer>(
   arena: &'a Arena<'outer>,
   buf: &mut Vec<u8>,
-  stage: &Stage<()>,
   prog: &mut Prog<'a, 'a, &'a str>,
 );
 
@@ -63,53 +62,15 @@ UnbracedPattern: () = {
   <e1:BaseTerm> "," <e2:BaseTerm> "\n"+ => prog.pats.push((Pattern::Comma(e1, e2), None)),
 }
 
-Prog2p1: () = {
+ProgInner: () = {
   UnbracedPattern,
   ToplevelBraced,
-  Prog2p1 ToplevelBraced,
-  Prog2p1 UnbracedPattern,
+  ProgInner ToplevelBraced,
+  ProgInner UnbracedPattern,
 }
 
-Prog2p2: () = {
-  UnbracedPattern,
-  Prog2p2 UnbracedPattern,
-  Prog2p2 ToplevelBase,
-}
-
-// TODO: migrate rest of code to new grammar, clean up old if it works
-
-pub Prog2: () = {
-  "\n"* Prog2p1? // Prog2p2?
-}
-
-Prog: Prog<'a,'a,&'a str> = {
-    // TODO: functions anywhere
-    "\n"*
-    <fs:Function*>
-    <begin:Begin?>
-    <pats:PatAction*>
-    // <sa:Expr?>
-    <prepare:Prepare?>
-    <end:End?> =>
-        Prog {
-            field_sep: None,
-            output_sep: None,
-            output_record_sep: None,
-            prelude_vardecs: Default::default(),
-            decs: fs,
-            begin,
-            end,
-            prepare,
-            stage: stage.clone(),
-            pats: {
-                pats
-                // let mut pats = pats;
-                // if let Some(sa) = sa {
-                //     pats.push((Pattern::Bool(sa), None));
-                // }
-                // pats
-            }
-        }
+pub Prog: () = {
+  "\n"* ProgInner?
 }
 
 Function: FunDec<'a, 'a, &'a str> = {

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -9,16 +9,88 @@ use crate::{
   runtime::{strtoi,strtod,hextoi},
   lexer::{self, Tok},
 };
+use lalrpop_util::ParseError;
 
-grammar<'a, 'outer>(arena: &'a Arena<'outer>, buf: &mut Vec<u8>, stage: &Stage<()>);
+grammar<'a, 'outer>(
+  arena: &'a Arena<'outer>,
+  buf: &mut Vec<u8>,
+  stage: &Stage<()>,
+  prog: &mut Prog<'a, 'a, &'a str>,
+);
 
 pub VarDef: (&'a str, &'a Expr<'a, 'a, &'a str>) = {
     <id:"IDENT"> "=" <e:BaseTerm> => (id, e),
 }
 
-pub Prog: Prog<'a,'a,&'a str> = {
+ToplevelBase: () = {
+   <Begin> =>? {
+     if prog.begin.is_some() {
+       Err(ParseError::User{ error: "Only one BEGIN block allowed".into() })
+     } else {
+       prog.begin = Some(<>);
+       Ok(())
+     }
+   },
+
+   <End> =>? {
+     if prog.end.is_some() {
+       Err(ParseError::User{ error: "Only one END block allowed".into() })
+     } else {
+       prog.end = Some(<>);
+       Ok(())
+     }
+   },
+
+   <Prepare> =>? {
+     if prog.prepare.is_some() {
+       Err(ParseError::User{ error: "Only one PREPARE block allowed".into() })
+     } else {
+       prog.prepare = Some(<>);
+       Ok(())
+     }
+   },
+
+   <Function> => prog.decs.push(<>),
+}
+
+ToplevelBraced: () = {
+  ToplevelBase,
+  <PatAction> => prog.pats.push(<>),
+}
+
+UnbracedPattern: () = {
+  <Expr> "\n"+ => prog.pats.push((Pattern::Bool(<>), None)),
+  <e1:BaseTerm> "," <e2:BaseTerm> "\n"+ => prog.pats.push((Pattern::Comma(e1, e2), None)),
+}
+
+Prog2p1: () = {
+  UnbracedPattern,
+  ToplevelBraced,
+  Prog2p1 ToplevelBraced,
+  Prog2p1 UnbracedPattern,
+}
+
+Prog2p2: () = {
+  UnbracedPattern,
+  Prog2p2 UnbracedPattern,
+  Prog2p2 ToplevelBase,
+}
+
+// TODO: migrate rest of code to new grammar, clean up old if it works
+
+pub Prog2: () = {
+  "\n"* Prog2p1? // Prog2p2?
+}
+
+Prog: Prog<'a,'a,&'a str> = {
     // TODO: functions anywhere
-    "\n"* <fs:Function*> <begin:Begin?> <pats:PatAction*> <sa:Expr?> <prepare:Prepare?> <end:End?> =>
+    "\n"*
+    <fs:Function*>
+    <begin:Begin?>
+    <pats:PatAction*>
+    // <sa:Expr?>
+    <prepare:Prepare?>
+    <end:End?> =>
         Prog {
             field_sep: None,
             output_sep: None,
@@ -30,11 +102,12 @@ pub Prog: Prog<'a,'a,&'a str> = {
             prepare,
             stage: stage.clone(),
             pats: {
-                let mut pats = pats;
-                if let Some(sa) = sa {
-                    pats.push((Pattern::Bool(sa), None));
-                }
                 pats
+                // let mut pats = pats;
+                // if let Some(sa) = sa {
+                //     pats.push((Pattern::Bool(sa), None));
+                // }
+                // pats
             }
         }
 }
@@ -69,7 +142,7 @@ End: &'a Stmt<'a,'a,&'a str> = {
 }
 
 PatAction: (Pattern<'a,'a,&'a str>, Option<&'a Stmt<'a,'a,&'a str>>) = {
-   <p:Expr?> <b:Block> => (match p {
+  <p:Expr?> <b:Block> => (match p {
                    Some(e) => Pattern::Bool(e),
                    None => Pattern::Null,
               }, Some(b)),
@@ -103,14 +176,14 @@ ClosedStmt: &'a Stmt<'a,'a,&'a str> = {
     "if" "(" <cond:Expr> Rparen <s1:ClosedStmt> Else <s2:ClosedStmt> =>
            arena.alloc_v(Stmt::If(cond, s1, Some(s2))),
     "while" "(" <cond:Expr> Rparen <body:ClosedStmt> => arena.alloc_v(Stmt::While(false, cond, body)),
-    "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> Rparen <body:ClosedStmt> =>
+    "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> Rparen <body:ClosedLoopBody> =>
         arena.alloc_v(Stmt::For(
                 init.map(|x| arena.alloc_v(Stmt::Expr(x))),
                 cond,
                 update.map(|x| arena.alloc_v(Stmt::Expr(x))),
                 body
         )),
-    "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:ClosedStmt> =>
+    "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:ClosedLoopBody> =>
         arena.alloc_v(Stmt::ForEach(id, arr, body)),
 
 
@@ -118,8 +191,13 @@ ClosedStmt: &'a Stmt<'a,'a,&'a str> = {
 }
 
 Redirect: (&'a Expr<'a, 'a, &'a str>, bool) = {
-    ">" <BaseTerm> => (<>, false),
-    ">>" <BaseTerm> => (<>, true),
+    ">" <Expr> => (<>, false),
+    ">>" <Expr> => (<>, true),
+}
+
+ClosedLoopBody: &'a Stmt<'a, 'a, &'a str> = {
+    SemiSep => arena.alloc_v(Stmt::Block(vec![])),
+    ClosedStmt,
 }
 
 BaseStmt: &'a Stmt<'a, 'a, &'a str> = {
@@ -167,14 +245,7 @@ PrintArgs: Vec<&'a Expr<'a,'a,&'a str>> = {
     // To avoid ambiguities with expressions including ">" we jump down the precedence hierarchy
     // past the comparison operators.
     <PrecAdd> => vec![<>],
-    <v:(<PrecAdd> ",")+> <e:PrecAdd?> => match e {
-        None => v,
-        Some(e) => {
-            let mut v = v;
-            v.push(e);
-            v
-        }
-    }
+    <v:(<PrecAdd> "," "\n"*)+> <e:PrecAdd> => { let mut v = v; v.push(e); v },
 }
 
 Args: Vec<&'a Expr<'a,'a,&'a str>> = {
@@ -228,6 +299,14 @@ PrecIn: &'a Expr<'a,'a,&'a str> = {
     PrecMatch,
 }
 
+PrecMatch: &'a Expr<'a,'a,&'a str> = {
+    <l: PrecMatch> "~" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::IsMatch, l, r)),
+    <l: PrecMatch> "!~" <r: PrecCmp> => arena.alloc_v(Expr::Unop(
+            Unop::Not,
+            arena.alloc_v(Expr::Binop(Binop::IsMatch, l, r)))),
+    PrecCmp,
+}
+
 // XXX Replicate the first two layers of the precedence hierarchy to skip "in" expressions to avoid
 // ambiguity between beginning of for loop and foreach loop. This is a hack; we should find a way
 // to tell LALRPOP the right thing here.
@@ -262,13 +341,6 @@ PrecAndNoIn: &'a Expr<'a, 'a, &'a str> = {
     PrecMatch,
 }
 
-PrecMatch: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecMatch> "~" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::IsMatch, l, r)),
-    <l: PrecMatch> "!~" <r: PrecCmp> => arena.alloc_v(Expr::Unop(
-            Unop::Not,
-            arena.alloc_v(Expr::Binop(Binop::IsMatch, l, r)))),
-    PrecCmp,
-}
 
 PrecCmp: &'a Expr<'a,'a,&'a str> = {
     <l: PrecAdd> "<" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::LT, l, r)),
@@ -297,8 +369,8 @@ PrecPow: &'a Expr<'a, 'a, &'a str> = {
     <l: PrecUnop> "^" <r: PrecPow> => arena.alloc_v(Expr::Binop(Binop::Pow, l, r)),
     PrecUnop
 }
-PrecUnop: &'a Expr<'a,'a,&'a str> = {
 
+PrecUnop: &'a Expr<'a,'a,&'a str> = {
     "-" <e: PrecInc> => arena.alloc_v(Expr::Unop(Unop::Neg, e)),
     "+" <e: PrecInc> => arena.alloc_v(Expr::Unop(Unop::Pos, e)),
     "!" <e: PrecInc> => arena.alloc_v(Expr::Unop(Unop::Not, e)),
@@ -343,7 +415,14 @@ IndexBase: (&'a Expr<'a,'a,&'a str>, &'a Expr<'a,'a,&'a str>) = {
   <arr:BaseTerm> "[" <e:Expr> "]" => (arr, e),
 }
 
+
+
 BaseTerm: &'a Expr<'a,'a, &'a str> = {
+  LeafTerm,
+  "(" <e:Expr> ")" => e,
+}
+
+LeafTerm: &'a Expr<'a,'a, &'a str> = {
   Ident,
   Index,
   StrLit,
@@ -354,8 +433,9 @@ BaseTerm: &'a Expr<'a,'a, &'a str> = {
   // TODO: not Rparen for these next two?
   <i:CallStart> <args:Args?> ")" =>
         arena.alloc_v(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),
-  "(" <e:Expr> ")" => e,
 }
+
+
 
 And: () = { "&&" "\n"* }
 Or: () = { "||" "\n"* }

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -12,13 +12,13 @@ use crate::{
 
 grammar<'a, 'outer>(arena: &'a Arena<'outer>, buf: &mut Vec<u8>, stage: &Stage<()>);
 
-
 pub VarDef: (&'a str, &'a Expr<'a, 'a, &'a str>) = {
     <id:"IDENT"> "=" <e:BaseTerm> => (id, e),
 }
 
 pub Prog: Prog<'a,'a,&'a str> = {
-    <fs:(NL <Function>)*> NL <begin:Begin?> <pats:PatAction*> <sa:Expr?> <prepare:Prepare?> <end:End?> =>
+    // TODO: functions anywhere
+    "\n"* <fs:Function*> <begin:Begin?> <pats:PatAction*> <sa:Expr?> <prepare:Prepare?> <end:End?> =>
         Prog {
             field_sep: None,
             output_sep: None,
@@ -40,7 +40,7 @@ pub Prog: Prog<'a,'a,&'a str> = {
 }
 
 Function: FunDec<'a, 'a, &'a str> = {
-    <name:"FUNDEC"> "(" <args:FormalParams?> ")" <body:Block> =>
+    <name:"FUNDEC"> "(" <args:FormalParams?> Rparen <body:Block> =>
         FunDec {
           name,
           body,
@@ -49,49 +49,72 @@ Function: FunDec<'a, 'a, &'a str> = {
 }
 
 FormalParams: Vec<&'a str> = {
-   NL <"IDENT"> => vec![<>],
-   <v:(NL <"IDENT"> ",")+> <iopt:(NL <"IDENT">)?> => match iopt {
+   <"IDENT"> => vec![<>],
+   <v:(<"IDENT"> ",")+> <iopt:(<"IDENT">)?> => match iopt {
       Some(e) => { let mut v = v; v.push(e); v }
       None => v,
    }
 }
 
 Begin: &'a Stmt<'a,'a,&'a str> = {
-    "BEGIN" NL <Block> NL => <>
+    "BEGIN" "\n"* <Block> => <>
 }
 
 Prepare: &'a Stmt<'a,'a,&'a str> = {
-    "PREPARE" NL <Block> NL => <>
+    "PREPARE" "\n"* <Block> => <>
 }
 
 End: &'a Stmt<'a,'a,&'a str> = {
-    "END" NL <Block> NL => <>
+    "END" "\n"* <Block> => <>
 }
 
 PatAction: (Pattern<'a,'a,&'a str>, Option<&'a Stmt<'a,'a,&'a str>>) = {
-   <p:Expr?> <b:Block> NL => (match p {
+   <p:Expr?> <b:Block> => (match p {
                    Some(e) => Pattern::Bool(e),
                    None => Pattern::Null,
               }, Some(b)),
-  <l:BaseTerm> "," <r:BaseTerm> <b:Block> NL => (Pattern::Comma(l, r), Some(b)),
+  <l:BaseTerm> "," <r:BaseTerm> <b:Block> => (Pattern::Comma(l, r), Some(b)),
 }
 
-Stmt: &'a Stmt<'a,'a,&'a str> = {
-    "if" "(" <cond:Expr> ")" NL <s1:BaseStmt> "else" NL <s2:Stmt> =>
-           arena.alloc_v(Stmt::If(cond, s1, Some(s2))),
-    "if" "(" <cond:Expr> ")" NL <s1:BaseStmt> => arena.alloc_v(Stmt::If(cond, s1, None)),
-    "do" NL <body:BaseStmt> "while" "(" <cond:Expr> ")" => arena.alloc_v(Stmt::DoWhile(cond, body)),
-    "while" NL "(" <cond:Expr> ")" <body:BaseStmt> => arena.alloc_v(Stmt::While(false, cond, body)),
-    "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> ")" NL <body:BaseStmt> =>
+// Resolving if/else groupings courtesy of wikipedia
+
+Stmt: &'a Stmt<'a, 'a, &'a str> = {
+    OpenStmt,
+    ClosedStmt,
+}
+
+OpenStmt: &'a Stmt<'a,'a,&'a str> = {
+    "if" "(" <cond:Expr> Rparen <s1:ClosedStmt> Else <s2:OpenStmt> => arena.alloc_v(Stmt::If(cond, s1, Some(s2))),
+    "if" "(" <cond:Expr> Rparen <s1:Stmt> => arena.alloc_v(Stmt::If(cond, s1, None)),
+    "while" "(" <cond:Expr> Rparen <body:OpenStmt> => arena.alloc_v(Stmt::While(false, cond, body)),
+    "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> Rparen <body:OpenStmt> =>
         arena.alloc_v(Stmt::For(
                 init.map(|x| arena.alloc_v(Stmt::Expr(x))),
                 cond,
                 update.map(|x| arena.alloc_v(Stmt::Expr(x))),
                 body
         )),
-    "for" "(" <id:"IDENT"> "in" <arr:Expr> ")" NL <body: BaseStmt> =>
+    "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:OpenStmt> =>
         arena.alloc_v(Stmt::ForEach(id, arr, body)),
+}
+
+ClosedStmt: &'a Stmt<'a,'a,&'a str> = {
     BaseStmt,
+    "if" "(" <cond:Expr> Rparen <s1:ClosedStmt> Else <s2:ClosedStmt> =>
+           arena.alloc_v(Stmt::If(cond, s1, Some(s2))),
+    "while" "(" <cond:Expr> Rparen <body:ClosedStmt> => arena.alloc_v(Stmt::While(false, cond, body)),
+    "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> Rparen <body:ClosedStmt> =>
+        arena.alloc_v(Stmt::For(
+                init.map(|x| arena.alloc_v(Stmt::Expr(x))),
+                cond,
+                update.map(|x| arena.alloc_v(Stmt::Expr(x))),
+                body
+        )),
+    "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:ClosedStmt> =>
+        arena.alloc_v(Stmt::ForEach(id, arr, body)),
+
+
+    Do <body:BaseStmt> "while" "(" <cond:Expr> ")" Sep => arena.alloc_v(Stmt::DoWhile(cond, body)),
 }
 
 Redirect: (&'a Expr<'a, 'a, &'a str>, bool) = {
@@ -99,35 +122,38 @@ Redirect: (&'a Expr<'a, 'a, &'a str>, bool) = {
     ">>" <BaseTerm> => (<>, true),
 }
 
+BaseStmt: &'a Stmt<'a, 'a, &'a str> = {
+   <LeafStmt> Sep => <>,
+   Block,
+}
 
-BaseStmt: &'a Stmt<'a,'a,&'a str> = {
+LeafStmt: &'a Stmt<'a, 'a, &'a str> = {
     <e: Expr> => arena.alloc_v(Stmt::Expr(e)),
     "delete" <i: IndexBase> =>
         arena.alloc_v(Stmt::Expr(arena.alloc_v(Expr::Call(Either::Right(Function::Delete), vec![i.0, i.1])))),
     "print" <pa:PrintArgs?> <re:Redirect?> =>
         arena.alloc_v(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
-    "print(" <pa:(<Args?>)> ")" <re:Redirect?> =>
+    "print(" "\n"* <pa:(<Args?>)> ")" <re:Redirect?> =>
         arena.alloc_v(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
     "printf" <spec:PrecAdd> <pa: ("," <PrintArgs>)?> <re:Redirect?> =>
         arena.alloc_v(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
-    "printf(" <spec:Expr> <pa: ("," <Args>)?> ")" <re:Redirect?> =>
+    "printf(" "\n"* <spec:Expr> <pa: ("," <Args>)?> ")" <re:Redirect?> =>
         arena.alloc_v(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
     "break" => arena.alloc_v(Stmt::Break),
     "continue" => arena.alloc_v(Stmt::Continue),
     "next" => arena.alloc_v(Stmt::Next),
     "nextfile" => arena.alloc_v(Stmt::NextFile),
     "return" <Expr?> => arena.alloc_v(Stmt::Return(<>)),
-    Block,
 }
 
 Block: &'a Stmt<'a,'a,&'a str> = {
-    "{" NL "}" => arena.alloc_v(Stmt::Block(vec![])),
-    "{" NL <Stmt> "}" => <>,
-    "{" NL  <BlockInner> "}" => arena.alloc_v(Stmt::Block(<>)),
+    Lbrace Rbrace SemiSep? => arena.alloc_v(Stmt::Block(vec![])),
+    Lbrace <LeafStmt> Rbrace SemiSep? => <>,
+    Lbrace <BlockInner> Rbrace SemiSep? => arena.alloc_v(Stmt::Block(<>)),
 }
 
 BlockInner: Vec<&'a Stmt<'a,'a,&'a str>> = {
-    <v:(<Stmt> Sep)+> <e:Stmt?> => match e {
+    <v:(<Stmt>)+> <e:LeafStmt?> => match e {
         None => v,
         Some(e) => {
             let mut v = v;
@@ -154,8 +180,8 @@ PrintArgs: Vec<&'a Expr<'a,'a,&'a str>> = {
 Args: Vec<&'a Expr<'a,'a,&'a str>> = {
     // To avoid ambiguities with expressions including ">" we jump down the precedence hierarchy
     // past the comparison operators.
-    NL <Expr> => vec![<>],
-    <v:(NL <Expr> ",")+> <e:(NL <Expr?>)> => match e {
+    <Expr> => vec![<>],
+    <v:(<Expr> "," "\n"*)+> <e:(<Expr> "\n"*)?> => match e {
         None => v,
         Some(e) => {
             let mut v = v;
@@ -164,15 +190,6 @@ Args: Vec<&'a Expr<'a,'a,&'a str>> = {
         }
     }
 }
-
-#[inline]
-NL: () = "\n"*;
-
-Sep: () = {
-    SepBase+
-}
-
-SepBase: () = { ";", "\n" }
 
 Expr: &'a Expr<'a,'a,&'a str> = {
     "getline" <into:BaseTerm?> <from:("<" <BaseTerm>)?> => arena.alloc_v(Expr::Getline{ into, from}),
@@ -196,12 +213,12 @@ PrecTern: &'a Expr<'a, 'a, &'a str> = {
 }
 
 PrecOr: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecAnd> "||" <r: PrecOr> => arena.alloc_v(Expr::Or(l, r)),
+    <l: PrecAnd> Or <r: PrecOr> => arena.alloc_v(Expr::Or(l, r)),
     PrecAnd,
 }
 
 PrecAnd: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecIn> "&&" <r: PrecAnd> => arena.alloc_v(Expr::And(l, r)),
+    <l: PrecIn> And <r: PrecAnd> => arena.alloc_v(Expr::And(l, r)),
     PrecIn,
 }
 
@@ -236,12 +253,12 @@ PrecTernNoIn: &'a Expr<'a, 'a, &'a str> = {
 }
 
 PrecOrNoIn: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecAndNoIn> "||" <r: PrecOrNoIn> => arena.alloc_v(Expr::Or(l, r)),
+    <l: PrecAndNoIn> Or <r: PrecOrNoIn> => arena.alloc_v(Expr::Or(l, r)),
     PrecAndNoIn,
 }
 
 PrecAndNoIn: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecMatch> "&&" <r: PrecAndNoIn> => arena.alloc_v(Expr::And(l, r)),
+    <l: PrecMatch> And <r: PrecAndNoIn> => arena.alloc_v(Expr::And(l, r)),
     PrecMatch,
 }
 
@@ -334,9 +351,24 @@ BaseTerm: &'a Expr<'a,'a, &'a str> = {
   "HEX" => arena.alloc_v(Expr::ILit(hextoi(<>.as_bytes()))),
   "FLOAT" => arena.alloc_v(Expr::FLit(strtod(<>.as_bytes()))),
   "PATLIT" => arena.alloc_v(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf))),
-  <i:"CALLSTART"> <args:Args?> ")" =>
+  // TODO: not Rparen for these next two?
+  <i:CallStart> <args:Args?> ")" =>
         arena.alloc_v(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),
   "(" <e:Expr> ")" => e,
+}
+
+And: () = { "&&" "\n"* }
+Or: () = { "||" "\n"* }
+Do: () = { "do" "\n"* }
+Else: () = { "else" "\n"* }
+Lbrace: () = { "{" "\n"* }
+Rbrace: () = { "}" "\n"* }
+#[inline]
+Rparen: () = { ")" "\n"* }
+SemiSep: () = { ";" "\n"* }
+Sep: () = { "\n"+, ";" "\n"* }
+CallStart: &'a str = {
+   <"CALLSTART"> "\n"*
 }
 
 extern {


### PR DESCRIPTION
This PR contains a fix for most (but not _all_) mentioned in #24 
The bulk of this change is a refactor of the grammar in `syntax.lalrpop` for better handling of newlines. Along the way, I fixed a few edge cases in code gen uncovered by some of the examples that parse now, but did not at the time. I'll follow up on #24 to discuss next steps.