### PR TITLE
Add support for `SUBSEP` syntactic sugar with

### DIFF
--- a/info/overview.md
+++ b/info/overview.md
@@ -228,17 +228,15 @@ surprised to discover there were bugs in frawk's parser.
   print floating point numbers, rather than the `CONVFMT` variable. Explicitly
   changing the precision of floating point output requires an appropriate
   invocation of `printf` or `sprintf`.
-* frawk does not support the `m[k, v]` syntactic sugar for `m[k SUBSEP v]`. This
-  is because I wanted to hold open the possibility of having true tuples as keys
-  for maps in frawk.
 * `next`,  or `nextfile` are supported in frawk, but they can only be invoked
   from the main loop. I haven't come across any Awk scripts that use either of
   these commands from within a function, and it's a major simplification to just
   disallow this case. Again, let me know if this is an important use-case for
   you.
-* Some basic Awk commands are missing (e.g. `exit`), because I have not gotten
-  to them yet. Many of the extensions in gawk (e.g. co-processes,
-  multidimensional arrays) are also not implemented.
+* Some basic Awk commands are missing (e.g. `exit` is not present, though
+  `nextfile` is and suffices in many cases), because I have not gotten to them
+  yet. Many of the extensions in gawk (e.g. co-processes, multidimensional
+  arrays) are also not implemented.
 * While it has never been tried, I sincerely doubt that frawk will run at all
   well --- or at all --- on a 32-bit platform. I suspect it would run much
   slower on a 64-bit non-x86 architecture.
@@ -300,11 +298,11 @@ if you find that the following are a serious hindrance:
   with most Awk implementations that I have come across. This is done largely for
   performance reasons, and reflects the intended use-case of "batch" data-
   processing scripts.
-* frawk supports spawning a subshell via the `<string> | getline`, `print[f] ...
-  | <string>` syntax as well as the `system` builtin function. From what I
-  understand, functions like this (where an arbitrary
-  string is passed wholesale to a shell) are considered anti-patterns, and have
-  been deprecated [in some
+* frawk supports spawning a subshell via the `<string> | getline`,
+  `print[f] ...  | <string>` syntax as well as the `system` builtin function.
+  From what I understand, functions like this (where an arbitrary string is
+  passed wholesale to a shell) are considered anti-patterns, and have been
+  deprecated [in some
   languages](https://www.python.org/dev/peps/pep-0324/#id14) because they make
   it easy for unsanitized user input to make it into a subshell, potentially
   doing nefarious or unwanted things with the user's machine. To help mitigate

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -149,7 +149,7 @@ pub(crate) enum PrimVal<'a> {
     Var(Ident),
     ILit(i64),
     FLit(f64),
-    StrLit(&'a str),
+    StrLit(&'a [u8]),
 }
 
 #[derive(Debug, Clone)]
@@ -310,8 +310,8 @@ impl<'a> ProgramContext<'a, &'a str> {
 #[derive(Debug)]
 pub enum SepAssign<'a> {
     Potential {
-        field_sep: Option<&'a str>,
-        record_sep: Option<&'a str>,
+        field_sep: Option<&'a [u8]>,
+        record_sep: Option<&'a [u8]>,
     },
     Unsure,
 }
@@ -618,7 +618,7 @@ pub(crate) struct Function<'a, I> {
 
     // Variable assignments, used to extract fast paths for splitting.
     // None indicates a call to `getline`.
-    vars: HashMap<Option<builtins::Variable>, Vec<(usize, Option<&'a str>)>>,
+    vars: HashMap<Option<builtins::Variable>, Vec<(usize, Option<&'a [u8]>)>>,
 
     // Dominance information about `cfg`.
     dt: dom::Tree,
@@ -1275,7 +1275,7 @@ where
         &mut self,
         v: &'c Expr<'c, 'b, I>,
         to: impl FnOnce(&PrimVal<'b>) -> PrimExpr<'b>,
-        str_lit: Option<&'b str>,
+        str_lit: Option<&'b [u8]>,
         current_open: NodeIx,
     ) -> Result<(NodeIx, PrimExpr<'b>)> {
         use ast::Expr::*;

--- a/src/display.rs
+++ b/src/display.rs
@@ -118,7 +118,7 @@ impl<'a> Display for PrimVal<'a> {
             Var(id) => write!(f, "{}", Wrap(*id)),
             ILit(n) => write!(f, "{}@int", *n),
             FLit(n) => write!(f, "{}@float", *n),
-            StrLit(s) => write!(f, "\"{}\"", s),
+            StrLit(s) => write!(f, "\"{}\"", std::string::String::from_utf8_lossy(s)),
         }
     }
 }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -104,16 +104,17 @@ cfg_if! {
                         field_sep,
                         record_sep,
                     } => {
-                        let field_sep = field_sep.unwrap_or(" ");
-                        let record_sep = record_sep.unwrap_or("\n");
+                        // TODO: unify this code with the code in main.
+                        let field_sep = field_sep.unwrap_or(b" ");
+                        let record_sep = record_sep.unwrap_or(b"\n");
                         if field_sep.len() == 1 && record_sep.len() == 1 {
-                            if field_sep == " " && record_sep == "\n" {
+                            if field_sep == b" " && record_sep == b"\n" {
                                 let $id = simulate_stdin_whitespace($inp);
                                 $body
                             } else  {
                                 let $id = simulate_stdin_singlechar(
-                                    field_sep.as_bytes()[0],
-                                    record_sep.as_bytes()[0],
+                                    field_sep[0],
+                                    record_sep[0],
                                     $inp,
                                 );
                                 $body
@@ -1214,6 +1215,12 @@ this as well"#
         print y, z, 0XFea6, -0x63abc, hex("0xFFww"), hex("DEADBEEF");
     }"#,
         "125 126 65190 -408252 255 3735928559\n"
+    );
+
+    test_program!(
+        basic_subsep,
+        "BEGIN { m[1,2] = 3; for (k in m) { split(k, arr, SUBSEP); print arr[1], arr[2], m[k]; } }",
+        "1 2 3\n"
     );
 
     test_program!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,10 +510,10 @@ fn main() {
                             record_sep,
                         },
                     ) => {
-                        let field_sep = field_sep.unwrap_or(" ");
-                        let record_sep = record_sep.unwrap_or("\n");
+                        let field_sep = field_sep.unwrap_or(b" ");
+                        let record_sep = record_sep.unwrap_or(b"\n");
                         if field_sep.len() == 1 && record_sep.len() == 1 {
-                            if field_sep == " " && record_sep == "\n" {
+                            if field_sep == b" " && record_sep == b"\n" {
                                 let $inp = ByteReader::new_whitespace(
                                     once((_reader, String::from("-"))),
                                     chunk_size,
@@ -524,8 +524,8 @@ fn main() {
                             } else {
                                 let $inp = ByteReader::new(
                                     once((io::stdin(), String::from("-"))),
-                                    field_sep.as_bytes()[0],
-                                    record_sep.as_bytes()[0],
+                                    field_sep[0],
+                                    record_sep[0],
                                     chunk_size,
                                     check_utf8,
                                     exec_strategy,
@@ -564,15 +564,15 @@ fn main() {
                         field_sep,
                         record_sep,
                     } => {
-                        let field_sep = field_sep.unwrap_or(" ");
-                        let record_sep = record_sep.unwrap_or("\n");
+                        let field_sep = field_sep.unwrap_or(b" ");
+                        let record_sep = record_sep.unwrap_or(b"\n");
                         if field_sep.len() == 1 && record_sep.len() == 1 {
                             let file_handles: Vec<_> = input_files
                                 .iter()
                                 .cloned()
                                 .map(move |file| (open_file_read(file.as_str()), file))
                                 .collect();
-                            if field_sep == " " && record_sep == "\n" {
+                            if field_sep == b" " && record_sep == b"\n" {
                                 let $inp = ByteReader::new_whitespace(
                                     file_handles.into_iter(),
                                     chunk_size,
@@ -583,8 +583,8 @@ fn main() {
                             } else {
                                 let $inp = ByteReader::new(
                                     file_handles.into_iter(),
-                                    field_sep.as_bytes()[0],
-                                    record_sep.as_bytes()[0],
+                                    field_sep[0],
+                                    record_sep[0],
                                     chunk_size,
                                     check_utf8,
                                     exec_strategy,

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -128,6 +128,7 @@ OpenStmt: &'a Stmt<'a,'a,&'a str> = {
                 update.map(|x| arena.alloc_v(Stmt::Expr(x))),
                 body
         )),
+    // TODO: for ((i, j) in arr)
     "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:OpenStmt> =>
         arena.alloc_v(Stmt::ForEach(id, arr, body)),
 }
@@ -247,6 +248,14 @@ PrecAsgn: &'a Expr<'a,'a,&'a str> = {
     PrecTern,
 }
 
+LookupList: Vec<&'a Expr<'a, 'a, &'a str>> = {
+    <first:PrecMatch> <rest:("," <PrecMatch>)+> => {
+      let mut rest = rest;
+      rest.insert(0, first);
+      rest
+   }
+}
+
 PrecTern: &'a Expr<'a, 'a, &'a str> = {
    <c: PrecOr> "?" <t: PrecTern> ":" <f: PrecTern> => arena.alloc_v(Expr::ITE(c, t, f)),
    PrecOr,
@@ -265,6 +274,7 @@ PrecAnd: &'a Expr<'a, 'a, &'a str> = {
 PrecIn: &'a Expr<'a,'a,&'a str> = {
     <l: PrecMatch> "in" <r: PrecMatch> =>
         arena.alloc_v(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
+    "(" <l: LookupList> Rparen "in" <r: PrecMatch> => unimplemented!(),
     PrecMatch,
 }
 
@@ -382,6 +392,7 @@ Index: &'a Expr<'a,'a,&'a str> = {
 
 IndexBase: (&'a Expr<'a,'a,&'a str>, &'a Expr<'a,'a,&'a str>) = {
   <arr:BaseTerm> "[" <e:Expr> "]" => (arr, e),
+  <arr:BaseTerm> "[" <ll:LookupList> "]" => unimplemented!(),
 }
 
 BaseTerm: &'a Expr<'a,'a, &'a str> = {

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -248,11 +248,15 @@ PrecAsgn: &'a Expr<'a,'a,&'a str> = {
     PrecTern,
 }
 
-LookupList: Vec<&'a Expr<'a, 'a, &'a str>> = {
+LookupList: &'a Expr<'a, 'a, &'a str> = {
     <first:PrecMatch> <rest:("," <PrecMatch>)+> => {
-      let mut rest = rest;
-      rest.insert(0, first);
-      rest
+      let mut res = first;
+      let subsep = arena.alloc_v(Expr::Var("SUBSEP"));
+      for dim in rest.into_iter() {
+        res = arena.alloc_v(Expr::Binop(Binop::Concat, res, subsep));
+        res = arena.alloc_v(Expr::Binop(Binop::Concat, res, dim));
+      }
+      res
    }
 }
 
@@ -274,7 +278,8 @@ PrecAnd: &'a Expr<'a, 'a, &'a str> = {
 PrecIn: &'a Expr<'a,'a,&'a str> = {
     <l: PrecMatch> "in" <r: PrecMatch> =>
         arena.alloc_v(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
-    "(" <l: LookupList> Rparen "in" <r: PrecMatch> => unimplemented!(),
+    "(" <l: LookupList> Rparen "in" <r: PrecMatch> =>
+        arena.alloc_v(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
     PrecMatch,
 }
 
@@ -383,7 +388,7 @@ Ident: &'a Expr<'a,'a,&'a str> = {
 }
 
 StrLit: &'a Expr<'a,'a,&'a str> = {
-  "STRLIT" => arena.alloc_v(Expr::StrLit(lexer::parse_string_literal(<>, &arena, buf))),
+  "STRLIT" => arena.alloc_v(Expr::StrLit(lexer::parse_string_literal(<>, &arena, buf).as_bytes())),
 }
 
 Index: &'a Expr<'a,'a,&'a str> = {
@@ -392,7 +397,7 @@ Index: &'a Expr<'a,'a,&'a str> = {
 
 IndexBase: (&'a Expr<'a,'a,&'a str>, &'a Expr<'a,'a,&'a str>) = {
   <arr:BaseTerm> "[" <e:Expr> "]" => (arr, e),
-  <arr:BaseTerm> "[" <ll:LookupList> "]" => unimplemented!(),
+  <arr:BaseTerm> "[" <ll:LookupList> "]" => (arr, ll),
 }
 
 BaseTerm: &'a Expr<'a,'a, &'a str> = {
@@ -407,7 +412,7 @@ LeafTerm: &'a Expr<'a,'a, &'a str> = {
   "INT" => arena.alloc_v(Expr::ILit(strtoi(<>.as_bytes()))),
   "HEX" => arena.alloc_v(Expr::ILit(hextoi(<>.as_bytes()))),
   "FLOAT" => arena.alloc_v(Expr::FLit(strtod(<>.as_bytes()))),
-  "PATLIT" => arena.alloc_v(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf))),
+  "PATLIT" => arena.alloc_v(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf).as_bytes())),
   // TODO: not Rparen for these next two?
   <i:CallStart> <args:Args?> ")" =>
         arena.alloc_v(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),


### PR DESCRIPTION
This change adds support for array subscripts like `m[x,y]` or `(x, y) in m`.

I initially left this out with the hope that I'd be able to add more structured datatypes to frawk. While I still think this is a worthwhile goal, I do not think it's likely that I'll get to it in the next several months. On the other hand it's a fairly common feature in awk for which support was not terribly difficult to add.

This PR also moves more of the AST from strings to byte slices.