### PR TITLE
Parse header

### DIFF
--- a/info/overview.md
+++ b/info/overview.md
@@ -232,8 +232,9 @@ surprised to discover there were bugs in frawk's parser.
   these commands from within a function, and it's a major simplification to just
   disallow this case. Again, let me know if this is an important use-case for
   you.
-* Some basic Awk commands are missing (e.g. `exit` is not present, though
-  `nextfile` is and suffices in many cases), because I have not gotten to them
+* Some basic Awk commands are missing (e.g. `exit` is not present as its
+  semantics are unclear in a multithreaded setting, though `nextfile` is and
+  suffices in many cases), because I have not gotten to them
   yet. Many of the extensions in gawk (e.g. co-processes, multidimensional
   arrays) are also not implemented.
 * While it has never been tried, I sincerely doubt that frawk will run at all
@@ -262,6 +263,12 @@ surprised to discover there were bugs in frawk's parser.
   not variadic.
 * frawk functions can return arrays, function calls can appear in the array
   position for a for-each loop.
+* With the `-H` flag, frawk parses the first line of input (without updating
+  `NR` or `FNR`) and populates the `FI` builtin variable with the contents the
+  fields in the first line mapping to their index. So in a script parsing a
+  file with a field called "count" in column 6, the expression `$FI["count"]`
+  behaves like `$6`. frawk's implementation of this feature plays nicely with
+  its projection pushdown analysis.
 
 ### What is different
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -630,7 +630,7 @@ impl<'a> Variables<'a> {
         match var {
             ARGV => Ok(self.argv.clone()),
             FI | PID | ORS | OFS | ARGC | NF | NR | FNR | FS | RS | FILENAME | RSTART | RLENGTH => {
-                err!("var {} is not a map", var)
+                err!("var {} is not an int-keyed map", var)
             }
         }
     }
@@ -640,11 +640,33 @@ impl<'a> Variables<'a> {
         match var {
             ARGV => Ok(self.argv = m),
             FI | PID | ORS | OFS | ARGC | NF | NR | FNR | FS | RS | FILENAME | RSTART | RLENGTH => {
-                err!("var {} is not a map", var)
+                err!("var {} is not an int-keyed map", var)
+            }
+        }
+    }
+    pub fn load_strmap(&self, var: Variable) -> Result<StrMap<'a, Int>> {
+        use Variable::*;
+        match var {
+            FI => Ok(self.fi.clone()),
+            ARGV | PID | ORS | OFS | ARGC | NF | NR | FNR | FS | RS | FILENAME | RSTART
+            | RLENGTH => {
+                err!("var {} is not a string-keyed map", var)
+            }
+        }
+    }
+
+    pub fn store_strmap(&mut self, var: Variable, m: StrMap<'a, Int>) -> Result<()> {
+        use Variable::*;
+        match var {
+            FI => Ok(self.fi = m),
+            ARGV | PID | ORS | OFS | ARGC | NF | NR | FNR | FS | RS | FILENAME | RSTART
+            | RLENGTH => {
+                err!("var {} is not a string-keyed map", var)
             }
         }
     }
 }
+
 impl Variable {
     pub(crate) fn ty(&self) -> types::TVar<types::BaseTy> {
         use Variable::*;

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -182,6 +182,10 @@ pub(crate) enum Instr<'a> {
     NextLineStdinFused(),
     // Advances early to the next file in our sequence
     NextFile(),
+    UpdateUsedFields(),
+    // Set the corresponding index in the FI variable. This is equivalent of loading FI, but we
+    // keep this as a separate instruction to make static analysis easier.
+    SetFI(Reg<Int>, Reg<Int>),
 
     // Split
     SplitInt(
@@ -757,7 +761,12 @@ impl<'a> Instr<'a> {
             JmpIf(cond, _lbl) => cond.accum(&mut f),
             Push(ty, reg) => f(*reg, *ty),
             Pop(ty, reg) => f(*reg, *ty),
-            NextFile() | NextLineStdinFused() | Call(_) | Jmp(_) | Ret | Halt => {}
+            SetFI(key, val) => {
+                key.accum(&mut f);
+                val.accum(&mut f);
+            }
+            UpdateUsedFields() | NextFile() | NextLineStdinFused() | Call(_) | Jmp(_) | Ret
+            | Halt => {}
         }
     }
 }

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -264,6 +264,8 @@ pub(crate) enum Instr<'a> {
     StoreVarInt(Variable, Reg<Int>),
     LoadVarIntMap(Reg<runtime::IntMap<Str<'a>>>, Variable),
     StoreVarIntMap(Variable, Reg<runtime::IntMap<Str<'a>>>),
+    LoadVarStrMap(Reg<runtime::StrMap<'a, Int>>, Variable),
+    StoreVarStrMap(Variable, Reg<runtime::StrMap<'a, Int>>),
 
     LoadSlot {
         ty: Ty,
@@ -723,6 +725,8 @@ impl<'a> Instr<'a> {
             StoreVarInt(_var, src) => src.accum(&mut f),
             LoadVarIntMap(dst, _var) => dst.accum(&mut f),
             StoreVarIntMap(_var, src) => src.accum(&mut f),
+            LoadVarStrMap(dst, _var) => dst.accum(&mut f),
+            StoreVarStrMap(_var, src) => src.accum(&mut f),
 
             LoadSlot { ty, dst, .. } => f(*dst, *ty),
             StoreSlot { ty, src, .. } => f(*src, *ty),

--- a/src/common.rs
+++ b/src/common.rs
@@ -257,9 +257,6 @@ impl<T: Clone + Hash + Eq> WorkList<T> {
         debug_assert!(_was_there);
         Some(next)
     }
-    pub(crate) fn iter(&mut self) -> impl Iterator<Item = T> + '_ {
-        self.mem.iter().cloned()
-    }
 }
 
 /// Notification is a simple object used to synchronize multiple threads around a single event

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -167,6 +167,12 @@ pub(crate) fn bytecode<'a, LR: runtime::LineReader>(
 }
 
 #[cfg(test)]
+pub(crate) fn context_compiles<'a>(ctx: &mut cfg::ProgramContext<'a, &'a str>) -> Result<()> {
+    Typer::init_from_ctx(ctx)?;
+    Ok(())
+}
+
+#[cfg(test)]
 pub(crate) fn used_fields<'a>(ctx: &mut cfg::ProgramContext<'a, &'a str>) -> Result<FieldSet> {
     Ok(Typer::init_from_ctx(ctx)?.used_fields)
 }

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -1,0 +1,381 @@
+//! A common library for constructing dataflow analyses on frawk programs.
+use crate::builtins::Variable;
+use crate::bytecode::{Accum, Instr, Reg};
+use crate::common::{Graph, NodeIx, NumTy, WorkList};
+use crate::compile::{HighLevel, Ty};
+
+use hashbrown::{HashMap, HashSet};
+use petgraph::{
+    visit::{Dfs, EdgeRef},
+    Direction,
+};
+
+use std::convert::TryFrom;
+use std::hash::Hash;
+use std::mem;
+
+/// A bounded lattice, optimized for the kind of dataflow analyses we do on frawk programs. In
+/// particular you specify "transfer funcitons" as part of the lattice, rather than specifying
+/// join and meet separately. This means that, even though meet should "exist" (seems hard to
+/// define top() without reference to it); Func need not include it if it is not relevant to the
+/// analysis.
+pub trait BoundedLattice {
+    type Func: Default;
+    // invoke(other, &Default::default()) ~ *self = join(self, other);
+    fn invoke(&mut self, other: &Self, f: &Self::Func) -> bool /* changed */;
+    fn bottom() -> Self;
+    fn top() -> Self;
+}
+
+pub(crate) struct Analysis<B: BoundedLattice, K = Key> {
+    sentinel: NodeIx,
+    nodes: HashMap<K, NodeIx>,
+    graph: Graph<B, B::Func>,
+    queries: HashSet<NodeIx>,
+    blank: HashSet<NodeIx>,
+}
+
+impl<K, B: BoundedLattice> Default for Analysis<B, K> {
+    fn default() -> Analysis<B, K> {
+        let mut res = Analysis {
+            sentinel: Default::default(),
+            nodes: Default::default(),
+            graph: Default::default(),
+            queries: Default::default(),
+            blank: Default::default(),
+        };
+        res.sentinel = res.graph.add_node(B::bottom());
+        res
+    }
+}
+
+impl<K: Eq + Hash, B: BoundedLattice> Analysis<B, K> {
+    pub(crate) fn add_src(&mut self, k: impl Into<K>, mut v: B) {
+        let ix = self.get_node(k);
+        let weight = self.graph.node_weight_mut(ix).unwrap();
+        v.invoke(weight, &Default::default());
+        *weight = v;
+        self.blank.remove(&ix);
+    }
+    pub(crate) fn add_dep(&mut self, src: impl Into<K>, dst: impl Into<K>, edge: B::Func) {
+        // We add dependencies in reverse order, so we can dfs for relevant nodes later on
+        let dst_ix = self.get_node(dst);
+        let src_ix = self.get_node(src);
+        self.blank.remove(&dst_ix);
+        self.graph.add_edge(dst_ix, src_ix, edge);
+    }
+    fn get_node(&mut self, k: impl Into<K>) -> NodeIx {
+        let blank = &mut self.blank;
+        let graph = &mut self.graph;
+        self.nodes
+            .entry(k.into())
+            .or_insert_with(|| {
+                let res = graph.add_node(B::bottom());
+                blank.insert(res);
+                res
+            })
+            .clone()
+    }
+    pub(crate) fn add_query(&mut self, k: impl Into<K>) {
+        let ix = self.get_node(k);
+        self.queries.insert(ix);
+    }
+    pub(crate) fn query(&mut self, k: impl Into<K>) -> &B {
+        let ix = self.get_node(k);
+        assert!(self.queries.contains(&ix));
+        self.solve();
+        self.graph.node_weight(ix).unwrap()
+    }
+    fn populate(&mut self, wl: &mut WorkList<NodeIx>) {
+        let sentinel = self.sentinel;
+        for node in self.queries.iter().cloned() {
+            self.graph.add_edge(sentinel, node, Default::default());
+        }
+        let mut dfs = Dfs::new(&self.graph, sentinel);
+        while let Some(ix) = dfs.next(&self.graph) {
+            wl.insert(ix);
+        }
+        for ix in self.blank.iter().cloned() {
+            *self.graph.node_weight_mut(ix).unwrap() = B::top();
+        }
+    }
+    fn solve(&mut self) {
+        let mut wl = WorkList::default();
+        self.populate(&mut wl);
+        while let Some(n) = wl.pop() {
+            let mut start = mem::replace(self.graph.node_weight_mut(n).unwrap(), B::bottom());
+            let mut changed = false;
+            for edge in self.graph.edges_directed(n, Direction::Outgoing) {
+                let neigh = edge.target();
+                let func = edge.weight();
+                changed |= start.invoke(self.graph.node_weight(neigh).unwrap(), func);
+            }
+            mem::swap(&mut start, self.graph.node_weight_mut(n).unwrap());
+            if !changed {
+                continue;
+            }
+            for neigh in self.graph.neighbors_directed(n, Direction::Incoming) {
+                wl.insert(neigh)
+            }
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+pub(crate) enum Key {
+    Reg(NumTy, Ty),
+    MapKey(NumTy, Ty),
+    MapVal(NumTy, Ty),
+    Rng,
+    Var(Variable),
+    VarKey(Variable),
+    VarVal(Variable),
+    Slot(NumTy, Ty),
+    Func(NumTy),
+}
+
+impl<T> From<&Reg<T>> for Key
+where
+    Reg<T>: Accum,
+{
+    fn from(r: &Reg<T>) -> Key {
+        let (reg, ty) = r.reflect();
+        Key::Reg(reg, ty)
+    }
+}
+
+// TODO: wire into input_taint, get those tests passing.
+// TODO: wire into used_fields
+// TODO: wire into string constants
+
+pub(crate) mod boilerplate {
+    //! Some utility functions for discovering reads and writes in various parts of the IR.
+    //! TODO: more precise tracking of function arguments.
+    use super::*;
+
+    pub(crate) fn visit_hl(
+        inst: &HighLevel,
+        cur_fn_id: NumTy,
+        mut f: impl FnMut(/*dst*/ Key, /*src*/ Option<Key>),
+    ) {
+        use HighLevel::*;
+        match inst {
+            Call {
+                func_id,
+                dst_reg,
+                dst_ty,
+                args,
+            } => {
+                let dst_key = Key::Reg(*dst_reg, *dst_ty);
+                f(dst_key.clone(), Some(Key::Func(*func_id)));
+                for (reg, ty) in args.iter().cloned() {
+                    f(dst_key.clone(), Some(Key::Reg(reg, ty)));
+                }
+            }
+            Ret(reg, ty) => {
+                f(Key::Func(cur_fn_id), Some(Key::Reg(*reg, *ty)));
+            }
+            Phi(reg, ty, preds) => {
+                for (_, pred_reg) in preds.iter() {
+                    f(Key::Reg(*reg, *ty), Some(Key::Reg(*pred_reg, *ty)));
+                }
+            }
+            DropIter(..) => {}
+        }
+    }
+
+    pub(crate) fn visit_ll(inst: &Instr, mut f: impl FnMut(/*dst*/ Key, /*src*/ Option<Key>)) {
+        use Instr::*;
+        match inst {
+            StoreConstStr(dst, _) => f(dst.into(), None),
+            StoreConstInt(dst, _) => f(dst.into(), None),
+            StoreConstFloat(dst, _) => f(dst.into(), None),
+
+            IntToStr(dst, src) => f(dst.into(), Some(src.into())),
+            IntToFloat(dst, src) => f(dst.into(), Some(src.into())),
+            FloatToStr(dst, src) => f(dst.into(), Some(src.into())),
+            FloatToInt(dst, src) => f(dst.into(), Some(src.into())),
+            StrToFloat(dst, src) => f(dst.into(), Some(src.into())),
+            LenStr(dst, src) | StrToInt(dst, src) | HexStrToInt(dst, src) => f(dst.into(), Some(src.into())),
+
+            Mov(ty, dst, src) => if !ty.is_array() {
+                f(Key::Reg(*dst, *ty), Some(Key::Reg(*src, *ty)))
+            } else {
+                f(Key::MapKey(*dst, *ty), Some(Key::MapKey(*src, *ty)));
+                f(Key::MapVal(*dst, *ty), Some(Key::MapVal(*src, *ty)));
+            },
+            AddInt(dst, x, y)
+            | MulInt(dst, x, y)
+            | MinusInt(dst, x, y)
+            | ModInt(dst, x, y)
+            | Int2(_, dst, x, y) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+            }
+            AddFloat(dst, x, y)
+            | MulFloat(dst, x, y)
+            | MinusFloat(dst, x, y)
+            | ModFloat(dst, x, y)
+            | Div(dst, x, y)
+            | Pow(dst, x, y)
+            | Float2(_, dst, x, y) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+            }
+            Not(dst, src) | NegInt(dst, src) | Int1(_, dst, src) => f(dst.into(), Some(src.into())),
+            NegFloat(dst, src) | Float1(_, dst, src) => f(dst.into(), Some(src.into())),
+            NotStr(dst, src) => f(dst.into(), Some(src.into())),
+            Rand(dst) => f(dst.into(), Some(Key::Rng)),
+            Srand(old, new) => {
+                f(old.into(), Some(Key::Rng));
+                f(Key::Rng, Some(new.into()));
+            }
+            ReseedRng(new) => f(Key::Rng, Some(new.into())),
+            Concat(dst, x, y) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+            }
+
+            // NB: this assumes that regexes that have been constant-folded are not tainted by
+            // user-input. That is certainly true today, but any kind of dynamic simplification or
+            // inlining could change that.
+            MatchConst(dst, x, _) | IsMatchConst(dst, x, _) => f(dst.into(), Some(x.into())),
+            IsMatch(dst, x, y) | Match(dst, x, y) | SubstrIndex(dst, x, y) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+            }
+            GSub(dst, x, y, dstin) | Sub(dst, x, y, dstin) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+                f(dstin.into(), Some(x.into()));
+                f(dstin.into(), Some(y.into()));
+            }
+            EscapeTSV(dst, src) | EscapeCSV(dst, src) => f(dst.into(), Some(src.into())),
+            Substr(dst, x, y, z) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+                f(dst.into(), Some(z.into()));
+            }
+            LTFloat(dst, x, y)
+            | GTFloat(dst, x, y)
+            | LTEFloat(dst, x, y)
+            | GTEFloat(dst, x, y)
+            | EQFloat(dst, x, y) => {
+                    f(dst.into(), Some(x.into()));
+                    f(dst.into(), Some(y.into()));
+                }
+            LTInt(dst, x, y)
+            | GTInt(dst, x, y)
+            | LTEInt(dst, x, y)
+            | GTEInt(dst, x, y)
+            | EQInt(dst, x, y) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+            }
+            LTStr(dst, x, y)
+            | GTStr(dst, x, y)
+            | LTEStr(dst, x, y)
+            | GTEStr(dst, x, y)
+            | EQStr(dst, x, y) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+            }
+            GetColumn(dst, _) => f(dst.into(), None),
+            JoinTSV(dst, start, end) | JoinCSV(dst, start, end) => {
+                f(dst.into(), Some(start.into()));
+                f(dst.into(), Some(end.into()));
+            }
+            JoinColumns(dst, x, y, z) => {
+                f(dst.into(), Some(x.into()));
+                f(dst.into(), Some(y.into()));
+                f(dst.into(), Some(z.into()));
+            }
+            ReadErr(dst, _cmd, _) => f(dst.into(), None),
+            NextLine(dst, _cmd, _) => f(dst.into(), None),
+            ReadErrStdin(dst) => f(dst.into(), None),
+            NextLineStdin(dst) => f(dst.into(), None),
+            SplitInt(dst1, src1, dst2, src2) => {
+                f(dst1.into(), Some(src1.into()));
+                f(dst1.into(), Some(src2.into()));
+                let (dst2_reg, dst2_ty) = dst2.reflect();
+                debug_assert!(dst2_ty.is_array());
+                f(Key::MapVal(dst2_reg, dst2_ty), Some(src1.into()));
+                f(Key::MapVal(dst2_reg, dst2_ty), Some(src2.into()));
+            }
+            SplitStr(dst1, src1, dst2, src2) => {
+                f(dst1.into(), Some(src1.into()));
+                f(dst1.into(), Some(src2.into()));
+                f(dst2.into(), Some(src1.into()));
+                f(dst2.into(), Some(src2.into()));
+            }
+            Sprintf { dst, fmt, args } => {
+                f(dst.into(), Some(fmt.into()));
+                for (reg, ty) in args.iter() {
+                    f(dst.into(), Some(Key::Reg(*reg, *ty)));
+                }
+            }
+            RunCmd(dst, _) => f(dst.into(), None),
+            Lookup {
+                map_ty,
+                dst,
+                map,
+                key,
+            } => {
+                // lookups are also writes to the keys
+                f(Key::MapKey(*dst, *map_ty), Some(Key::Reg(*key, map_ty.val().unwrap())));
+                f(Key::MapVal(*dst, *map_ty), None);
+                f(Key::Reg(*dst, map_ty.val().unwrap()), Some(Key::MapVal(*map, *map_ty)))
+            },
+            Len { map_ty, dst, map } => f(Key::Reg(*dst, Ty::Int), Some(Key::Reg(*map, *map_ty))),
+            Store { map_ty, map, key, val } => {
+                f(Key::MapKey(*map, *map_ty), Some(Key::Reg(*key, map_ty.key().unwrap())));
+                f(Key::MapVal(*map, *map_ty), Some(Key::Reg(*val, map_ty.val().unwrap())));
+            }
+            IterBegin { map_ty, dst, map } => {
+                f(Key::Reg(*dst, map_ty.key_iter().unwrap()), Some(Key::MapKey(*map, *map_ty)))
+            }
+            IterGetNext{iter_ty, dst, iter} => {
+                f(Key::Reg(*dst, iter_ty.iter().unwrap()), Some(Key::Reg(*iter, *iter_ty)));
+            }
+            LoadVarStr(dst, v) => f(dst.into(), Some(Key::Var(*v))),
+            LoadVarInt(dst, v) => f(dst.into(), Some(Key::Var(*v))),
+            LoadVarIntMap(dst, v) => {
+                let (dst_reg, dst_ty) = dst.reflect();
+                f(Key::MapKey(dst_reg, dst_ty), Some(Key::VarKey(*v)));
+                f(Key::MapVal(dst_reg, dst_ty), Some(Key::VarVal(*v)));
+            },
+            LoadVarStrMap(dst, v) => {
+                let (dst_reg, dst_ty) = dst.reflect();
+                f(Key::MapKey(dst_reg, dst_ty), Some(Key::VarKey(*v)));
+                f(Key::MapVal(dst_reg, dst_ty), Some(Key::VarVal(*v)));
+            },
+            StoreVarStr(v, src) => f(Key::Var(*v), Some(src.into())),
+            StoreVarInt(v, src) => f(Key::Var(*v), Some(src.into())),
+            StoreVarIntMap(v, src) => f(Key::Var(*v), Some(src.into())),
+            StoreVarStrMap(v, src) => f(Key::Var(*v), Some(src.into())),
+            LoadSlot{ty,slot,dst} =>
+                f(Key::Reg(*dst, *ty), Some(Key::Slot(u32::try_from(*slot).expect("slot too large"), *ty))),
+            StoreSlot{ty,slot,src} =>
+                f(Key::Slot(u32::try_from(*slot).expect("slot too large"), *ty), Some(Key::Reg(*src, *ty))),
+            Delete{..}
+            | PrintAll{..}
+            | Contains{..} // 0 or 1
+            | IterHasNext{..}
+            | JmpIf(..)
+            | Jmp(_)
+            | Halt
+            | Push(..)
+            | Pop(..)
+            // We consume high-level instructions, so calls and returns are handled by visit_hl
+            // above
+            | Call(_)
+            | Ret
+            | Printf { .. }
+            | Close(_)
+            | NextLineStdinFused()
+            | NextFile()
+            | SetColumn(_, _)
+            | AllocMap(_, _) => {}
+        }
+    }
+}

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -43,6 +43,7 @@ impl<K, J: JoinSemiLattice> Default for Analysis<J, K> {
     }
 }
 
+// TODO: remove this bound
 impl<K: Eq + Hash, J: JoinSemiLattice> Analysis<J, K> {
     pub(crate) fn add_src(&mut self, k: impl Into<K>, mut v: J) {
         let ix = self.get_node(k);
@@ -67,13 +68,15 @@ impl<K: Eq + Hash, J: JoinSemiLattice> Analysis<J, K> {
         let ix = self.get_node(k);
         self.queries.insert(ix);
     }
+
+    /// Call "solve" ahead of time to get a stable value here.
     pub(crate) fn query(&mut self, k: impl Into<K>) -> &J {
         let ix = self.get_node(k);
         assert!(self.queries.contains(&ix));
-        self.solve();
         self.graph.node_weight(ix).unwrap()
     }
-    /// The join of all of the queries
+
+    /// Solves the constraints, then returns the join of all the queries.
     pub(crate) fn root(&mut self) -> &J {
         self.solve();
         self.graph.node_weight(self.sentinel).unwrap()
@@ -133,7 +136,7 @@ where
     }
 }
 
-// TODO: wire into used_fields
+// TODO: loads/stores _of maps_ need to be bidirectional, because maps are referencey.
 // TODO: wire into string constants
 
 pub(crate) mod boilerplate {

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -43,7 +43,6 @@ impl<K, J: JoinSemiLattice> Default for Analysis<J, K> {
     }
 }
 
-// TODO: remove this bound
 impl<K: Eq + Hash, J: JoinSemiLattice> Analysis<J, K> {
     pub(crate) fn add_src(&mut self, k: impl Into<K>, mut v: J) {
         let ix = self.get_node(k);

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -321,7 +321,7 @@ pub(crate) mod boilerplate {
                 key,
             } => {
                 // lookups are also writes to the keys
-                f(Key::MapKey(*map, *map_ty), Some(Key::Reg(*key, map_ty.val().unwrap())));
+                f(Key::MapKey(*map, *map_ty), Some(Key::Reg(*key, map_ty.key().unwrap())));
                 // a null value will be inserted as a value into the map
                 f(Key::MapVal(*map, *map_ty), None);
                 f(Key::Reg(*dst, map_ty.val().unwrap()), Some(Key::MapVal(*map, *map_ty)))
@@ -363,6 +363,8 @@ pub(crate) mod boilerplate {
             StoreSlot{ty,slot,src} =>
                 f(Key::Slot(u32::try_from(*slot).expect("slot too large"), *ty), Some(Key::Reg(*src, *ty))),
             Delete{..}
+            | UpdateUsedFields()
+            | SetFI(..)
             | PrintAll{..}
             | Contains{..} // 0 or 1
             | IterHasNext{..}

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -339,25 +339,24 @@ pub(crate) mod boilerplate {
             }
             LoadVarStr(dst, v) => f(dst.into(), Some(Key::Var(*v))),
             LoadVarInt(dst, v) => f(dst.into(), Some(Key::Var(*v))),
-            LoadVarIntMap(dst, v) => {
-                let (dst_reg, dst_ty) = dst.reflect();
+            StoreVarIntMap(v, reg) | LoadVarIntMap(reg, v) => {
+                let (reg, ty) = reg.reflect();
 
-                f(Key::MapKey(dst_reg, dst_ty), Some(Key::VarKey(*v)));
-                f(Key::MapVal(dst_reg, dst_ty), Some(Key::VarVal(*v)));
-                f(Key::VarKey(*v), Some(Key::MapKey(dst_reg, dst_ty)));
-                f(Key::VarVal(*v), Some(Key::MapVal(dst_reg, dst_ty)));
+                f(Key::MapKey(reg, ty), Some(Key::VarKey(*v)));
+                f(Key::MapVal(reg, ty), Some(Key::VarVal(*v)));
+                f(Key::VarKey(*v), Some(Key::MapKey(reg, ty)));
+                f(Key::VarVal(*v), Some(Key::MapVal(reg, ty)));
             },
-            LoadVarStrMap(dst, v) => {
-                let (dst_reg, dst_ty) = dst.reflect();
-                f(Key::MapKey(dst_reg, dst_ty), Some(Key::VarKey(*v)));
-                f(Key::MapVal(dst_reg, dst_ty), Some(Key::VarVal(*v)));
-                f(Key::VarKey(*v), Some(Key::MapKey(dst_reg, dst_ty)));
-                f(Key::VarVal(*v), Some(Key::MapVal(dst_reg, dst_ty)));
+            StoreVarStrMap(v, reg) | LoadVarStrMap(reg, v) => {
+                let (reg, ty) = reg.reflect();
+
+                f(Key::MapKey(reg, ty), Some(Key::VarKey(*v)));
+                f(Key::MapVal(reg, ty), Some(Key::VarVal(*v)));
+                f(Key::VarKey(*v), Some(Key::MapKey(reg, ty)));
+                f(Key::VarVal(*v), Some(Key::MapVal(reg, ty)));
             },
             StoreVarStr(v, src) => f(Key::Var(*v), Some(src.into())),
             StoreVarInt(v, src) => f(Key::Var(*v), Some(src.into())),
-            StoreVarIntMap(v, src) => f(Key::Var(*v), Some(src.into())),
-            StoreVarStrMap(v, src) => f(Key::Var(*v), Some(src.into())),
             LoadSlot{ty,slot,dst} =>
                 f(Key::Reg(*dst, *ty), Some(Key::Slot(u32::try_from(*slot).expect("slot too large"), *ty))),
             StoreSlot{ty,slot,src} =>

--- a/src/display.rs
+++ b/src/display.rs
@@ -206,6 +206,7 @@ impl Display for Variable {
                 RSTART => "RSTART",
                 RLENGTH => "RLENGTH",
                 PID => "PID",
+                FI => "FI",
             }
         )
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -182,6 +182,8 @@ impl Display for Function {
             Srand => write!(f, "srand"),
             ReseedRng => write!(f, "srand_reseed"),
             System => write!(f, "system"),
+            UpdateUsedFields => write!(f, "update_used_fields"),
+            SetFI => write!(f, "set-FI"),
         }
     }
 }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -261,6 +261,15 @@ pub(crate) fn bench_program(
     run_prog_nodebug(&mut interp, stdout)
 }
 
+pub(crate) fn program_compiles(prog: &str, allow_arbitrary: bool) -> Result<()> {
+    let a = Arena::default();
+    let esc = Escaper::Identity;
+    let stmt = parse_program(prog, &a, esc, ExecutionStrategy::Serial)?;
+    let mut ctx = cfg::ProgramContext::from_prog(&a, stmt, esc)?;
+    ctx.allow_arbitrary_commands = allow_arbitrary;
+    compile::context_compiles(&mut ctx)
+}
+
 pub(crate) fn used_fields(prog: &str) -> Result<FieldSet> {
     let a = Arena::default();
     let esc = Escaper::Identity;

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -570,6 +570,15 @@ mod tests {
         assert_eq!(s1, used_fields(p1).unwrap());
     }
 
+    #[test]
+    fn used_fields_global_variable_store_poisons() {
+        // frawk used to get this one wrong and build a used-field set of {2}.
+        let p1 = r#"function unused() { print x; } { x=2; x=NF; print $x; }"#;
+        let s1 = FieldSet::all();
+        assert_eq!(s1, used_fields(p1).unwrap());
+    }
+
+
     test_program_parallel!(
         parallel_aggs,
         ShardPerFile,

--- a/src/input_taint.rs
+++ b/src/input_taint.rs
@@ -49,7 +49,7 @@ use crate::compile::HighLevel;
 use crate::dataflow::{self, JoinSemiLattice};
 
 /// aka bool, with join = ||; making our own enum for explicitness.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum Taint {
     Tainted,
     Okay,

--- a/src/input_taint.rs
+++ b/src/input_taint.rs
@@ -146,7 +146,6 @@ impl TaintedStringAnalysis {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::Result;
     use crate::harness::program_compiles;
 
     fn assert_analysis_reject(p: &str) {

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1154,6 +1154,16 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         let s = self.get(src).clone();
                         self.core.vars.store_intmap(*var, s)?;
                     }
+                    LoadVarStrMap(dst, var) => {
+                        let arr = self.core.vars.load_strmap(*var)?;
+                        let dst = *dst;
+                        *self.get_mut(dst) = arr;
+                    }
+                    StoreVarStrMap(var, src) => {
+                        let src = *src;
+                        let s = self.get(src).clone();
+                        self.core.vars.store_strmap(*var, s)?;
+                    }
 
                     IterBegin { map_ty, map, dst } => self.iter_begin(*map_ty, *map, *dst),
                     IterHasNext { iter_ty, dst, iter } => self.iter_has_next(*iter_ty, *dst, *iter),

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -153,6 +153,8 @@ impl<'a> Core<'a> {
         let rs: UniqueStr<'a> = self.vars.rs.clone().into();
         let ors: UniqueStr<'a> = self.vars.ors.clone().into();
         let filename: UniqueStr<'a> = self.vars.filename.clone().into();
+        let argv = self.vars.argv.shuttle();
+        let fi = self.vars.fi.shuttle();
         let slots = self.slots.clone();
         move || {
             let vars = Variables {
@@ -168,7 +170,8 @@ impl<'a> Core<'a> {
                 rstart: 0,
                 rlength: 0,
                 argc: 0,
-                argv: Default::default(),
+                argv: argv.into(),
+                fi: fi.into(),
             };
             Core {
                 vars,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1975,6 +1975,21 @@ impl<'a> View<'a> {
                 let sv = self.get_local(src.reflect())?;
                 self.call("store_var_intmap", &mut [self.runtime_val(), v, sv]);
             }
+            LoadVarStrMap(dst, var) => {
+                let v = self.var_val(var);
+                let res = self.call("load_var_strmap", &mut [self.runtime_val(), v]);
+                // See the comment in the LoadVarStr case.
+                let dreg = dst.reflect();
+                self.bind_val(dreg, res);
+                if self.is_global(dreg) {
+                    self.drop_reg(dreg)?;
+                }
+            }
+            StoreVarStrMap(var, src) => {
+                let v = self.var_val(var);
+                let sv = self.get_local(src.reflect())?;
+                self.call("store_var_strmap", &mut [self.runtime_val(), v, sv]);
+            }
 
             LoadSlot { ty, dst, slot } => self.load_slot((*dst, *ty), *slot),
             StoreSlot { ty, src, slot } => self.store_slot((*src, *ty), *slot)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ pub mod bytecode;
 pub mod cfg;
 pub mod compile;
 pub mod cross_stage;
+pub mod dataflow;
 mod display;
 pub mod dom;
 #[cfg(test)]

--- a/src/pushdown.rs
+++ b/src/pushdown.rs
@@ -41,21 +41,8 @@
 //!     GetCol(dst, 0)
 //!
 //! Which corresponds roughly to the AWK snippet `$$2`, or "the field corresponding to the value of
-//! the second column." We cannot predict this value ahead of time, but our rules do not generate
-//! any constraints for the StrToInt instruction, or for any number of other instructions that can
-//! assign to integer registers. If we apply the algorithm as written, register 0 will have no
-//! incoming edges, and so will contribute no fields to the dst register, thereby producing false
-//! negatives.
-//!
-//! The most direct solution here would be to contribute "full sets" (sets that contain all
-//! possible fields --- [FieldSet::all] below) to any register stored to by an instruction other
-//! than StoreConstInt, MovInt, or Phi. This would work, but it would require a lot more code, and
-//! we would have to continually update the analysis code as we added or removed instructions from
-//! the bytecode.
-//!
-//! Instead, we do this implicitly by detecting nodes with no incoming edges that have empty field
-//! sets. These nodes are replaced with full sets during iteration; the algorithm treats these
-//! jumps like standard updates for now, though they could probably be shortcircuited in some way.
+//! the second column." We cannot predict this value ahead of time, for cases like this, we
+//! contribute "full" sets to registers written by primitives that our analysis cannot introspect.
 
 use std::fmt;
 

--- a/src/pushdown.rs
+++ b/src/pushdown.rs
@@ -227,6 +227,7 @@ impl Default for UsedFieldAnalysis {
             dfa: Default::default(),
             joins: Default::default(),
         };
+        res.dfa.add_src(Key::Rng, FieldSet::all());
         res.dfa.add_src(Key::VarVal(Variable::FI), FieldSet::fi());
         res.dfa.add_src(Key::VarKey(Variable::FI), FieldSet::all());
         res

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -413,6 +413,11 @@ pub(crate) struct Inputs {
     commands: Registry<RegexSplitter<ChildStdout>>,
 }
 
+// TODO: save used_fields
+// TODO: save columns
+// TODO: supply an "update used fields" that takes FI
+//
+
 pub(crate) struct FileRead<LR = RegexSplitter<Box<dyn io::Read + Send>>> {
     pub(crate) inputs: Inputs,
     stdin: LR,
@@ -444,6 +449,8 @@ impl<LR: LineReader> FileRead<LR> {
         res.stdin.set_used_fields(used_fields);
         res
     }
+
+    // pub(crate) fn update_named_columns(&mut self)
 
     pub(crate) fn stdin_filename(&self) -> Str<'static> {
         self.stdin.filename()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -771,7 +771,6 @@ impl<K: Hash + Eq + Clone, V> SharedMap<K, V> {
     pub(crate) fn to_iter(&self) -> Iter<K> {
         self.0.borrow().keys().cloned().collect()
     }
-    #[cfg(feature = "llvm_backend")]
     pub(crate) fn to_vec(&self) -> Vec<K> {
         self.0.borrow().keys().cloned().collect()
     }

--- a/src/runtime/splitter/mod.rs
+++ b/src/runtime/splitter/mod.rs
@@ -60,7 +60,7 @@ pub trait LineReader: Sized {
     }
     fn read_state(&self) -> i64;
     fn next_file(&mut self) -> Result<bool>;
-    fn set_used_fields(&mut self, _used_fields: &FieldSet);
+    fn set_used_fields(&mut self, used_fields: &FieldSet);
     // Whether or not this LineReader is configured to check for valid UTF-8. This is used to
     // propagate consistent options across multiple LineReader instances.
     fn check_utf8(&self) -> bool;

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -318,6 +318,10 @@ impl<'a> UniqueStr<'a> {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    // TODO: is this safe for INLINE values?
+    // Seems like we aren't guaranteed that inlines are valid for all of <'a>
+    // We probably just want to use Strs
     pub fn literal_bytes(&self) -> &'a [u8] {
         assert!(self.0.drop_is_trivial());
         unsafe { &*self.0.get_bytes() }

--- a/tests/nawk_p.rs
+++ b/tests/nawk_p.rs
@@ -16,7 +16,10 @@ use std::fs::{read_to_string, File};
 use std::io::Write;
 use tempfile::tempdir;
 
+#[cfg(feature = "llvm_backend")]
 const BACKEND_ARGS: &'static [&'static str] = &["-b", "-O3"];
+#[cfg(not(feature = "llvm_backend"))]
+const BACKEND_ARGS: &'static [&'static str] = &["-b"];
 
 const COUNTRIES: &'static str = r#"Russia	8650	262	Asia
 Canada	3852	24	North America

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -18,7 +18,11 @@ fn numbers_str(n: usize) -> (String, String) {
 }
 
 const N: usize = 10_000;
+
+#[cfg(feature = "llvm_backend")]
 const BACKEND_ARGS: &'static [&'static str] = &["-b", "-O3"];
+#[cfg(not(feature = "llvm_backend"))]
+const BACKEND_ARGS: &'static [&'static str] = &["-b"];
 
 #[cfg(not(target_os = "windows"))]
 #[test]

--- a/tests/string_constants.rs
+++ b/tests/string_constants.rs
@@ -1,0 +1,78 @@
+use assert_cmd::Command;
+use std::fs::File;
+use std::io::Write;
+use tempfile::tempdir;
+
+const BACKEND_ARGS: &'static [&'static str] = &["-b", "-O3"];
+
+// A simple function that looks for the "constant folded" regex instructions in the generated
+// output. This is a function that is possible to fool: test cases should be mindful of how it is
+// implemented to ensure it is testing what is intended.
+fn assert_folded(p: &str) {
+    let prog: String = p.into();
+    let out = String::from_utf8(
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(prog.clone())
+            .arg(String::from("--dump-bytecode"))
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert!(out.contains("MatchConst"))
+}
+
+#[test]
+fn constant_regex_folded() {
+    // NB: 'function unused()' forces `x` to be global
+    let prog: String = r#"function unused() { print x; }
+BEGIN {
+    x = "hi";
+    x=ARGV[1];
+    print("h" ~ x);
+}"#
+    .into();
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(prog.clone())
+            .arg(String::from("h"))
+            .assert()
+            .stdout(String::from("1\n"));
+    }
+    assert_folded(
+        r#"function unused() { print x; }
+    BEGIN { x = "hi"; print("h" ~ x); }"#,
+    );
+    assert_folded(r#"BEGIN { x = "hi"; x = "there"; print("h" ~ x); }"#);
+}
+
+#[test]
+fn simple_fi() {
+    let input = r#"Item,Count
+    carrots,2
+    potato chips,3
+    custard,1"#;
+    let expected = "6.0 3\n";
+
+    let tmpdir = tempdir().unwrap();
+    let data_fname = tmpdir.path().join("numbers");
+    {
+        let mut file = File::create(data_fname.clone()).unwrap();
+        file.write(input.as_bytes()).unwrap();
+    }
+    let prog: String = r#"{n+=$FI["Count"]} END { print n, NR; }"#.into();
+    for backend_arg in BACKEND_ARGS {
+        Command::cargo_bin("frawk")
+            .unwrap()
+            .arg(String::from(*backend_arg))
+            .arg(String::from("-icsv"))
+            .arg(String::from("-H"))
+            .arg(prog.clone())
+            .arg(data_fname.clone().into_os_string().into_string().unwrap())
+            .assert()
+            .stdout(expected.clone());
+    }
+}


### PR DESCRIPTION
This PR implements the feature request #31. You can now skip the header line by passing the `-H` flag and then access fields by name by looking up the column name in new builtin `FI` variable. The core challenge here is to integrate the new `FI`-related functionality  _without_ completely trivializing the fields inferred in the projection pushdown analysis.

I went about this by adding to the constant string analysis already used to eliminate regex lookups to gathering a set of strings passed as keys to `FI`. We need corresponding changes in the used field analysis to ensure we "look the other way" when accessing a field that comes from a value in `FI`. After all of that is done, special runtime primitives munge the relevant column indexes gleaned from the header line into the used field set we are using at runtime. This avoids complicated schemes where we run custom logic on the first line of input before yielding control back to the frawk program.

All of this was complicated by the fact that I discovered some soundness issues in the existing dataflow analyses that had been implemented so far. This PR includes fixes and tests for those issues, and unifies the implementations in a common framework so that future bugs will only have to be fixed once.