### PR TITLE
Fix usage of '-v' args as last argument before program.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,7 @@ fn main() {
              .short('v')
              .multiple(true)
              .takes_value(true)
+             .number_of_values(1)
              .about("Has the form <identifier>=<expr>"))
         .arg("-F, --field-separator=[SEPARATOR] 'Field separator for frawk program.'")
         .arg(Arg::new("backend")

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -105,8 +105,7 @@ fn simple_fi() {
 }
 
 mod v_args {
-    //! Tests for v args. For now, we require "--" to separate the `v`s from the program. This appears
-    //! to be a clap limitation.
+    //! Tests for v args.
     use super::*;
 
     #[test]
@@ -118,7 +117,6 @@ mod v_args {
                 .unwrap()
                 .arg(String::from(*backend_arg))
                 .arg(String::from("-vx=1"))
-                .arg(String::from("--"))
                 .arg(prog.clone())
                 .assert()
                 .stdout(expected.clone());
@@ -134,7 +132,6 @@ mod v_args {
                 .unwrap()
                 .arg(String::from(*backend_arg))
                 .arg(String::from("-vx=var-with-dash"))
-                .arg(String::from("--"))
                 .arg(prog.clone())
                 .assert()
                 .stdout(expected.clone());
@@ -151,7 +148,6 @@ mod v_args {
                 .arg(String::from(*backend_arg))
                 .arg(String::from("-vx=var-with\\n-dash"))
                 .arg(String::from("-vy=1+1"))
-                .arg(String::from("--"))
                 .arg(prog.clone())
                 .assert()
                 .stdout(expected.clone());


### PR DESCRIPTION
Fix usage of '-v' args as last argument before program.
Now it is not needed anymore to have another option after
'-v' or to have '--' before the program part.

As indicated in the clap documentation for Arg::multiple:
  Setting multiple(true) for an option with no other details,
  allows multiple values and multiple occurrences because it
  isn't possible to have more occurrences than values for options.
  Because multiple values are allowed, --option val1 val2 val3 is
  perfectly valid, be careful when designing a CLI where positional
  arguments are expected after a option which accepts multiple
  values, as clap will continue parsing values until it reaches the
  max or specific number of values defined, or another flag or
  option.

  It's possible to define an option which allows multiple
  occurrences, but only one value per occurrence. To do this use
  Arg::number_of_values(1) in coordination with Arg::multiple(true).