### PR TITLE
line-buffered stdout where appropriate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ crossbeam = "0.7.3"
 num_cpus = "1.13.0"
 cfg-if = "0.1"
 memchr = "2.3.3"
+grep-cli = "0.1"
+termcolor = "1.1"
 
 [features]
 default = ["use_jemalloc", "allow_avx2", "llvm_backend"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ extern crate clap;
 extern crate crossbeam;
 extern crate crossbeam_channel;
 extern crate elsa;
+extern crate grep_cli;
 extern crate hashbrown;
 #[cfg(feature = "use_jemalloc")]
 extern crate jemallocator;
@@ -47,6 +48,7 @@ extern crate regex;
 extern crate ryu;
 extern crate smallvec;
 extern crate stable_deref_trait;
+extern crate termcolor;
 extern crate unicode_xid;
 
 use clap::{App, Arg};


### PR DESCRIPTION
Based on the suggestion in #18, this change adopts grep_cli to detect
when to line-buffer output, and adds support for line-buffering to the
`writers` module.

This change accomplishes this by:

* Plumbing through "flush on newlines" information into FileHandles for
  stdout, when stdout is a tty.
* Allowing write requests to trigger a flush of the underlying writer.