### PR TITLE
Compile using stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ termcolor = "1.1"
 itertools = "0.9.0"
 
 [features]
-default = ["use_jemalloc", "allow_avx2", "llvm_backend"]
+default = ["use_jemalloc", "allow_avx2", "llvm_backend", "unstable"]
 use_jemalloc = ["jemallocator"]
 # Certain features leverage the AVX2 instruction set, but AVX2 can often make
 # the entire application slightly slower, even on chips that support it. As a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,13 +38,14 @@ grep-cli = "0.1"
 termcolor = "1.1"
 
 [features]
-default = ["use_jemalloc", "allow_avx2", "llvm_backend"]
+default = ["use_jemalloc", "allow_avx2", "llvm_backend", "unstable"]
 use_jemalloc = ["jemallocator"]
 # Certain features leverage the AVX2 instruction set, but AVX2 can often make
 # the entire application slightly slower, even on chips that support it. As a
 # result, we default to SSE2 implementations unless this feature is enabled.
 allow_avx2 = []
 llvm_backend = ["llvm-sys"]
+unstable = []
 
 [profile.release]
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ grep-cli = "0.1"
 termcolor = "1.1"
 
 [features]
-default = ["use_jemalloc", "allow_avx2", "llvm_backend", "unstable"]
+default = ["use_jemalloc", "allow_avx2", "llvm_backend"]
 use_jemalloc = ["jemallocator"]
 # Certain features leverage the AVX2 instruction set, but AVX2 can often make
 # the entire application slightly slower, even on chips that support it. As a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ cfg-if = "0.1"
 memchr = "2.3.3"
 grep-cli = "0.1"
 termcolor = "1.1"
+itertools = "0.9.0"
 
 [features]
 default = ["use_jemalloc", "allow_avx2", "llvm_backend"]

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -197,8 +197,6 @@ impl<'outer> Arena<'outer> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate test;
-    use test::{black_box, Bencher};
 
     fn bytes(n: usize) -> String {
         let mut res = Vec::with_capacity(n);
@@ -297,6 +295,13 @@ mod tests {
             }
         }
     }
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod bench {
+    use super::*;
+    extern crate test;
+    use test::{black_box, Bencher};
     enum Arith1 {
         N(i64),
         Add(Box<Arith1>, Box<Arith1>),

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -205,7 +205,7 @@ pub(crate) fn dump_llvm<'a>(
     }
 }
 
-#[cfg(all(test, feature = "llvm_backend"))]
+#[cfg(all(feature = "llvm_backend", feature = "unstable"))]
 pub(crate) fn compile_llvm<'a>(
     ctx: &mut cfg::ProgramContext<'a, &'a str>,
     cfg: llvm::Config,

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -404,9 +404,7 @@ pub(crate) fn run_prog<'a>(
 }
 
 mod tests {
-    extern crate test;
     use super::*;
-    use test::{black_box, Bencher};
 
     macro_rules! test_program_parallel {
         ($desc:ident, $strat:tt, $e:expr, $in:expr, $out:expr) => {
@@ -1265,6 +1263,13 @@ this as well"#
     );
 
     // TODO test more operators, consider more edge cases around functions
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod bench {
+    extern crate test;
+    use super::*;
+    use test::{black_box, Bencher};
 
     // TODO if we ever want to benchmark stdin, the program_only benchmarks here will not work,
     // because "reset" does not work on stdin today.

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1490,6 +1490,7 @@ pub(crate) fn pop<'a, T: Clone>(s: &'a mut Storage<T>) -> T {
 
 #[cfg(test)]
 impl<T: Default> Storage<T> {
+    #[cfg(feature = "unstable")]
     fn reset(&mut self) {
         self.stack.clear();
         for i in self.regs.iter_mut() {
@@ -1500,6 +1501,7 @@ impl<T: Default> Storage<T> {
 
 #[cfg(test)]
 impl<'a, LR: LineReader> Interp<'a, LR> {
+    #[cfg(feature = "unstable")]
     pub(crate) fn reset(&mut self) {
         self.stack = Default::default();
         self.core.vars = Default::default();

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -326,7 +326,7 @@ impl<'a, 'b> Generator<'a, 'b> {
     }
 
     // For benchmarking.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "unstable"))]
     pub unsafe fn compile_main(&mut self) -> Result<()> {
         let mains = self.gen_main()?;
         self.verify()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "256"]
-#![feature(core_intrinsics)]
+#![cfg_attr(feature = "unstable", feature(core_intrinsics))]
 #![cfg_attr(feature = "unstable", feature(test))]
-#![feature(write_all_vectored)]
+#![cfg_attr(feature = "unstable", feature(write_all_vectored))]
 #[macro_use]
 pub mod common;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "256"]
 #![feature(core_intrinsics)]
-#![feature(test)]
+#![cfg_attr(feature = "unstable", feature(test))]
 #![feature(write_all_vectored)]
 #[macro_use]
 pub mod common;

--- a/src/runtime/float_parse/mod.rs
+++ b/src/runtime/float_parse/mod.rs
@@ -6,7 +6,9 @@
 #[cfg(feature = "unstable")]
 use std::intrinsics::unlikely;
 #[cfg(not(feature = "unstable"))]
-fn unlikely(b: bool) -> bool { b }
+fn unlikely(b: bool) -> bool {
+    b
+}
 
 use std::mem;
 mod slow_path;

--- a/src/runtime/float_parse/mod.rs
+++ b/src/runtime/float_parse/mod.rs
@@ -2,7 +2,12 @@
 //! semantics (no failures, just 0s and stopping early). Mistakes are surely my own.
 //!
 //! TODO: rename to num_parse
+
+#[cfg(feature = "unstable")]
 use std::intrinsics::unlikely;
+#[cfg(not(feature = "unstable"))]
+fn unlikely(b: bool) -> bool { b }
+
 use std::mem;
 mod slow_path;
 

--- a/src/runtime/float_parse/slow_path.rs
+++ b/src/runtime/float_parse/slow_path.rs
@@ -85,8 +85,7 @@ impl SmallCString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate test;
-    use test::{black_box, Bencher};
+
     fn test_strtoi(mut f: impl FnMut(&[u8]) -> i64) {
         assert_eq!(f(b"0"), 0);
         assert_eq!(f(b"012345678910"), 12345678910);
@@ -153,6 +152,13 @@ mod tests {
     fn test_strtod_libc() {
         test_strtod(strtod_libc);
     }
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod bench {
+    use super::*;
+    extern crate test;
+    use test::{black_box, Bencher};
     fn bench_strtoi_long(b: &mut Bencher, mut f: impl FnMut(&[u8]) -> i64) {
         const INPUT: &[u8] = b"9514590998633183616833425126589570467868 some more data after that";
         b.iter(|| {

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -1000,6 +1000,7 @@ mod generic {
         const BUFFER_SIZE: usize = 4;
         macro_rules! iterate {
             ($buf:expr) => {{
+                #[cfg(feature = "unstable")]
                 std::intrinsics::prefetch_read_data($buf.offset(128), 3);
                 // find commas not inside quotes
                 let inp = V::fill_input($buf);
@@ -1071,6 +1072,7 @@ mod generic {
         const BUFFER_SIZE: usize = 4;
         macro_rules! iterate {
             ($buf:expr) => {{
+                #[cfg(feature = "unstable")]
                 std::intrinsics::prefetch_read_data($buf.offset(128), 3);
                 f($buf)
             }};
@@ -1139,6 +1141,7 @@ mod generic {
         const BUFFER_SIZE: usize = 4;
         macro_rules! iterate {
             ($buf:expr) => {{
+                #[cfg(feature = "unstable")]
                 std::intrinsics::prefetch_read_data($buf.offset(128), 3);
                 let inp = V::fill_input($buf);
                 let (ws, nl, next_start) = inp.whitespace_masks(start_ws);

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -17,6 +17,12 @@ use std::cell::{Cell, UnsafeCell};
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::marker::PhantomData;
+
+#[cfg(feature = "unstable")]
+use std::intrinsics::likely;
+#[cfg(not(feature = "unstable"))]
+fn likely(b: bool) -> bool { b }
+
 use std::mem;
 use std::ptr;
 use std::rc::Rc;
@@ -1137,7 +1143,7 @@ impl Buf {
                         .into(),
                 )
             }
-        } else if std::intrinsics::likely(
+        } else if likely(
             from <= u32::max_value() as usize && to <= u32::max_value() as usize,
         ) {
             Str::from_rep(

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -21,7 +21,9 @@ use std::marker::PhantomData;
 #[cfg(feature = "unstable")]
 use std::intrinsics::likely;
 #[cfg(not(feature = "unstable"))]
-fn likely(b: bool) -> bool { b }
+fn likely(b: bool) -> bool {
+    b
+}
 
 use std::mem;
 use std::ptr;
@@ -1143,9 +1145,7 @@ impl Buf {
                         .into(),
                 )
             }
-        } else if likely(
-            from <= u32::max_value() as usize && to <= u32::max_value() as usize,
-        ) {
+        } else if likely(from <= u32::max_value() as usize && to <= u32::max_value() as usize) {
             Str::from_rep(
                 Shared {
                     buf: self.clone(),
@@ -1318,7 +1318,6 @@ And this is the second part"#
         s7.with_bytes(|bs| assert_eq!(bs, b"String number one substituted into another xxyz"));
         assert!(subbed);
     }
-
 }
 
 #[cfg(all(feature = "unstable", test))]

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -1175,9 +1175,7 @@ impl Buf {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
     use super::*;
-    use test::{black_box, Bencher};
 
     #[test]
     fn inline_basics() {
@@ -1314,6 +1312,14 @@ And this is the second part"#
         s7.with_bytes(|bs| assert_eq!(bs, b"String number one substituted into another xxyz"));
         assert!(subbed);
     }
+
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod bench {
+    extern crate test;
+    use super::*;
+    use test::{black_box, Bencher};
 
     #[bench]
     fn bench_get_bytes_drop_empty(b: &mut Bencher) {

--- a/src/runtime/utf8.rs
+++ b/src/runtime/utf8.rs
@@ -197,7 +197,6 @@ mod tests {
         }
         res
     }
-
 }
 
 #[cfg(all(feature = "unstable", test))]
@@ -313,7 +312,6 @@ mod bench {
         }
         res
     }
-
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
I saw #25 , so I went ahead and took a pass. I added a default feature called `unstable`, so everything should work as is on nightly. On stable (`rustc 1.48.0 (7eac88abb 2020-11-16)` at the moment), this should now work:

```
cargo test --no-default-features --features use_jemalloc,allow_avx2,llvm_backend 2>&1 | tail
test runtime::utf8::x86::tests::test_utf8 ... ok
test runtime::writers::tests::basic_writing ... ok
test runtime::utf8::tests::test_partial ... ok
test runtime::writers::tests::reopen_named_file ... ok
test runtime::writers::tests::multithreaded_write ... ok
test runtime::utf8::tests::utf8_valid ... ok
test runtime::splitter::regex::tests::test_clipped_chunk_split_random ... ok

test result: ok. 194 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```

I excluded the `bench` tests when run on `stable`, which is why the number of tests is lower.