### PR TITLE
Add new CLI-level tests in `tests` directory.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ memchr = "2.3.3"
 grep-cli = "0.1"
 termcolor = "1.1"
 itertools = "0.9.0"
+assert_cmd = "1.0.2"
+
+[dev-dependencies]
+assert_cmd = "1.0.2"
+tempfile = "3.1.0"
+
 
 [features]
 default = ["use_jemalloc", "allow_avx2", "llvm_backend", "unstable"]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -18,8 +18,6 @@ pub enum Function {
     Binop(ast::Binop),
     FloatFunc(FloatFunc),
     IntFunc(Bitwise),
-    Print,
-    PrintStdout,
     Close,
     ReadErr,
     ReadErrCmd,
@@ -252,7 +250,6 @@ impl FloatFunc {
 static_map!(
     FUNCTIONS<&'static str, Function>,
     ["close", Function::Close],
-    ["print", Function::Print],
     ["split", Function::Split],
     ["length", Function::Length],
     ["match", Function::Match],
@@ -423,8 +420,6 @@ impl Function {
                     }
                 }
             }
-            Print => (smallvec![Str, Str, Int], Int),
-            PrintStdout => (smallvec![Str], Int),
             NextlineCmd | Nextline => (smallvec![Str], Str),
             ReadErrCmd | ReadErr => (smallvec![Str], Int),
             NextFile | ReadLineStdinFused => (smallvec![], Int),
@@ -458,10 +453,10 @@ impl Function {
             IntFunc(bw) => bw.arity(),
             Rand | ReseedRng | ReadErrStdin | NextlineStdin | NextFile | ReadLineStdinFused => 0,
             Srand | System | HexToInt | ToInt | EscapeCSV | EscapeTSV | Close | Length
-            | ReadErr | ReadErrCmd | Nextline | NextlineCmd | PrintStdout | Unop(_) => 1,
+            | ReadErr | ReadErrCmd | Nextline | NextlineCmd | Unop(_) => 1,
             SubstrIndex | Match | Setcol | Binop(_) => 2,
             JoinCSV | JoinTSV | Delete | Contains => 2,
-            JoinCols | Substr | Sub | GSub | Print | Split => 3,
+            JoinCols | Substr | Sub | GSub | Split => 3,
         })
     }
 
@@ -492,7 +487,7 @@ impl Function {
                 }
             }
             Rand | Binop(Div) | Binop(Pow) => Ok(Scalar(BaseTy::Float).abs()),
-            Setcol | Print | PrintStdout => Ok(Scalar(BaseTy::Null).abs()),
+            Setcol => Ok(Scalar(BaseTy::Null).abs()),
             SubstrIndex | Srand | ReseedRng | Unop(Not) | Binop(IsMatch) | Binop(LT)
             | Binop(GT) | Binop(LTE) | Binop(GTE) | Binop(EQ) | Length | Split | ReadErr
             | ReadErrCmd | ReadErrStdin | Contains | Delete | Match | Sub | GSub | ToInt

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -210,12 +210,6 @@ pub(crate) enum Instr<'a> {
         output: Option<(Reg<Str<'a>>, FileSpec)>,
         args: Vec<Reg<Str<'a>>>,
     },
-    PrintStdout(Reg<Str<'a>> /*text*/),
-    Print(
-        Reg<Str<'a>>, /*text*/
-        Reg<Str<'a>>, /*output*/
-        FileSpec,     /*append*/
-    ),
     Close(Reg<Str<'a>>),
     RunCmd(Reg<Int>, Reg<Str<'a>>),
 
@@ -672,11 +666,6 @@ impl<'a> Instr<'a> {
                 for reg in args.iter().cloned() {
                     reg.accum(&mut f)
                 }
-            }
-            PrintStdout(txt) => txt.accum(&mut f),
-            Print(txt, out, _append) => {
-                txt.accum(&mut f);
-                out.accum(&mut f)
             }
             Close(file) => file.accum(&mut f),
             RunCmd(dst, cmd) => {

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -206,6 +206,10 @@ pub(crate) enum Instr<'a> {
         fmt: Reg<Str<'a>>,
         args: Vec<(NumTy, Ty)>,
     },
+    PrintAll {
+        output: Option<(Reg<Str<'a>>, FileSpec)>,
+        args: Vec<Reg<Str<'a>>>,
+    },
     PrintStdout(Reg<Str<'a>> /*text*/),
     Print(
         Reg<Str<'a>>, /*text*/
@@ -659,6 +663,14 @@ impl<'a> Instr<'a> {
                 fmt.accum(&mut f);
                 for (reg, ty) in args.iter().cloned() {
                     f(reg, ty);
+                }
+            }
+            PrintAll { output, args } => {
+                if let Some((path_reg, _)) = output {
+                    path_reg.accum(&mut f);
+                }
+                for reg in args.iter().cloned() {
+                    reg.accum(&mut f)
                 }
             }
             PrintStdout(txt) => txt.accum(&mut f),

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,7 @@
 //! This file contains common type definitions and utilities used in other parts of the project.
 use hashbrown::HashSet;
 use std::collections::VecDeque;
+use std::fmt;
 use std::hash::Hash;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -319,9 +320,17 @@ pub enum FileSpec {
     Cmd = 2,
 }
 
+#[derive(Debug)]
+pub struct InvalidFileSpec;
+impl fmt::Display for InvalidFileSpec {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt("invalid file spec", fmt)
+    }
+}
+
 impl std::convert::TryFrom<i64> for FileSpec {
-    type Error = ();
-    fn try_from(i: i64) -> std::result::Result<FileSpec, ()> {
+    type Error = InvalidFileSpec;
+    fn try_from(i: i64) -> std::result::Result<FileSpec, InvalidFileSpec> {
         // uglier than a match, but stays in sync with the enum more easily.
         if i == FileSpec::Trunc as i64 {
             Ok(FileSpec::Trunc)
@@ -330,7 +339,7 @@ impl std::convert::TryFrom<i64> for FileSpec {
         } else if i == FileSpec::Cmd as i64 {
             Ok(FileSpec::Cmd)
         } else {
-            Err(())
+            Err(InvalidFileSpec)
         }
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,9 +1,7 @@
 use crate::builtins;
 use crate::bytecode::{self, Accum};
 use crate::cfg::{self, is_unused, Function, Ident, PrimExpr, PrimStmt, PrimVal, ProgramContext};
-use crate::common::{
-    CompileError, Either, FileSpec, Graph, NodeIx, NumTy, Result, Stage, WorkList,
-};
+use crate::common::{CompileError, Either, Graph, NodeIx, NumTy, Result, Stage, WorkList};
 use crate::cross_stage;
 use crate::input_taint::TaintedStringAnalysis;
 #[cfg(feature = "llvm_backend")]
@@ -18,7 +16,6 @@ use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use regex::bytes::Regex;
 
 use std::collections::VecDeque;
-use std::convert::TryFrom;
 use std::mem;
 use std::sync::Arc;
 
@@ -1528,25 +1525,6 @@ impl<'a, 'b> View<'a, 'b> {
                     })
                 }
             }
-            Print => {
-                // XXX this imports a specific assumption on how the PrimStmt is generated, we may
-                // want to make the bool parameter to Print dynamic.
-                if let cfg::PrimVal::ILit(i) = &args[2] {
-                    self.pushl(LL::Print(
-                        conv_regs[0].into(),
-                        conv_regs[1].into(),
-                        FileSpec::try_from(*i).unwrap(),
-                    ));
-                    return Ok(());
-                } else {
-                    return err!("must pass constant append parameter to print");
-                }
-            }
-            PrintStdout => {
-                self.pushl(LL::PrintStdout(conv_regs[0].into()));
-                return Ok(());
-            }
-
             Delete => match &conv_tys[0] {
                 Ty::MapIntInt
                 | Ty::MapIntStr

--- a/src/display.rs
+++ b/src/display.rs
@@ -62,6 +62,26 @@ impl<'a> Display for PrimStmt<'a> {
                 }
                 Ok(())
             }
+            PrintAll(args, out) => {
+                write!(f, "print(")?;
+                for (i, a) in args.iter().enumerate() {
+                    if i == args.len() - 1 {
+                        write!(f, "{}", a)?;
+                    } else {
+                        write!(f, "{}, ", a)?;
+                    }
+                }
+                write!(f, ")")?;
+                if let Some((out, ap)) = out {
+                    let redirect = match ap {
+                        FileSpec::Trunc => ">",
+                        FileSpec::Append => ">>",
+                        FileSpec::Cmd => "|",
+                    };
+                    write!(f, " {} {}", out, redirect)?;
+                }
+                Ok(())
+            }
             IterDrop(v) => write!(f, "drop_iter {}", v),
         }
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -152,8 +152,6 @@ impl Display for Function {
             Binop(b) => write!(f, "{}", b),
             FloatFunc(ff) => write!(f, "{}", ff.func_name()),
             IntFunc(bw) => write!(f, "{}", bw.func_name()),
-            Print => write!(f, "print"),
-            PrintStdout => write!(f, "print(stdout)"),
             ReadErr => write!(f, "hasline"),
             ReadErrCmd => write!(f, "hasline(cmd)"),
             Nextline => write!(f, "nextline"),

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -166,7 +166,7 @@ type ProgResult<'a> = Result<(
 
 #[cfg(feature = "llvm_backend")]
 const LLVM_CONFIG: llvm::Config = llvm::Config {
-    opt_level: 3,
+    opt_level: 0,
     num_workers: 1,
 };
 

--- a/src/input_taint.rs
+++ b/src/input_taint.rs
@@ -251,7 +251,10 @@ impl TaintedStringAnalysis {
                     self.add_dep(dst, Key::Reg(*reg, *ty));
                 }
             }
-            Printf {
+            PrintAll {
+                output: Some((cmd, FileSpec::Cmd)),
+                .. 
+            } | Printf {
                 output: Some((cmd, FileSpec::Cmd)),
                 ..
             } => self.queries.push(cmd.into()),
@@ -289,6 +292,7 @@ impl TaintedStringAnalysis {
             LoadSlot{ty,slot,dst} => self.add_dep(Key::Reg(*dst, *ty), Key::Slot(*slot, *ty)),
             StoreSlot{ty,slot,src} => self.add_dep(Key::Slot(*slot, *ty), Key::Reg(*src, *ty)),
             Delete{..}
+            | PrintAll{..}
             | Contains{..} // 0 or 1
             | IterHasNext{..}
             |JmpIf(..)

--- a/src/input_taint.rs
+++ b/src/input_taint.rs
@@ -253,12 +253,11 @@ impl TaintedStringAnalysis {
             }
             PrintAll {
                 output: Some((cmd, FileSpec::Cmd)),
-                .. 
+                ..
             } | Printf {
                 output: Some((cmd, FileSpec::Cmd)),
                 ..
             } => self.queries.push(cmd.into()),
-            Print(_, out, FileSpec::Cmd) => self.queries.push(out.into()),
             RunCmd(dst, cmd) => {
                 self.queries.push(cmd.into());
                 self.add_src(dst, true);
@@ -305,8 +304,6 @@ impl TaintedStringAnalysis {
             | Call(_)
             | Ret
             | Printf { .. }
-            | PrintStdout(_)
-            | Print(..)
             | Close(_)
             | NextLineStdinFused()
             | NextFile()

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1009,11 +1009,10 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         let to_split = index(&self.strs, to_split);
                         let arr = index(&self.maps_int_str, arr);
                         let pat = index(&self.strs, pat);
-                        let old_len = arr.len();
                         self.core
                             .regexes
                             .split_regex_intmap(&pat, &to_split, &arr)?;
-                        let res = (arr.len() - old_len) as i64;
+                        let res = arr.len() as Int;
                         let flds = *flds;
                         *self.get_mut(flds) = res;
                     }
@@ -1022,11 +1021,10 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         let to_split = index(&self.strs, to_split);
                         let arr = index(&self.maps_str_str, arr);
                         let pat = index(&self.strs, pat);
-                        let old_len = arr.len();
                         self.core
                             .regexes
                             .split_regex_strmap(&pat, &to_split, &arr)?;
-                        let res = (arr.len() - old_len) as Int;
+                        let res = arr.len() as Int;
                         let flds = *flds;
                         *self.get_mut(flds) = res;
                     }

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1066,7 +1066,7 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                             let out_path = index(&self.strs, out_path_reg);
                             self.core
                                 .write_files
-                                .write_all(&scratch_strs[..], Some((*fspec, out_path)))
+                                .write_all(&scratch_strs[..], Some((out_path, *fspec)))
                         } else {
                             self.core.write_files.write_all(&scratch_strs[..], None)
                         };

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1028,19 +1028,6 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         let flds = *flds;
                         *self.get_mut(flds) = res;
                     }
-                    PrintStdout(txt) => {
-                        let txt = index(&self.strs, txt);
-                        // Why do this? We want to exit cleanly when output is closed. We use this
-                        // pattern for other IO functions as well.
-                        if let Err(_) = self.core.write_files.write_str_stdout(txt) {
-                            return Ok(());
-                        }
-                    }
-                    Print(txt, out, append) => {
-                        let txt = index(&self.strs, txt);
-                        let out = index(&self.strs, out);
-                        self.core.write_files.write_str(out, txt, *append)?
-                    }
                     Sprintf { dst, fmt, args } => {
                         debug_assert_eq!(scratch.len(), 0);
                         for a in args.iter() {

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1057,8 +1057,8 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         *self.get_mut(dst) = res;
                     }
                     PrintAll { output, args } => {
-                        // TODO: find a way to avoid building this vector locally.
-                        let mut scratch_strs: Vec<&Str> = Vec::with_capacity(args.len());
+                        let mut scratch_strs =
+                            smallvec::SmallVec::<[&Str; 4]>::with_capacity(args.len());
                         for a in args {
                             scratch_strs.push(index(&self.strs, a));
                         }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -500,9 +500,24 @@ impl<'a> Tokenizer<'a> {
 
     fn consume_ws(&mut self) {
         let mut res = 0;
-        for (ix, c) in self.text[self.cur..].char_indices() {
-            res = ix;
-            if c == '\n' || !c.is_whitespace() {
+        let mut iter = self.text[self.cur..].char_indices();
+        'outer: while let Some((ix, c)) = iter.next() {
+            loop {
+                res = ix;
+                if c == '\\' {
+                    // look ahead for a newline and hence a line continuation
+                    if let Some((_, next_c)) = iter.next() {
+                        if next_c == '\n' {
+                            // count this as whitespace
+                            continue 'outer;
+                        }
+                        break 'outer;
+                    }
+                }
+                if c == '\n' || !c.is_whitespace() {
+                    break 'outer;
+                }
+
                 break;
             }
         }

--- a/src/llvm/intrinsics.rs
+++ b/src/llvm/intrinsics.rs
@@ -302,8 +302,6 @@ pub(crate) unsafe fn register(module: LLVMModuleRef, ctx: LLVMContextRef) -> Int
         reseed_rng(rt_ty) -> int_ty;
 
         run_system(str_ref_ty) -> int_ty;
-        print_stdout(rt_ty, str_ref_ty);
-        print(rt_ty, str_ref_ty, str_ref_ty, int_ty);
         print_all_stdout(rt_ty, pa_args_ty, int_ty);
         print_all_file(rt_ty, pa_args_ty, int_ty, str_ref_ty, int_ty);
         sprintf_impl(rt_ty, str_ref_ty, fmt_args_ty, fmt_tys_ty, int_ty) -> str_ty;
@@ -523,39 +521,6 @@ pub unsafe extern "C" fn next_line(runtime: *mut c_void, file: *mut c_void, is_f
     match res {
         Ok(res) => mem::transmute::<Str, U128>(res),
         Err(_) => mem::transmute::<Str, U128>("".into()),
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn print_stdout(runtime: *mut c_void, txt: *mut c_void) {
-    let runtime = &mut *(runtime as *mut Runtime);
-    let txt = &*(txt as *mut Str);
-    if let Err(_) = runtime.core.write_files.write_str_stdout(txt) {
-        exit!(runtime);
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn print(
-    runtime: *mut c_void,
-    txt: *mut c_void,
-    out: *mut c_void,
-    append: Int,
-) {
-    let runtime = &mut *(runtime as *mut Runtime);
-    let txt = &*(txt as *mut Str);
-    let out = &*(out as *mut Str);
-    if runtime
-        .core
-        .write_files
-        .write_str(
-            out,
-            txt,
-            FileSpec::try_from(append).expect("invalid filespec"),
-        )
-        .is_err()
-    {
-        exit!(runtime);
     }
 }
 

--- a/src/llvm/intrinsics.rs
+++ b/src/llvm/intrinsics.rs
@@ -236,6 +236,7 @@ pub(crate) unsafe fn register(module: LLVMModuleRef, ctx: LLVMContextRef) -> Int
     let fmt_tys_ty = LLVMPointerType(LLVMIntTypeInContext(ctx, 32), 0);
     let map_ty = rt_ty;
     let str_ref_ty = LLVMPointerType(str_ty, 0);
+    let pa_args_ty = LLVMPointerType(str_ref_ty, 0);
     let iter_int_ty = LLVMPointerType(int_ty, 0);
     let iter_str_ty = LLVMPointerType(str_ty, 0);
     let mut table = IntrinsicMap::new(module, ctx);
@@ -303,8 +304,8 @@ pub(crate) unsafe fn register(module: LLVMModuleRef, ctx: LLVMContextRef) -> Int
         run_system(str_ref_ty) -> int_ty;
         print_stdout(rt_ty, str_ref_ty);
         print(rt_ty, str_ref_ty, str_ref_ty, int_ty);
-        print_all_stdout(rt_ty, fmt_args_ty, int_ty);
-        print_all_file(rt_ty, fmt_args_ty, int_ty, str_ref_ty, int_ty);
+        print_all_stdout(rt_ty, pa_args_ty, int_ty);
+        print_all_file(rt_ty, pa_args_ty, int_ty, str_ref_ty, int_ty);
         sprintf_impl(rt_ty, str_ref_ty, fmt_args_ty, fmt_tys_ty, int_ty) -> str_ty;
         printf_impl_file(rt_ty, str_ref_ty, fmt_args_ty, fmt_tys_ty, int_ty, str_ref_ty, int_ty);
         printf_impl_stdout(rt_ty, str_ref_ty, fmt_args_ty, fmt_tys_ty, int_ty);

--- a/src/llvm/intrinsics.rs
+++ b/src/llvm/intrinsics.rs
@@ -567,7 +567,6 @@ pub unsafe extern "C" fn split_str(
     let into_arr = mem::transmute::<*mut c_void, StrMap<Str>>(into_arr);
     let to_split = &*(to_split as *mut Str);
     let pat = &*(pat as *mut Str);
-    let old_len = into_arr.len();
     if let Err(e) = runtime
         .core
         .regexes
@@ -575,7 +574,7 @@ pub unsafe extern "C" fn split_str(
     {
         fail!(runtime, "failed to split string: {}", e);
     }
-    let res = (into_arr.len() - old_len) as Int;
+    let res = into_arr.len() as Int;
     mem::forget((into_arr, to_split, pat));
     res
 }
@@ -591,7 +590,6 @@ pub unsafe extern "C" fn split_int(
     let into_arr = mem::transmute::<*mut c_void, IntMap<Str>>(into_arr);
     let to_split = &*(to_split as *mut Str);
     let pat = &*(pat as *mut Str);
-    let old_len = into_arr.len();
     if let Err(e) = runtime
         .core
         .regexes
@@ -599,7 +597,7 @@ pub unsafe extern "C" fn split_int(
     {
         fail!(runtime, "failed to split string: {}", e);
     }
-    let res = (into_arr.len() - old_len) as Int;
+    let res = into_arr.len() as Int;
     mem::forget((into_arr, to_split, pat));
     res
 }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1863,10 +1863,6 @@ impl<'a> View<'a> {
                     c_str!(""),
                 );
             }
-            PrintStdout(txt) => {
-                let txtv = self.get_local(txt.reflect())?;
-                self.call("print_stdout", &mut [self.runtime_val(), txtv]);
-            }
             Close(file) => {
                 let filev = self.get_local(file.reflect())?;
                 self.call("close_file", &mut [self.runtime_val(), filev]);
@@ -1876,14 +1872,6 @@ impl<'a> View<'a> {
                 let resv = self.call("run_system", &mut [cmd]);
                 self.bind_reg(dst, resv);
             }
-            Print(txt, out, append) => {
-                let int_ty = self.tmap.get_ty(Ty::Int);
-                let appv = LLVMConstInt(int_ty, *append as u64, /*sign_extend=*/ 1);
-                let txtv = self.get_local(txt.reflect())?;
-                let outv = self.get_local(out.reflect())?;
-                self.call("print", &mut [self.runtime_val(), txtv, outv, appv]);
-            }
-
             ReadErr(dst, file, is_file) => {
                 let filev = self.get_local(file.reflect())?;
                 let int_ty = self.tmap.get_ty(Ty::Int);

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -760,10 +760,11 @@ impl<'a, 'b> Generator<'a, 'b> {
                 let (_, t) = frame.cfg.edge_endpoints(e).unwrap();
                 let bb = bbs[t.index()];
                 if let Some(e) = frame.cfg.edge_weight(e).unwrap().clone() {
-                    assert!(tcase.is_none());
                     tcase = Some((e, bb));
                 } else {
-                    assert!(ecase.is_none());
+                    // NB, we used to disallow duplicate unconditional branches outbound from a
+                    // basic block, but it does seem to happen in some cases, but only benignly
+                    // (where taking either branch results in the same behavior).
                     ecase = Some(bb);
                 }
             }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1802,6 +1802,7 @@ impl<'a> View<'a> {
                 );
                 self.bind_reg(dst, resv);
             }
+            PrintAll { output, args } => unimplemented!(),
             Printf { output, fmt, args } => {
                 // First, extract the types and use that to get a handle on a wrapped printf
                 // function.

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -73,6 +73,7 @@ struct View<'a> {
     ctx: LLVMContextRef,
     module: LLVMModuleRef,
     printfs: &'a mut HashMap<(SmallVec<Ty>, PrintfKind), LLVMValueRef>,
+    prints: &'a mut HashMap<(usize, /*stdout*/ bool), LLVMValueRef>,
     drop_str: LLVMValueRef,
     // We keep an extra builder always pointed at the start of the function. This is because
     // binding new string values requires an `alloca`; and we do not want to call `alloca` where a
@@ -158,6 +159,7 @@ pub(crate) struct Generator<'a, 'b> {
     type_map: TypeMap,
     intrinsics: IntrinsicMap,
     printfs: HashMap<(SmallVec<Ty>, PrintfKind), LLVMValueRef>,
+    prints: HashMap<(usize, /*stdout*/ bool), LLVMValueRef>,
     // We pass raw regex pointers in the generated code. These ensure we do not free them
     // before the code is run.
     regexes: Vec<Arc<Regex>>,
@@ -297,6 +299,7 @@ impl<'a, 'b> Generator<'a, 'b> {
             type_map: TypeMap::new(ctx),
             intrinsics: intrinsics::register(module, ctx),
             printfs: Default::default(),
+            prints: Default::default(),
             cfg,
             drop_str: ptr::null_mut(),
         };
@@ -708,6 +711,7 @@ impl<'a, 'b> Generator<'a, 'b> {
             intrinsics: &self.intrinsics,
             decls: &self.decls,
             printfs: &mut self.printfs,
+            prints: &mut self.prints,
             ctx: self.ctx,
             module: self.module,
             drop_str: self.drop_str,
@@ -1802,7 +1806,28 @@ impl<'a> View<'a> {
                 );
                 self.bind_reg(dst, resv);
             }
-            PrintAll { output, args } => unimplemented!(),
+            PrintAll { output, args } => {
+                let print_fn =
+                    self.print_all_fn(args.len(), /*is_stdout=*/ output.is_none())?;
+                let mut args_v =
+                    SmallVec::with_capacity(args.len() + 1 + if output.is_some() { 2 } else { 0 });
+                args_v.push(self.runtime_val());
+                for a in args.iter() {
+                    args_v.push(self.get_local(a.reflect())?);
+                }
+                if let Some((out, fspec)) = output {
+                    args_v.push(self.get_local(out.reflect())?);
+                    let int_ty = self.tmap.get_ty(Ty::Int);
+                    args_v.push(LLVMConstInt(int_ty, *fspec as u64, /*sign_extend=*/ 0));
+                }
+                LLVMBuildCall(
+                    self.f.builder,
+                    print_fn,
+                    args_v.as_mut_ptr(),
+                    args_v.len() as libc::c_uint,
+                    c_str!(""),
+                );
+            }
             Printf { output, fmt, args } => {
                 // First, extract the types and use that to get a handle on a wrapped printf
                 // function.
@@ -2108,7 +2133,6 @@ impl<'a> View<'a> {
     // We could implement this all inline, but making it a separate function allows us to cache the
     // codegen across compatible invocations, and also makes the generated code a lot cleaner.
     unsafe fn wrapped_printf(&mut self, key: (SmallVec<Ty>, PrintfKind)) -> LLVMValueRef {
-        use std::io::{Cursor, Write};
         use PrintfKind::*;
         let kind = key.1;
         if let Some(v) = self.printfs.get(&key) {
@@ -2116,16 +2140,7 @@ impl<'a> View<'a> {
         }
         let args = &key.0[..];
 
-        let ix = self.printfs.len();
-        let name = "_pf";
-        // 64 bit integers should only ever need 20 digits or so.
-        let mut name_c: smallvec::SmallVec<[u8; 32]> = smallvec![0; 32];
-        for (i, b) in name.as_bytes().iter().enumerate() {
-            name_c[i] = *b;
-        }
-        let mut w = Cursor::new(&mut name_c[name.as_bytes().len()..]);
-        write!(w, "{:x}", ix).unwrap();
-        assert_eq!(name_c[name_c.len() - 1], 0);
+        let name_c = gen_name("_pf", self.printfs.len());
 
         // The var-arg portion + runtime + format spec
         //  (+ output + append, if named_output)
@@ -2264,4 +2279,96 @@ impl<'a> View<'a> {
         self.printfs.insert(key, f);
         f
     }
+
+    // A scaled-down version of the strategy we have for printf. This is for the var-args "print"
+    // function that only prints strings. That means we don't have to pass an array of types, and
+    // we don't have to cast anything: we just pass a single array of strings. Otherwise, the setup
+    // is quite similar.
+    unsafe fn print_all_fn(&mut self, n_args: usize, is_stdout: bool) -> Result<LLVMValueRef> {
+        let key = (n_args, is_stdout);
+        if let Some(res) = self.prints.get(&key) {
+            return Ok(*res);
+        }
+
+        // Build the function type.
+        let mut arg_lltys = smallvec::SmallVec::<[_; 8]>::with_capacity(n_args + 3);
+        arg_lltys.push(self.tmap.runtime_ty);
+        // var-arg portion
+        let str_ty = self.tmap.get_ptr_ty(Ty::Str);
+        let int_ty = self.tmap.get_ty(Ty::Int);
+        let u32_ty = LLVMIntTypeInContext(self.ctx, 32);
+        arg_lltys.extend((0..n_args).map(|_| str_ty));
+        if !is_stdout {
+            // file params
+            arg_lltys.push(str_ty);
+            arg_lltys.push(int_ty);
+        }
+        let ret = LLVMVoidTypeInContext(self.ctx);
+        let func_ty = LLVMFunctionType(ret, arg_lltys.as_mut_ptr(), arg_lltys.len() as u32, 0);
+
+        // Set up the function
+        let name = gen_name("_pa", self.prints.len());
+        let builder = LLVMCreateBuilderInContext(self.ctx);
+        let f = LLVMAddFunction(self.module, name.as_ptr() as *const libc::c_char, func_ty);
+        let bb = LLVMAppendBasicBlockInContext(self.ctx, f, c_str!(""));
+        LLVMPositionBuilderAtEnd(builder, bb);
+        let len = n_args as libc::c_uint;
+        let args_ty = LLVMArrayType(str_ty, len);
+        let args_array = LLVMBuildAlloca(builder, args_ty, c_str!(""));
+        let zero = LLVMConstInt(u32_ty, 0, /*sign_extend=*/ 0);
+
+        for i in 0..n_args {
+            let mut index = [zero, LLVMConstInt(u32_ty, i as u64, /*sign_extend=*/ 0)];
+            let arg_ptr = LLVMBuildGEP(builder, args_array, index.as_mut_ptr(), 2, c_str!(""));
+            // We are storing index `i` in the array, which is going to be argument `i + 1`
+            let argval = LLVMGetParam(f, i as libc::c_uint + 1);
+            LLVMBuildStore(builder, argval, arg_ptr);
+        }
+        let mut start_index = [zero, zero];
+        let args_ptr = LLVMBuildGEP(builder, args_array, start_index.as_mut_ptr(), 2, c_str!(""));
+        let len_v = LLVMConstInt(int_ty, len as u64, /*sign_extend=*/ 0);
+        if is_stdout {
+            let intrinsic = self.intrinsics.get("print_all_stdout");
+            let mut args = [LLVMGetParam(f, 0), args_ptr, len_v];
+            LLVMBuildCall(
+                builder,
+                intrinsic,
+                args.as_mut_ptr(),
+                args.len() as libc::c_uint,
+                c_str!(""),
+            );
+            LLVMBuildRetVoid(builder);
+        } else {
+            let intrinsic = self.intrinsics.get("print_all_file");
+            let out_v = LLVMGetParam(f, 1 + len);
+            let spec_v = LLVMGetParam(f, 1 + len + 1);
+            let mut args = [LLVMGetParam(f, 0), args_ptr, len_v, out_v, spec_v];
+            LLVMBuildCall(
+                builder,
+                intrinsic,
+                args.as_mut_ptr(),
+                args.len() as libc::c_uint,
+                c_str!(""),
+            );
+            LLVMBuildRetVoid(builder);
+        }
+        LLVMSetLinkage(f, llvm_sys::LLVMLinkage::LLVMLinkerPrivateLinkage);
+        LLVMDisposeBuilder(builder);
+        self.prints.insert(key, f);
+        Ok(f)
+    }
+}
+
+fn gen_name(base_name: &str, index: usize) -> [u8; 32] {
+    use std::io::{Cursor, Write};
+    // 64 bit integers should only ever need 20 digits or so.
+    assert!(base_name.len() < 4);
+    let mut name_c = [0u8; 32];
+    for (i, b) in base_name.as_bytes().iter().enumerate() {
+        name_c[i] = *b;
+    }
+    let mut w = Cursor::new(&mut name_c[base_name.as_bytes().len()..]);
+    write!(w, "{:x}", index).unwrap();
+    assert_eq!(name_c[name_c.len() - 1], 0);
+    name_c
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 #![cfg_attr(feature = "unstable", feature(core_intrinsics))]
 #![cfg_attr(feature = "unstable", feature(test))]
 #![cfg_attr(feature = "unstable", feature(write_all_vectored))]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -403,16 +403,6 @@ impl FileWrite {
                 .write_all(ss, FileSpec::Append)
         }
     }
-
-    pub(crate) fn write_str_stdout(&mut self, s: &Str) -> Result<()> {
-        self.0
-            .get_handle(None, FileSpec::default())?
-            .write(s, /*append=*/ FileSpec::Append)
-    }
-
-    pub(crate) fn write_str(&mut self, path: &Str, s: &Str, spec: FileSpec) -> Result<()> {
-        self.0.get_handle(Some(path), spec)?.write(s, spec)
-    }
 }
 
 pub const CHUNK_SIZE: usize = 8 << 10;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -393,9 +393,9 @@ impl FileWrite {
     pub(crate) fn write_all(
         &mut self,
         ss: &[&Str],
-        out_spec: Option<(FileSpec, &Str)>,
+        out_spec: Option<(&Str, FileSpec)>,
     ) -> Result<()> {
-        if let Some((spec, path)) = out_spec {
+        if let Some((path, spec)) = out_spec {
             self.0.get_handle(Some(path), spec)?.write_all(ss, spec)
         } else {
             self.0

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -66,6 +66,12 @@ impl<T> LazyVec<T> {
     pub(crate) fn len(&self) -> usize {
         for_either!(self, |x| x.len())
     }
+    pub fn keys(&self) -> impl Iterator<Item = usize> {
+        match self {
+            Either::Left(v) => Either::Left(0..v.len()),
+            Either::Right(m) => Either::Right(m.to_vec().into_iter().map(|x| x as usize)),
+        }
+    }
 }
 
 impl LazyVec<Str<'static>> {
@@ -286,9 +292,11 @@ impl RegexCache {
         m: &IntMap<Str<'a>>,
     ) -> Result<()> {
         let mut i = 0i64;
+        let mut m_b = m.0.borrow_mut();
+        m_b.clear();
         self.split_internal(pat, s, &FieldSet::all(), |s| {
             i += 1;
-            m.insert(i, s);
+            m_b.insert(i, s);
         })
     }
 
@@ -299,9 +307,11 @@ impl RegexCache {
         m: &StrMap<'a, Str<'a>>,
     ) -> Result<()> {
         let mut i = 0i64;
+        let mut m_b = m.0.borrow_mut();
+        m_b.clear();
         self.split_internal(pat, s, &FieldSet::all(), |s| {
             i += 1;
-            m.insert(convert::<i64, Str<'_>>(i), s);
+            m_b.insert(convert::<i64, Str<'_>>(i), s);
         })
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -390,6 +390,19 @@ impl FileWrite {
         let s = unsafe { text.into_str() };
         handle.write(&s, fspec)
     }
+    pub(crate) fn write_all(
+        &mut self,
+        ss: &[&Str],
+        out_spec: Option<(FileSpec, &Str)>,
+    ) -> Result<()> {
+        if let Some((spec, path)) = out_spec {
+            self.0.get_handle(Some(path), spec)?.write_all(ss, spec)
+        } else {
+            self.0
+                .get_handle(None, FileSpec::default())?
+                .write_all(ss, FileSpec::Append)
+        }
+    }
 
     pub(crate) fn write_str_stdout(&mut self, s: &Str) -> Result<()> {
         self.0

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -1562,7 +1562,7 @@ where
     }
 }
 
-// Most of the implementation for splitting by whitespace and splitting by a single byte are
+// Most of the implementation for splitting by whitespace and splitting by a single byte is
 // shared. ByteReaderBase encapsulates the portions of the implementation that are different. This
 // isn't the cleanest abstraction, but given that it doesn't tend to "leak" into the rest of the
 // code-base, the win in code deduplication seems to justify its existence.
@@ -1709,8 +1709,10 @@ impl ByteReaderBase for ByteReader<Box<dyn ChunkProducer<Chunk = OffsetChunk<Whi
         refresh_buf_impl(self)
     }
     fn maybe_done(&self) -> bool {
+        // TODO: This is a pretty gross check; we should see if we can streamline the ws.fields check.
         self.cur_chunk.off.nl.start == self.cur_chunk.off.nl.fields.len()
-            && self.cur_chunk.off.ws.start == self.cur_chunk.off.ws.fields.len()
+            && (self.cur_chunk.off.ws.start == self.cur_chunk.off.ws.fields.len()
+                || self.progress == self.buf_len)
     }
     fn read_line_inner<'a, 'b: 'a>(
         &'b mut self,

--- a/src/runtime/splitter/mod.rs
+++ b/src/runtime/splitter/mod.rs
@@ -159,9 +159,9 @@ impl<'a> Line<'a> for DefaultLine {
                 let old_set = std::mem::replace(&mut self.used_fields, FieldSet::all());
                 let mut new_vec = LazyVec::new();
                 rc.split_regex(pat, &self.line, &self.used_fields, &mut new_vec)?;
-                for i in 0..new_vec.len() {
-                    if old_set.get(i + 1) {
-                        new_vec.insert(i, self.fields.get(i).unwrap_or_else(Str::default));
+                for k in self.fields.keys() {
+                    if old_set.get(k + 1) {
+                        new_vec.insert(k, self.fields.get(k).unwrap_or_else(Str::default));
                     }
                 }
                 self.fields = new_vec;

--- a/src/runtime/writers.rs
+++ b/src/runtime/writers.rs
@@ -440,19 +440,29 @@ impl FileHandle {
         Ok(())
     }
 
-    pub fn write<'a>(&mut self, s: &Str<'a>, spec: FileSpec) -> Result<()> {
+    pub fn write_all<'a>(&mut self, ss: &[&Str<'a>], spec: FileSpec) -> Result<()> {
         let cur_len = self.cur_batch.data.len();
-        let bs = unsafe { &*s.get_bytes() };
-        self.cur_batch.extend(&*bs, spec);
-        if self.raw.line_buffer {
-            if let Some(ix) = memchr::memchr(b'\n', bs) {
-                // +1 to include the newline
-                self.clear_batch(Some(cur_len + ix + 1))?;
+        let mut added_bytes = 0;
+        let mut last_line = None;
+        for s in ss.iter() {
+            let bs = unsafe { &*s.get_bytes() };
+            self.cur_batch.extend(&*bs, spec);
+            if self.raw.line_buffer {
+                if let Some(ix) = memchr::memchr(b'\n', bs) {
+                    // +1 to include the newline
+                    last_line = Some(cur_len + added_bytes + ix + 1);
+                }
             }
-        } else if bs.len() + cur_len > BUFFER_SIZE {
-            self.clear_batch(None)?;
+            added_bytes += bs.len();
+        }
+        if (self.raw.line_buffer && last_line.is_some()) || (added_bytes + cur_len > BUFFER_SIZE) {
+            self.clear_batch(last_line)?;
         }
         Ok(())
+    }
+    pub fn write<'a>(&mut self, s: &Str<'a>, spec: FileSpec) -> Result<()> {
+        // TODO: get rid of this method
+        self.write_all(&[s], spec)
     }
 
     pub fn flush(&mut self) -> Result<()> {

--- a/src/runtime/writers.rs
+++ b/src/runtime/writers.rs
@@ -461,7 +461,6 @@ impl FileHandle {
         Ok(())
     }
     pub fn write<'a>(&mut self, s: &Str<'a>, spec: FileSpec) -> Result<()> {
-        // TODO: get rid of this method
         self.write_all(&[s], spec)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -968,6 +968,9 @@ impl<'b, 'c, 'd> View<'b, 'c, 'd> {
             // For IterDrop, we do not add extra constraints because IterBegin and IterNext will be
             // sufficient to determine the type of a given iterator.
             IterDrop(_) | SetBuiltin(_, _) => {}
+            // Attempting something different for PrintAll vs Printf; the constraints are similar,
+            // but looking at deferring the type checks to the `compile` phase.
+            PrintAll(..) => {}
         }
     }
 

--- a/tests/nawk_p.rs
+++ b/tests/nawk_p.rs
@@ -1,0 +1,2450 @@
+//! A translation of the `p.` tests in the test directory in the [one true awk
+//! repo](https://github.com/onetrueawk/awk/tree/master/testdir) into Rust, modified for
+//! differences in frawk behavior/semantics.
+//!
+//! Those changes are:
+//! * A frawk parsing limitation leads `FNR==1, FNR==5` not to parse; we need parens around the
+//! comparisons
+//! * `length` is not syntactic sugar for `length($0)`.
+//! * frawk prints more digits on floating point values by default.
+//! * frawk's parser requires semicolons between a last statement and a `}` sometimes
+//! * frawk's rules aronud comparing strings and numbers are different, e.g. "Russia < 1" is true
+//!   in frawk but false in awk/mawk.
+
+use assert_cmd::Command;
+use std::fs::{read_to_string, File};
+use std::io::Write;
+use tempfile::tempdir;
+
+const BACKEND_ARGS: &'static [&'static str] = &["-b", "-O3"];
+
+const COUNTRIES: &'static str = r#"Russia	8650	262	Asia
+Canada	3852	24	North America
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+"#;
+
+fn unordered_output_equals(bs1: &[u8], bs2: &[u8]) {
+    let mut lines1: Vec<_> = bs1.split(|x| *x == b'\n').collect();
+    let mut lines2: Vec<_> = bs2.split(|x| *x == b'\n').collect();
+    lines1.sort();
+    lines2.sort();
+    if lines1 != lines2 {
+        let pretty_1: Vec<_> = lines1.into_iter().map(String::from_utf8_lossy).collect();
+        let pretty_2: Vec<_> = lines2.into_iter().map(String::from_utf8_lossy).collect();
+        assert!(
+            false,
+            "expected (in any order) {:?}, got {:?}",
+            pretty_1, pretty_2
+        );
+    }
+}
+
+#[test]
+fn p_test_1() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+Canada	3852	24	North America
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+Russia	8650	262	Asia
+Canada	3852	24	North America
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ print }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_10() {
+    let expected = String::from(
+        r#"Australia	2968	14	Australia
+Australia	2968	14	Australia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$1 == $4"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_11() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/Asia/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_12() {
+    let expected = String::from(
+        r#"Russia
+China
+India
+Russia
+China
+India
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$4 ~ /Asia/ { print $1 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_13() {
+    let expected = String::from(
+        r#"Canada
+USA
+Brazil
+Australia
+Argentina
+Sudan
+Algeria
+Canada
+USA
+Brazil
+Australia
+Argentina
+Sudan
+Algeria
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$4 !~ /Asia/ {print $1 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_14() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/\$/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_15() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/\\/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_16() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/^.$/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_17() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$2 !~ /^[0-9]+$/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_18() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/(apple|cherry) (pie|tart)/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_19() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ digits = "^[0-9]+$" }
+$2 !~ digits"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_2() {
+    let expected = String::from(
+        r#"Russia 262
+Canada 24
+China 866
+USA 219
+Brazil 116
+Australia 14
+India 637
+Argentina 26
+Sudan 19
+Algeria 18
+Russia 262
+Canada 24
+China 866
+USA 219
+Brazil 116
+Australia 14
+India 637
+Argentina 26
+Sudan 19
+Algeria 18
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ print $1, $3 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_20() {
+    let expected = String::from(
+        r#"China	3692	866	Asia
+India	1269	637	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$4 == "Asia" && $3 > 500"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_21() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$4 == "Asia" || $4 == "Europe""#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_21a() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/Asia/ || /Africa/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_22() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+Russia	8650	262	Asia
+China	3692	866	Asia
+India	1269	637	Asia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$4 ~ /^(Asia|Europe)$/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_23() {
+    let expected = String::from(
+        r#"Canada	3852	24	North America
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+Canada	3852	24	North America
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"/Canada/, /Brazil/"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_24() {
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    let expected = format!(
+        r#"{filename} Russia	8650	262	Asia
+{filename} Canada	3852	24	North America
+{filename} China	3692	866	Asia
+{filename} USA	3615	219	North America
+{filename} Brazil	3286	116	South America
+{filename} Russia	8650	262	Asia
+{filename} Canada	3852	24	North America
+{filename} China	3692	866	Asia
+{filename} USA	3615	219	North America
+{filename} Brazil	3286	116	South America
+"#,
+        filename = data_string.as_str()
+    );
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"(FNR == 1), (FNR == 5) { print FILENAME, $0 }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_25() {
+    let expected = String::from(
+        r#"    Russia   30.3
+    Canada    6.2
+     China  234.6
+       USA   60.6
+    Brazil   35.3
+ Australia    4.7
+     India  502.0
+ Argentina   24.3
+     Sudan   19.6
+   Algeria   19.6
+    Russia   30.3
+    Canada    6.2
+     China  234.6
+       USA   60.6
+    Brazil   35.3
+ Australia    4.7
+     India  502.0
+ Argentina   24.3
+     Sudan   19.6
+   Algeria   19.6
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"{ printf "%10s %6.1f\n", $1, 1000 * $3 / $2 }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_26() {
+    let expected = String::from(
+        r#"population of 6 Asian countries in millions is 3530.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"/Asia/	{ pop = pop + $3; n = n + 1 }
+END	{ print "population of", n,\
+		"Asian countries in millions is", pop }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_26a() {
+    let expected = String::from(
+        r#"population of 6 Asian countries in millions is 3530.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"/Asia/	{ pop += $3; ++n }
+END	{ print "population of", n,\
+		"Asian countries in millions is", pop }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_27() {
+    let expected = String::from(
+        r#"China 866
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"maxpop < $3	{ maxpop = $3; country = $1 }
+END		{ print country, maxpop }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_28() {
+    let expected = String::from(
+        r#"1:Russia	8650	262	Asia
+2:Canada	3852	24	North America
+3:China	3692	866	Asia
+4:USA	3615	219	North America
+5:Brazil	3286	116	South America
+6:Australia	2968	14	Australia
+7:India	1269	637	Asia
+8:Argentina	1072	26	South America
+9:Sudan	968	19	Africa
+10:Algeria	920	18	Africa
+11:Russia	8650	262	Asia
+12:Canada	3852	24	North America
+13:China	3692	866	Asia
+14:USA	3615	219	North America
+15:Brazil	3286	116	South America
+16:Australia	2968	14	Australia
+17:India	1269	637	Asia
+18:Argentina	1072	26	South America
+19:Sudan	968	19	Africa
+20:Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ print NR ":" $0 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_29() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+Canada	3852	24	North America
+China	3692	866	Asia
+United States	3615	219	North America
+Brazil	3286	116	South America
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+Russia	8650	262	Asia
+Canada	3852	24	North America
+China	3692	866	Asia
+United States	3615	219	North America
+Brazil	3286	116	South America
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"	{ gsub(/USA/, "United States"); print }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_3() {
+    let expected = String::from(
+        r#"[    Russia] [262             ]
+[    Canada] [24              ]
+[     China] [866             ]
+[       USA] [219             ]
+[    Brazil] [116             ]
+[ Australia] [14              ]
+[     India] [637             ]
+[ Argentina] [26              ]
+[     Sudan] [19              ]
+[   Algeria] [18              ]
+[    Russia] [262             ]
+[    Canada] [24              ]
+[     China] [866             ]
+[       USA] [219             ]
+[    Brazil] [116             ]
+[ Australia] [14              ]
+[     India] [637             ]
+[ Argentina] [26              ]
+[     Sudan] [19              ]
+[   Algeria] [18              ]
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ printf "[%10s] [%-16d]\n", $1, $3 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_30() {
+    let expected = String::from(
+        r#"20 Russia	8650	262	Asia
+28 Canada	3852	24	North America
+19 China	3692	866	Asia
+26 USA	3615	219	North America
+29 Brazil	3286	116	South America
+27 Australia	2968	14	Australia
+19 India	1269	637	Asia
+31 Argentina	1072	26	South America
+19 Sudan	968	19	Africa
+21 Algeria	920	18	Africa
+20 Russia	8650	262	Asia
+28 Canada	3852	24	North America
+19 China	3692	866	Asia
+26 USA	3615	219	North America
+29 Brazil	3286	116	South America
+27 Australia	2968	14	Australia
+19 India	1269	637	Asia
+31 Argentina	1072	26	South America
+19 Sudan	968	19	Africa
+21 Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ print length($0), $0 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_31() {
+    let expected = String::from(
+        r#"Australia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"length($1) > max	{ max = length($1); name = $1 }
+END			{ print name }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_32() {
+    let expected = String::from(
+        r#"Rus 8650 262 Asia
+Can 3852 24 North America
+Chi 3692 866 Asia
+USA 3615 219 North America
+Bra 3286 116 South America
+Aus 2968 14 Australia
+Ind 1269 637 Asia
+Arg 1072 26 South America
+Sud 968 19 Africa
+Alg 920 18 Africa
+Rus 8650 262 Asia
+Can 3852 24 North America
+Chi 3692 866 Asia
+USA 3615 219 North America
+Bra 3286 116 South America
+Aus 2968 14 Australia
+Ind 1269 637 Asia
+Arg 1072 26 South America
+Sud 968 19 Africa
+Alg 920 18 Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ $1 = substr($1, 1, 3); print }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_33() {
+    let expected = String::from(
+        r#" Rus Can Chi USA Bra Aus Ind Arg Sud Alg Rus Can Chi USA Bra Aus Ind Arg Sud Alg
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"	{ s = s " " substr($1, 1, 3) }
+END	{ print s }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_34() {
+    let expected = String::from(
+        r#"Russia 8.65 262 Asia
+Canada 3.852 24 North America
+China 3.692 866 Asia
+USA 3.615 219 North America
+Brazil 3.286 116 South America
+Australia 2.968 14 Australia
+India 1.269 637 Asia
+Argentina 1.072 26 South America
+Sudan 0.968 19 Africa
+Algeria 0.92 18 Africa
+Russia 8.65 262 Asia
+Canada 3.852 24 North America
+China 3.692 866 Asia
+USA 3.615 219 North America
+Brazil 3.286 116 South America
+Australia 2.968 14 Australia
+India 1.269 637 Asia
+Argentina 1.072 26 South America
+Sudan 0.968 19 Africa
+Algeria 0.92 18 Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ $2 /= 1000; print }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_35() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+Canada	3852	24	NA
+China	3692	866	Asia
+USA	3615	219	NA
+Brazil	3286	116	SA
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	SA
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+Russia	8650	262	Asia
+Canada	3852	24	NA
+China	3692	866	Asia
+USA	3615	219	NA
+Brazil	3286	116	SA
+Australia	2968	14	Australia
+India	1269	637	Asia
+Argentina	1072	26	SA
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN			{ FS = OFS = "\t" }
+$4 ~ /^North America$/	{ $4 = "NA" }
+$4 ~ /^South America$/	{ $4 = "SA" }
+			{ print }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_36() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia	30.289017341040463
+Canada	3852	24	North America	6.230529595015576
+China	3692	866	Asia	234.56121343445287
+USA	3615	219	North America	60.58091286307054
+Brazil	3286	116	South America	35.30127814972611
+Australia	2968	14	Australia	4.716981132075472
+India	1269	637	Asia	501.9700551615445
+Argentina	1072	26	South America	24.253731343283583
+Sudan	968	19	Africa	19.628099173553718
+Algeria	920	18	Africa	19.565217391304348
+Russia	8650	262	Asia	30.289017341040463
+Canada	3852	24	North America	6.230529595015576
+China	3692	866	Asia	234.56121343445287
+USA	3615	219	North America	60.58091286307054
+Brazil	3286	116	South America	35.30127814972611
+Australia	2968	14	Australia	4.716981132075472
+India	1269	637	Asia	501.9700551615445
+Argentina	1072	26	South America	24.253731343283583
+Sudan	968	19	Africa	19.628099173553718
+Algeria	920	18	Africa	19.565217391304348
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = OFS = "\t" }
+	{ $5 = 1000 * $3 / $2 ; print $1, $2, $3, $4, $5 }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_37() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$1 "" == $2 """#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_38() {
+    let expected = String::from(
+        r#"China 866
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"{	if (maxpop < $3) {
+		maxpop = $3
+		country = $1
+	}
+}
+END	{ print country, maxpop }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_39() {
+    let expected = String::from(
+        r#"Russia
+8650
+262
+Asia
+Canada
+3852
+24
+North
+America
+China
+3692
+866
+Asia
+USA
+3615
+219
+North
+America
+Brazil
+3286
+116
+South
+America
+Australia
+2968
+14
+Australia
+India
+1269
+637
+Asia
+Argentina
+1072
+26
+South
+America
+Sudan
+968
+19
+Africa
+Algeria
+920
+18
+Africa
+Russia
+8650
+262
+Asia
+Canada
+3852
+24
+North
+America
+China
+3692
+866
+Asia
+USA
+3615
+219
+North
+America
+Brazil
+3286
+116
+South
+America
+Australia
+2968
+14
+Australia
+India
+1269
+637
+Asia
+Argentina
+1072
+26
+South
+America
+Sudan
+968
+19
+Africa
+Algeria
+920
+18
+Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"{	i = 1
+	while (i <= NF) {
+		print $i
+		i++
+	}
+}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_4() {
+    let expected = String::from(
+        r#"1 Russia	8650	262	Asia
+2 Canada	3852	24	North America
+3 China	3692	866	Asia
+4 USA	3615	219	North America
+5 Brazil	3286	116	South America
+6 Australia	2968	14	Australia
+7 India	1269	637	Asia
+8 Argentina	1072	26	South America
+9 Sudan	968	19	Africa
+10 Algeria	920	18	Africa
+11 Russia	8650	262	Asia
+12 Canada	3852	24	North America
+13 China	3692	866	Asia
+14 USA	3615	219	North America
+15 Brazil	3286	116	South America
+16 Australia	2968	14	Australia
+17 India	1269	637	Asia
+18 Argentina	1072	26	South America
+19 Sudan	968	19	Africa
+20 Algeria	920	18	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"{ print NR, $0 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_40() {
+    let expected = String::from(
+        r#"Russia
+8650
+262
+Asia
+Canada
+3852
+24
+North
+America
+China
+3692
+866
+Asia
+USA
+3615
+219
+North
+America
+Brazil
+3286
+116
+South
+America
+Australia
+2968
+14
+Australia
+India
+1269
+637
+Asia
+Argentina
+1072
+26
+South
+America
+Sudan
+968
+19
+Africa
+Algeria
+920
+18
+Africa
+Russia
+8650
+262
+Asia
+Canada
+3852
+24
+North
+America
+China
+3692
+866
+Asia
+USA
+3615
+219
+North
+America
+Brazil
+3286
+116
+South
+America
+Australia
+2968
+14
+Australia
+India
+1269
+637
+Asia
+Argentina
+1072
+26
+South
+America
+Sudan
+968
+19
+Africa
+Algeria
+920
+18
+Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"{	for (i = 1; i <= NF; i++)
+		print $i
+}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_41() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"NR >= 10	{ exit }
+END		{ if (NR < 10)
+			print FILENAME " has only " NR " lines" }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_42() {
+    let expected = String::from(
+        r#"Asian population in millions is 3530.0
+African population in millions is 74.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"/Asia/		{ pop["Asia"] += $3 }
+/Africa/	{ pop["Africa"] += $3 }
+END		{ print "Asian population in millions is", pop["Asia"]
+		  print "African population in millions is", pop["Africa"] }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_43() {
+    let expected = String::from(
+        r#"Asia:27222.0
+Australia:5936.0
+Africa:3776.0
+South America:8716.0
+North America:14934.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        let output = Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = "\t" }
+	{ area[$4] += $2 }
+END	{ for (name in area)
+		print name ":" area[name]; }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .output()
+            .unwrap()
+            .stdout;
+        unordered_output_equals(expected.as_bytes(), &output[..]);
+    }
+}
+
+#[test]
+fn p_test_44() {
+    let expected = String::from(
+        r#"Russia! is 1.0
+Canada! is 1.0
+China! is 1.0
+USA! is 1.0
+Brazil! is 1.0
+Australia! is 1.0
+India! is 1.0
+Argentina! is 1.0
+Sudan! is 1.0
+Algeria! is 1.0
+Russia! is 1.0
+Canada! is 1.0
+China! is 1.0
+USA! is 1.0
+Brazil! is 1.0
+Australia! is 1.0
+India! is 1.0
+Argentina! is 1.0
+Sudan! is 1.0
+Algeria! is 1.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"function fact(n) {
+	if (n <= 1)
+		return 1
+	else
+		return n * fact(n-1)
+}
+{ print $1 "! is " fact($1) }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_45() {
+    let expected = String::from(
+        r#"Russia:8650
+
+Canada:3852
+
+China:3692
+
+USA:3615
+
+Brazil:3286
+
+Australia:2968
+
+India:1269
+
+Argentina:1072
+
+Sudan:968
+
+Algeria:920
+
+Russia:8650
+
+Canada:3852
+
+China:3692
+
+USA:3615
+
+Brazil:3286
+
+Australia:2968
+
+India:1269
+
+Argentina:1072
+
+Sudan:968
+
+Algeria:920
+
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ OFS = ":" ; ORS = "\n\n" }
+	{ print $1, $2 }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_46() {
+    let expected = String::from(
+        r#"Russia8650
+Canada3852
+China3692
+USA3615
+Brazil3286
+Australia2968
+India1269
+Argentina1072
+Sudan968
+Algeria920
+Russia8650
+Canada3852
+China3692
+USA3615
+Brazil3286
+Australia2968
+India1269
+Argentina1072
+Sudan968
+Algeria920
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"	{ print $1 $2 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_47() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let small_path = tmpdir.path().join("tempsmall");
+    let big_path = tmpdir.path().join("tempbig");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    let small = small_path.clone().into_os_string().into_string().unwrap();
+    let big = big_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(format!(
+                r#"$3 > 100	{{ print >"{tempbig}" }}
+$3 <= 100	{{ print >"{tempsmall}" }}"#,
+                tempsmall = small,
+                tempbig = big,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+        let got_small = read_to_string(small_path.clone()).unwrap();
+        assert_eq!(
+            got_small,
+            r#"Canada	3852	24	North America
+Australia	2968	14	Australia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+Canada	3852	24	North America
+Australia	2968	14	Australia
+Argentina	1072	26	South America
+Sudan	968	19	Africa
+Algeria	920	18	Africa
+"#
+        );
+        let got_big = read_to_string(big_path.clone()).unwrap();
+        assert_eq!(
+            got_big,
+            r#"Russia	8650	262	Asia
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+India	1269	637	Asia
+Russia	8650	262	Asia
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+India	1269	637	Asia
+"#
+        );
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn p_test_48() {
+    let expected = String::from(
+        r#"Africa:74.0
+Asia:3530.0
+Australia:28.0
+North America:486.0
+South America:284.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = "\t" }
+	{ pop[$4] += $3 }
+END	{ for (c in pop)
+		print c ":" pop[c] | "sort"; }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_48a() {
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    let expected = format!("{filename} {filename} \n", filename = data_string.as_str());
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN {
+	for (i = 1; i < ARGC; i++)
+		printf "%s ", ARGV[i]
+	printf "\n"
+	exit
+}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_48b() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+USA	3615	219	North America
+India	1269	637	Asia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ srand(10); k = 3; n = 10 }
+{	if (n <= 0) exit
+	if (rand() <= k/n) { print; k-- }
+	n--
+}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_49() {
+    let expected = String::from(r#""#);
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$1 == "include" { system("cat " $2) }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_5() {
+    let expected = String::from(
+        r#"   COUNTRY   AREA   POP       CONTINENT
+    Russia   8650   262            Asia
+    Canada   3852    24   North America
+     China   3692   866            Asia
+       USA   3615   219   North America
+    Brazil   3286   116   South America
+ Australia   2968    14       Australia
+     India   1269   637            Asia
+ Argentina   1072    26   South America
+     Sudan    968    19          Africa
+   Algeria    920    18          Africa
+    Russia   8650   262            Asia
+    Canada   3852    24   North America
+     China   3692   866            Asia
+       USA   3615   219   North America
+    Brazil   3286   116   South America
+ Australia   2968    14       Australia
+     India   1269   637            Asia
+ Argentina   1072    26   South America
+     Sudan    968    19          Africa
+   Algeria    920    18          Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = "\t"
+	  printf "%10s %6s %5s %15s\n", "COUNTRY", "AREA", "POP", "CONTINENT" }
+	{ printf "%10s %6d %5d %15s\n", $1, $2, $3, $4 }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn p_test_50() {
+    let expected = String::from(
+        r#"Africa:Sudan:38.0
+Africa:Algeria:36.0
+Asia:China:1732.0
+Asia:India:1274.0
+Asia:Russia:524.0
+Australia:Australia:28.0
+North America:USA:438.0
+North America:Canada:48.0
+South America:Brazil:232.0
+South America:Argentina:52.0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = "\t" }
+	{ pop[$4 ":" $1] += $3 }
+END	{ for (cc in pop)
+		print cc ":" pop[cc] | "sort -t: -k 1,1 -k 3nr"; }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_51() {
+    let expected = String::from(
+        r#"
+Russia	8650	262	Asia:
+	                0
+
+Canada	3852	24	North America:
+	                0
+
+China	3692	866	Asia:
+	                0
+
+USA	3615	219	North America:
+	                0
+
+Brazil	3286	116	South America:
+	                0
+
+Australia	2968	14	Australia:
+	                0
+
+India	1269	637	Asia:
+	                0
+
+Argentina	1072	26	South America:
+	                0
+
+Sudan	968	19	Africa:
+	                0
+
+Algeria	920	18	Africa:
+	                0
+
+Russia	8650	262	Asia:
+	                0
+
+Canada	3852	24	North America:
+	                0
+
+China	3692	866	Asia:
+	                0
+
+USA	3615	219	North America:
+	                0
+
+Brazil	3286	116	South America:
+	                0
+
+Australia	2968	14	Australia:
+	                0
+
+India	1269	637	Asia:
+	                0
+
+Argentina	1072	26	South America:
+	                0
+
+Sudan	968	19	Africa:
+	                0
+
+Algeria	920	18	Africa:
+	                0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = ":" }
+{	if ($1 != prev) {
+		print "\n" $1 ":"
+		prev = $1
+	}
+	printf "\t%-10s %6d\n", $2, $3
+}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_52() {
+    let expected = String::from(
+        r#"
+Russia	8650	262	Asia:
+	                0
+	total     	      0
+
+Canada	3852	24	North America:
+	                0
+	total     	      0
+
+China	3692	866	Asia:
+	                0
+	total     	      0
+
+USA	3615	219	North America:
+	                0
+	total     	      0
+
+Brazil	3286	116	South America:
+	                0
+	total     	      0
+
+Australia	2968	14	Australia:
+	                0
+	total     	      0
+
+India	1269	637	Asia:
+	                0
+	total     	      0
+
+Argentina	1072	26	South America:
+	                0
+	total     	      0
+
+Sudan	968	19	Africa:
+	                0
+	total     	      0
+
+Algeria	920	18	Africa:
+	                0
+	total     	      0
+
+Russia	8650	262	Asia:
+	                0
+	total     	      0
+
+Canada	3852	24	North America:
+	                0
+	total     	      0
+
+China	3692	866	Asia:
+	                0
+	total     	      0
+
+USA	3615	219	North America:
+	                0
+	total     	      0
+
+Brazil	3286	116	South America:
+	                0
+	total     	      0
+
+Australia	2968	14	Australia:
+	                0
+	total     	      0
+
+India	1269	637	Asia:
+	                0
+	total     	      0
+
+Argentina	1072	26	South America:
+	                0
+	total     	      0
+
+Sudan	968	19	Africa:
+	                0
+	total     	      0
+
+Algeria	920	18	Africa:
+	                0
+	total     	      0
+
+World Total		      0
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = ":" }
+{
+	if ($1 != prev) {
+		if (prev) {
+			printf "\t%-10s\t %6d\n", "total", subtotal
+			subtotal = 0
+		}
+		print "\n" $1 ":"
+		prev = $1
+	}
+	printf "\t%-10s %6d\n", $2, $3
+	wtotal += $3
+	subtotal += $3
+}
+END	{ printf "\t%-10s\t %6d\n", "total", subtotal
+	  printf "\n%-10s\t\t %6d\n", "World Total", wtotal }"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_5a() {
+    let expected = String::from(
+        r#"   COUNTRY	  AREA	 POP'N	      CONTINENT
+    Russia	  8650	   262	           Asia
+    Canada	  3852	    24	  North America
+     China	  3692	   866	           Asia
+       USA	  3615	   219	  North America
+    Brazil	  3286	   116	  South America
+ Australia	  2968	    14	      Australia
+     India	  1269	   637	           Asia
+ Argentina	  1072	    26	  South America
+     Sudan	   968	    19	         Africa
+   Algeria	   920	    18	         Africa
+    Russia	  8650	   262	           Asia
+    Canada	  3852	    24	  North America
+     China	  3692	   866	           Asia
+       USA	  3615	   219	  North America
+    Brazil	  3286	   116	  South America
+ Australia	  2968	    14	      Australia
+     India	  1269	   637	           Asia
+ Argentina	  1072	    26	  South America
+     Sudan	   968	    19	         Africa
+   Algeria	   920	    18	         Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"BEGIN	{ FS = "\t"
+	  printf "%10s\t%6s\t%6s\t%15s\n", "COUNTRY", "AREA", "POP'N", "CONTINENT"}
+	{ printf "%10s\t%6d\t%6d\t%15s\n", $1, $2, $3, $4}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_6() {
+    let expected = String::from(
+        r#"20
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"END	{ print NR }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_7() {
+    let expected = String::from(
+        r#"Russia	8650	262	Asia
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+India	1269	637	Asia
+Russia	8650	262	Asia
+China	3692	866	Asia
+USA	3615	219	North America
+Brazil	3286	116	South America
+India	1269	637	Asia
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$3 > 100"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_8() {
+    let expected = String::from(
+        r#"Russia
+China
+India
+Russia
+China
+India
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$4 == "Asia" { print $1 }"#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_9() {
+    let expected = String::from(
+        r#"USA	3615	219	North America
+Sudan	968	19	Africa
+USA	3615	219	North America
+Sudan	968	19	Africa
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(r#"$1 >= "S""#))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn p_test_table() {
+    let expected = String::from(
+        r#"Russia      8650   262   Asia         
+Canada      3852    24   North America
+China       3692   866   Asia         
+USA         3615   219   North America
+Brazil      3286   116   South America
+Australia   2968    14   Australia    
+India       1269   637   Asia         
+Argentina   1072    26   South America
+Sudan        968    19   Africa       
+Algeria      920    18   Africa       
+Russia      8650   262   Asia         
+Canada      3852    24   North America
+China       3692   866   Asia         
+USA         3615   219   North America
+Brazil      3286   116   South America
+Australia   2968    14   Australia    
+India       1269   637   Asia         
+Argentina   1072    26   South America
+Sudan        968    19   Africa       
+Algeria      920    18   Africa       
+"#,
+    );
+    let tmpdir = tempdir().unwrap();
+    let data_path = tmpdir.path().join("test.countries");
+    let data_string = data_path.clone().into_os_string().into_string().unwrap();
+    {
+        let mut file = File::create(data_path).unwrap();
+        write!(file, "{}", COUNTRIES).unwrap();
+    }
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from(
+                r#"# table - simple table formatter
+
+BEGIN {
+    FS = "\t"; blanks = sprintf("%100s", " ")
+    number = "^[+-]?([0-9]+[.]?[0-9]*|[.][0-9]+)$"
+}
+
+{   row[NR] = $0
+    for (i = 1; i <= NF; i++) {
+        if ($i ~ number)
+            nwid[i] = max(nwid[i], length($i))
+        wid[i] = max(wid[i], length($i))
+    }
+}
+
+END {
+    for (r = 1; r <= NR; r++) {
+        n = split(row[r], d)
+        for (i = 1; i <= n; i++) {
+            sep = (i < n) ? "   " : "\n"
+            if (d[i] ~ number)
+                printf("%" wid[i] "s%s", numjust(i,d[i]), sep)
+            else
+                printf("%-" wid[i] "s%s", d[i], sep)
+        }
+    }
+}
+
+function max(x, y) { return (x > y) ? x : y }
+
+function numjust(n, s) {   # position s in field n
+    return s substr(blanks, 1, int((wid[n]-nwid[n])/2))
+}"#,
+            ))
+            .arg(data_string.clone())
+            .arg(data_string.clone())
+            .assert()
+            .stdout(expected.clone());
+    }
+}

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -1,0 +1,67 @@
+use assert_cmd::Command;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::fs::File;
+use std::io::Write;
+use tempfile::tempdir;
+
+fn numbers_str(n: usize) -> (String, String) {
+    let mut input = String::new();
+    let mut sorted = String::new();
+    let mut vs: Vec<_> = (0..n).collect();
+    vs.shuffle(&mut thread_rng());
+    for (i, n) in vs.into_iter().enumerate() {
+        sorted.push_str(format!("{}\n", i).as_str());
+        input.push_str(format!("{}\n", n).as_str());
+    }
+    (input, sorted)
+}
+
+const N: usize = 10_000;
+const BACKEND_ARGS: &'static [&'static str] = &["-b", "-O3"];
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn sort_command_single_threaded() {
+    let (input, expected) = numbers_str(N);
+    let tmpdir = tempdir().unwrap();
+    let data_fname = tmpdir.path().join("numbers");
+    {
+        let mut file = File::create(data_fname.clone()).unwrap();
+        file.write(input.as_bytes()).unwrap();
+    }
+    let prog: String = r#"{ print $0 | "sort -n"; }"#.into();
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(prog.clone())
+            .arg(data_fname.clone().into_os_string().into_string().unwrap())
+            .assert()
+            .stdout(expected.clone());
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn sort_command_multi_threaded() {
+    let (input, expected) = numbers_str(N);
+    let tmpdir = tempdir().unwrap();
+    let data_fname = tmpdir.path().join("numbers");
+    {
+        let mut file = File::create(data_fname.clone()).unwrap();
+        file.write(input.as_bytes()).unwrap();
+    }
+    let prog: String = r#"{ print $0 | "sort -n"; }"#.into();
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from("-pr"))
+            .arg(String::from("-j4"))
+            .arg(prog.clone())
+            .arg(data_fname.clone().into_os_string().into_string().unwrap())
+            .assert()
+            .stdout(expected.clone());
+    }
+}


### PR DESCRIPTION
This includes two files:

1. `nawk_p` which is a translation of the `p.` tests in the nawk repo
   into frawk.
2. `sort` which tests multithreaded and singlethreaded sorts for large
   inputs.

These tests all pass, but only with several modifications to frawk to
fix bugs uncovered by the tests.