### PR TITLE
Speed up column mutation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hashbrown = "0.9"
 stable_deref_trait = "1.1.1"
 lazy_static = "1.4.0"
 regex = "1.3"
+regex-syntax = "0.6.22"
 ryu = "1.0"
 libc = "0.2"
 jemallocator = { version = "0.3", optional = true }

--- a/info/scripts/complex_sum.sh
+++ b/info/scripts/complex_sum.sh
@@ -1,7 +1,7 @@
 # Sum 2 numeric fields
 RUST=./complex_sum/target/release/complex_sum
 PYTHON="python3 ./complex_sum.py"
-FRAWK=frawk
+FRAWK=../frawk
 
 CSV=../TREE_GRM_ESTN.csv
 FRAWK_SCRIPT='function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }'
@@ -16,4 +16,3 @@ for i in {1..5}; do
 	time $FRAWK -bllvm -icsv -pr -j3 "$FRAWK_SCRIPT" "$CSV"
 	set +x
 done
-

--- a/info/scripts/complex_sum.sh.out
+++ b/info/scripts/complex_sum.sh.out
@@ -1,185 +1,185 @@
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m30.533s
-user	0m28.755s
-sys	0m1.723s
+real	0m30.903s
+user	0m29.127s
+sys	0m1.776s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	2m24.096s
-user	2m21.644s
-sys	0m2.448s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m16.683s
+user	2m14.826s
+sys	0m1.856s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m30.561s
-user	0m28.505s
-sys	0m2.056s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.77372366556336e18
-
-real	0m9.587s
-user	0m34.596s
-sys	0m3.588s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665564369e18
-
-real	0m29.331s
-user	0m27.383s
-sys	0m1.948s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m28.779s
+user	0m26.811s
+sys	0m1.968s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665563365e18
 
-real	0m9.564s
-user	0m34.627s
-sys	0m3.323s
+real	0m9.999s
+user	0m35.574s
+sys	0m3.748s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m27.970s
+user	0m26.286s
+sys	0m1.684s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563372e18
+
+real	0m9.484s
+user	0m33.904s
+sys	0m3.536s
 + set +x
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m30.481s
-user	0m28.528s
-sys	0m1.952s
+real	0m30.052s
+user	0m28.428s
+sys	0m1.624s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	2m19.940s
-user	2m17.763s
-sys	0m2.176s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m20.382s
+user	2m18.402s
+sys	0m1.968s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m30.755s
-user	0m28.795s
-sys	0m1.961s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563391e18
+real	0m29.638s
+user	0m27.643s
+sys	0m1.996s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563329e18
 
-real	0m9.557s
-user	0m34.595s
-sys	0m3.471s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m10.063s
+user	0m36.295s
+sys	0m3.557s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m29.263s
-user	0m27.403s
-sys	0m1.861s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563359e18
+real	0m29.184s
+user	0m27.228s
+sys	0m1.956s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563361e18
 
-real	0m9.930s
-user	0m36.307s
-sys	0m3.111s
+real	0m10.559s
+user	0m36.174s
+sys	0m4.741s
 + set +x
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m30.986s
-user	0m29.213s
-sys	0m1.772s
+real	0m30.098s
+user	0m28.562s
+sys	0m1.536s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	2m25.080s
-user	2m22.843s
-sys	0m2.236s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m16.225s
+user	2m14.173s
+sys	0m2.040s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m29.760s
-user	0m27.980s
-sys	0m1.780s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563414e18
+real	0m31.118s
+user	0m29.061s
+sys	0m2.056s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563379e18
 
-real	0m9.335s
-user	0m34.499s
-sys	0m2.741s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m9.986s
+user	0m35.623s
+sys	0m3.856s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m29.505s
-user	0m28.068s
+real	0m28.446s
+user	0m26.750s
+sys	0m1.696s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563342e18
+
+real	0m9.584s
+user	0m34.113s
+sys	0m3.641s
++ set +x
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m30.730s
+user	0m29.291s
 sys	0m1.436s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563375e18
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
 
-real	0m9.768s
-user	0m35.026s
-sys	0m3.694s
+real	2m19.593s
+user	2m17.480s
+sys	0m2.104s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m27.944s
+user	0m26.212s
+sys	0m1.732s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563361e18
+
+real	0m9.406s
+user	0m34.473s
+sys	0m2.954s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m29.568s
+user	0m27.592s
+sys	0m1.976s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563312e18
+
+real	0m9.948s
+user	0m34.869s
+sys	0m4.110s
 + set +x
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m30.465s
-user	0m28.584s
-sys	0m1.880s
+real	0m31.210s
+user	0m29.421s
+sys	0m1.788s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	2m18.552s
-user	2m16.597s
-sys	0m1.952s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m17.538s
+user	2m15.348s
+sys	0m2.188s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m29.987s
-user	0m27.823s
-sys	0m2.164s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563355e18
+real	0m28.357s
+user	0m26.277s
+sys	0m2.080s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563452e18
 
-real	0m9.325s
-user	0m34.342s
-sys	0m2.843s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m9.742s
+user	0m35.255s
+sys	0m3.438s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m29.518s
-user	0m27.866s
-sys	0m1.652s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563286e18
+real	0m27.850s
+user	0m25.806s
+sys	0m2.044s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563395e18
 
-real	0m9.302s
-user	0m33.986s
-sys	0m3.052s
-+ set +x
-+ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
-4773723665564369000
-
-real	0m30.509s
-user	0m28.956s
-sys	0m1.552s
-+ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
-4.773723665564369e+18
-
-real	2m20.341s
-user	2m18.483s
-sys	0m1.856s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665564369e18
-
-real	0m30.758s
-user	0m28.745s
-sys	0m2.012s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563356e18
-
-real	0m9.961s
-user	0m36.139s
-sys	0m3.493s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665564369e18
-
-real	0m30.223s
-user	0m28.091s
-sys	0m2.133s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563384e18
-
-real	0m9.548s
-user	0m34.707s
-sys	0m3.241s
+real	0m9.721s
+user	0m34.802s
+sys	0m3.546s
 + set +x

--- a/info/scripts/complex_sum.sh.out.mac
+++ b/info/scripts/complex_sum.sh.out.mac
@@ -1,185 +1,185 @@
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m29.526s
-user	0m27.984s
-sys	0m1.514s
+real	0m29.685s
+user	0m28.111s
+sys	0m1.546s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	2m50.633s
-user	2m49.135s
-sys	0m1.439s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m49.369s
+user	2m47.893s
+sys	0m1.442s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.977s
-user	0m20.763s
-sys	0m1.141s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563384e18
+real	0m21.233s
+user	0m20.089s
+sys	0m1.140s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563383e18
 
-real	0m6.337s
-user	0m24.054s
-sys	0m1.241s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m6.110s
+user	0m23.185s
+sys	0m1.202s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.447s
-user	0m20.283s
-sys	0m1.124s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563385e18
+real	0m20.877s
+user	0m19.738s
+sys	0m1.137s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563387e18
 
-real	0m6.172s
-user	0m23.370s
-sys	0m1.196s
+real	0m6.002s
+user	0m22.672s
+sys	0m1.207s
 + set +x
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m28.322s
-user	0m27.234s
-sys	0m1.085s
+real	0m28.416s
+user	0m27.301s
+sys	0m1.110s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	2m49.477s
-user	2m48.054s
-sys	0m1.408s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	3m7.042s
+user	3m5.412s
+sys	0m1.585s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.885s
-user	0m20.756s
-sys	0m1.126s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m23.953s
+user	0m22.642s
+sys	0m1.304s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.77372366556339e18
+
+real	0m7.397s
+user	0m27.942s
+sys	0m1.520s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m23.619s
+user	0m22.303s
+sys	0m1.310s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563383e18
+
+real	0m7.279s
+user	0m27.416s
+sys	0m1.501s
++ set +x
++ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
+4773723665564369000
+
+real	0m32.158s
+user	0m30.858s
+sys	0m1.292s
++ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
+4.773723665564369e+18
+
+real	3m0.253s
+user	2m58.692s
+sys	0m1.536s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665564369e18
+
+real	0m21.213s
+user	0m20.079s
+sys	0m1.130s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.77372366556338e18
 
-real	0m6.325s
-user	0m24.060s
-sys	0m1.192s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m6.358s
+user	0m24.150s
+sys	0m1.230s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.395s
-user	0m20.268s
-sys	0m1.124s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m21.034s
+user	0m19.889s
+sys	0m1.140s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665563384e18
 
-real	0m6.161s
-user	0m23.317s
-sys	0m1.192s
+real	0m6.017s
+user	0m22.743s
+sys	0m1.200s
 + set +x
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m28.214s
-user	0m27.127s
-sys	0m1.084s
+real	0m28.561s
+user	0m27.437s
+sys	0m1.120s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	3m9.757s
-user	2m48.904s
-sys	0m1.429s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m55.114s
+user	2m53.565s
+sys	0m1.528s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.879s
-user	0m20.743s
-sys	0m1.130s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563359e18
+real	0m21.861s
+user	0m20.673s
+sys	0m1.177s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563396e18
 
-real	0m6.505s
-user	0m24.756s
-sys	0m1.215s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m6.429s
+user	0m24.344s
+sys	0m1.284s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.392s
-user	0m20.255s
-sys	0m1.133s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563382e18
+real	0m21.468s
+user	0m20.300s
+sys	0m1.165s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563383e18
 
-real	0m6.174s
-user	0m23.398s
-sys	0m1.184s
+real	0m6.320s
+user	0m23.823s
+sys	0m1.269s
 + set +x
 + ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
 4773723665564369000
 
-real	0m28.393s
-user	0m27.283s
-sys	0m1.098s
+real	0m29.170s
+user	0m28.020s
+sys	0m1.140s
 + python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
 4.773723665564369e+18
 
-real	15m34.426s # note: laptop become unplugged here; we take the minimum so this outlier didn't meaningfully change the output
-user	2m49.604s
-sys	0m1.466s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	2m55.621s
+user	2m54.037s
+sys	0m1.540s
++ ../frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m22.283s
-user	0m21.108s
-sys	0m1.164s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563379e18
+real	0m21.947s
+user	0m20.684s
+sys	0m1.180s
++ ../frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.77372366556338e18
 
-real	0m6.470s
-user	0m24.562s
-sys	0m1.257s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+real	0m6.377s
+user	0m24.174s
+sys	0m1.278s
++ ../frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
 4.773723665564369e18
 
-real	0m21.828s
-user	0m20.656s
-sys	0m1.166s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563384e18
+real	0m21.573s
+user	0m20.351s
+sys	0m1.178s
++ ../frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
+4.773723665563383e18
 
-real	0m6.243s
-user	0m23.634s
-sys	0m1.222s
-+ set +x
-+ ./complex_sum/target/release/complex_sum ../TREE_GRM_ESTN.csv
-4773723665564369000
-
-real	0m28.521s
-user	0m27.402s
-sys	0m1.113s
-+ python3 ./complex_sum.py ../TREE_GRM_ESTN.csv
-4.773723665564369e+18
-
-real	3m17.255s
-user	3m15.899s
-sys	0m1.340s
-+ frawk -bcranelift -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665564369e18
-
-real	0m21.715s
-user	0m20.600s
-sys	0m1.110s
-+ frawk -bcranelift -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563381e18
-
-real	0m6.334s
-user	0m24.079s
-sys	0m1.204s
-+ frawk -bllvm -icsv 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665564369e18
-
-real	0m21.211s
-user	0m20.095s
-sys	0m1.112s
-+ frawk -bllvm -icsv -pr -j3 'function max(x,y) { return x<y?y:x; } "GS" == $8 { accum += (0.5*$1+0.5*max($4+0,$5+0))/1000.0 } END { print accum; }' ../TREE_GRM_ESTN.csv
-4.773723665563378e18
-
-real	0m6.115s
-user	0m23.155s
-sys	0m1.185s
+real	0m6.292s
+user	0m23.764s
+sys	0m1.263s
 + set +x

--- a/info/scripts/filter.sh
+++ b/info/scripts/filter.sh
@@ -1,9 +1,9 @@
 # Filter fields in all_train based on numeric values
-MAWK=mawk
-GAWK=gawk
+MAWK=../mawk
+GAWK="../gawk -b"
 TSV_UTILS_BIN=../bin
 XSV=xsv
-FRAWK=frawk
+FRAWK=../frawk
 
 CSV1=../all_train.csv
 CSV2=../TREE_GRM_ESTN.csv
@@ -20,14 +20,14 @@ for i in {1..5}; do
 	time $MAWK -F'\t' "$AWK_SCRIPT" "$TSV1" > /dev/null
 	time $GAWK -F,    "$AWK_SCRIPT" "$CSV1" > /dev/null
 	time $GAWK -F'\t' "$AWK_SCRIPT" "$TSV1" > /dev/null
-	time $FRAWK -bllvm -icsv --out-file=/dev/null "$AWK_SCRIPT" "$CSV1" 
-	time $FRAWK -bllvm -itsv --out-file=/dev/null "$AWK_SCRIPT" "$TSV1" 
-	time $FRAWK -bllvm -icsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT" "$CSV1" 
-	time $FRAWK -bllvm -itsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT" "$TSV1" 
-	time $FRAWK -bcranelift -icsv --out-file=/dev/null "$AWK_SCRIPT" "$CSV1" 
-	time $FRAWK -bcranelift -itsv --out-file=/dev/null "$AWK_SCRIPT" "$TSV1" 
-	time $FRAWK -bcranelift -icsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT" "$CSV1" 
-	time $FRAWK -bcranelift -itsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT" "$TSV1" 
+	time $FRAWK -bllvm -icsv "$AWK_SCRIPT" "$CSV1"  > /dev/null
+	time $FRAWK -bllvm -itsv "$AWK_SCRIPT" "$TSV1"  > /dev/null
+	time $FRAWK -bllvm -icsv -pr -j3 "$AWK_SCRIPT" "$CSV1"  > /dev/null
+	time $FRAWK -bllvm -itsv -pr -j3 "$AWK_SCRIPT" "$TSV1"  > /dev/null
+	time $FRAWK -bcranelift -icsv "$AWK_SCRIPT" "$CSV1" > /dev/null
+	time $FRAWK -bcranelift -itsv "$AWK_SCRIPT" "$TSV1" > /dev/null
+	time $FRAWK -bcranelift -icsv -pr -j3 "$AWK_SCRIPT" "$CSV1" > /dev/null
+	time $FRAWK -bcranelift -itsv -pr -j3 "$AWK_SCRIPT" "$TSV1" > /dev/null
 	time $TSV_UTILS_BIN/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 "$TSV1" > /dev/null
 	set +x
 done

--- a/info/scripts/filter.sh.out
+++ b/info/scripts/filter.sh.out
@@ -1,330 +1,330 @@
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.933s
-user	0m9.430s
-sys	0m1.468s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m10.412s
+user	0m8.960s
+sys	0m1.452s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.930s
-user	0m8.965s
-sys	0m1.955s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m10.768s
+user	0m9.440s
+sys	0m1.328s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m42.911s
-user	0m41.598s
-sys	0m1.312s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.542s
+user	0m8.171s
+sys	0m1.372s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m42.843s
-user	0m41.363s
-sys	0m1.480s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m9.659s
+user	0m8.343s
+sys	0m1.316s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m8.480s
-user	0m8.672s
-sys	0m2.603s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.756s
+user	0m6.767s
+sys	0m1.369s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m8.210s
-user	0m8.516s
-sys	0m2.341s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.441s
+user	0m6.425s
+sys	0m1.421s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m4.698s
-user	0m14.500s
-sys	0m4.530s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m4.937s
+user	0m14.629s
+sys	0m3.740s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m4.122s
-user	0m13.889s
-sys	0m3.594s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m4.448s
+user	0m13.665s
+sys	0m3.185s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m8.323s
-user	0m8.695s
-sys	0m2.429s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m8.130s
+user	0m7.286s
+sys	0m1.283s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m8.235s
-user	0m8.410s
-sys	0m2.604s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.477s
+user	0m6.483s
+sys	0m1.370s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m4.741s
-user	0m14.917s
-sys	0m4.419s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m5.067s
+user	0m14.286s
+sys	0m3.832s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m4.251s
-user	0m14.165s
-sys	0m3.668s
+real	0m4.825s
+user	0m13.952s
+sys	0m3.840s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m3.651s
-user	0m2.753s
-sys	0m0.880s
+real	0m3.885s
+user	0m2.885s
+sys	0m1.001s
 + set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m9.706s
-user	0m8.538s
-sys	0m1.168s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m10.245s
+user	0m8.865s
+sys	0m1.380s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.048s
-user	0m8.808s
-sys	0m1.240s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m10.939s
+user	0m9.463s
+sys	0m1.476s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m42.957s
-user	0m42.008s
-sys	0m0.948s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.552s
+user	0m8.124s
+sys	0m1.428s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m43.484s
-user	0m42.214s
-sys	0m1.268s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m9.568s
+user	0m8.340s
+sys	0m1.228s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m8.584s
-user	0m8.664s
-sys	0m2.744s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.743s
+user	0m6.764s
+sys	0m1.386s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m8.377s
-user	0m8.714s
-sys	0m2.358s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.473s
+user	0m6.529s
+sys	0m1.327s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m4.521s
-user	0m14.352s
-sys	0m4.087s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m5.097s
+user	0m14.185s
+sys	0m4.086s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m4.207s
-user	0m14.045s
-sys	0m3.732s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m4.371s
+user	0m13.666s
+sys	0m3.115s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m8.431s
-user	0m8.762s
-sys	0m1.939s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.673s
+user	0m6.642s
+sys	0m1.379s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m8.058s
-user	0m8.346s
-sys	0m2.455s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.568s
+user	0m6.600s
+sys	0m1.347s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m4.838s
-user	0m14.755s
-sys	0m4.735s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m4.875s
+user	0m13.735s
+sys	0m3.954s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m4.136s
-user	0m13.322s
-sys	0m4.106s
+real	0m4.368s
+user	0m13.455s
+sys	0m3.187s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m3.675s
-user	0m2.687s
-sys	0m0.988s
+real	0m3.494s
+user	0m2.693s
+sys	0m0.800s
 + set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.090s
-user	0m8.525s
-sys	0m1.564s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m10.202s
+user	0m8.978s
+sys	0m1.224s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.173s
-user	0m8.757s
-sys	0m1.416s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m10.910s
+user	0m9.406s
+sys	0m1.504s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m42.866s
-user	0m41.565s
-sys	0m1.300s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m41.854s
-user	0m40.442s
-sys	0m1.412s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m8.314s
-user	0m8.539s
-sys	0m2.585s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m8.258s
-user	0m8.352s
-sys	0m2.674s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m4.316s
-user	0m13.512s
-sys	0m4.210s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m4.230s
-user	0m14.066s
-sys	0m3.820s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m8.432s
-user	0m8.505s
-sys	0m2.052s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m7.977s
-user	0m8.303s
-sys	0m2.450s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m4.737s
-user	0m14.716s
-sys	0m4.506s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m4.135s
-user	0m13.540s
-sys	0m3.859s
-+ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
-
-real	0m3.488s
-user	0m2.692s
-sys	0m0.796s
-+ set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m10.428s
-user	0m9.280s
-sys	0m1.148s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m9.932s
-user	0m8.667s
-sys	0m1.264s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m42.775s
-user	0m41.699s
-sys	0m1.076s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m42.093s
-user	0m40.889s
-sys	0m1.204s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m8.112s
-user	0m8.581s
-sys	0m2.372s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m8.026s
-user	0m8.346s
-sys	0m2.460s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m4.707s
-user	0m14.438s
-sys	0m4.553s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m4.740s
-user	0m14.390s
-sys	0m4.547s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m8.194s
-user	0m8.490s
-sys	0m2.502s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m8.155s
-user	0m8.421s
-sys	0m2.531s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m5.030s
-user	0m14.892s
-sys	0m4.908s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m4.264s
-user	0m13.683s
-sys	0m4.186s
-+ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
-
-real	0m3.925s
-user	0m2.845s
-sys	0m1.081s
-+ set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m10.195s
-user	0m8.827s
-sys	0m1.368s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m10.178s
-user	0m8.801s
+real	0m9.509s
+user	0m8.133s
 sys	0m1.376s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m42.030s
-user	0m40.769s
-sys	0m1.260s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.506s
+user	0m8.170s
+sys	0m1.336s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m43.251s
-user	0m41.950s
-sys	0m1.300s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.695s
+user	0m6.693s
+sys	0m1.372s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m8.267s
-user	0m8.602s
-sys	0m2.475s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.676s
+user	0m6.791s
+sys	0m1.268s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m8.150s
-user	0m8.606s
-sys	0m2.345s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m4.792s
+user	0m14.150s
+sys	0m3.602s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m4.800s
-user	0m14.596s
-sys	0m4.536s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m4.403s
+user	0m13.394s
+sys	0m3.368s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m4.123s
-user	0m13.773s
-sys	0m3.633s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m8.794s
+user	0m7.776s
+sys	0m1.452s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m8.120s
-user	0m8.649s
-sys	0m2.252s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.677s
+user	0m6.637s
+sys	0m1.426s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.948s
-user	0m8.246s
-sys	0m2.424s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m4.634s
+user	0m13.617s
+sys	0m3.595s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m4.806s
-user	0m14.572s
-sys	0m4.618s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m4.235s
-user	0m13.876s
-sys	0m3.822s
+real	0m4.762s
+user	0m13.689s
+sys	0m3.721s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m3.554s
-user	0m2.698s
-sys	0m0.856s
+real	0m3.898s
+user	0m2.845s
+sys	0m1.053s
++ set +x
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m10.324s
+user	0m9.076s
+sys	0m1.248s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m10.567s
+user	0m9.167s
+sys	0m1.400s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m9.430s
+user	0m8.109s
+sys	0m1.320s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m9.572s
+user	0m8.356s
+sys	0m1.216s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.632s
+user	0m6.675s
+sys	0m1.348s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.772s
+user	0m6.717s
+sys	0m1.417s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m5.493s
+user	0m14.500s
+sys	0m4.397s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.739s
+user	0m13.593s
+sys	0m3.748s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.737s
+user	0m6.715s
+sys	0m1.419s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.703s
+user	0m6.760s
+sys	0m1.330s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m5.215s
+user	0m14.675s
+sys	0m3.832s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.314s
+user	0m13.255s
+sys	0m3.168s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.731s
+user	0m2.677s
+sys	0m1.053s
++ set +x
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m10.211s
+user	0m8.807s
+sys	0m1.404s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m10.364s
+user	0m8.955s
+sys	0m1.409s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m9.423s
+user	0m8.158s
+sys	0m1.265s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m11.008s
+user	0m9.656s
+sys	0m1.352s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.621s
+user	0m6.653s
+sys	0m1.360s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.473s
+user	0m6.515s
+sys	0m1.335s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m4.960s
+user	0m14.270s
+sys	0m3.671s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.841s
+user	0m13.964s
+sys	0m3.767s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.653s
+user	0m6.640s
+sys	0m1.416s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.714s
+user	0m6.706s
+sys	0m1.397s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m5.086s
+user	0m14.498s
+sys	0m3.873s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m4.132s
+user	0m13.046s
+sys	0m3.051s
++ ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
+
+real	0m3.482s
+user	0m2.601s
+sys	0m0.881s
 + set +x

--- a/info/scripts/filter.sh.out.mac
+++ b/info/scripts/filter.sh.out.mac
@@ -1,330 +1,330 @@
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.612s
-user	0m9.280s
-sys	0m1.314s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m12.115s
+user	0m10.861s
+sys	0m1.250s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.677s
-user	0m9.354s
-sys	0m1.313s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m11.476s
+user	0m10.294s
+sys	0m1.181s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m16.795s
-user	0m15.860s
-sys	0m0.929s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.111s
+user	0m8.090s
+sys	0m1.002s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m16.529s
-user	0m15.616s
-sys	0m0.910s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m9.005s
+user	0m8.025s
+sys	0m0.976s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.521s
-user	0m9.216s
-sys	0m1.278s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.314s
+user	0m6.784s
+sys	0m0.782s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.287s
-user	0m8.961s
-sys	0m1.266s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.071s
+user	0m6.548s
+sys	0m0.775s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.173s
-user	0m9.298s
-sys	0m0.965s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.281s
+user	0m8.382s
+sys	0m0.809s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.188s
-user	0m9.374s
-sys	0m0.957s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m2.202s
+user	0m8.126s
+sys	0m0.807s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.518s
-user	0m9.206s
-sys	0m1.264s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.504s
+user	0m6.971s
+sys	0m0.803s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.354s
-user	0m9.038s
-sys	0m1.283s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.766s
+user	0m6.852s
+sys	0m0.835s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.170s
-user	0m9.359s
-sys	0m0.963s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.263s
+user	0m8.384s
+sys	0m0.804s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.182s
-user	0m9.422s
-sys	0m0.947s
+real	0m2.248s
+user	0m8.314s
+sys	0m0.810s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m2.332s
-user	0m1.895s
-sys	0m0.425s
+real	0m2.645s
+user	0m2.170s
+sys	0m0.471s
 + set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.484s
-user	0m9.413s
-sys	0m1.068s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m11.872s
+user	0m10.665s
+sys	0m1.204s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.291s
-user	0m9.231s
-sys	0m1.058s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m11.668s
+user	0m10.472s
+sys	0m1.194s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m16.472s
-user	0m15.566s
-sys	0m0.902s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.560s
+user	0m8.499s
+sys	0m1.057s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m16.457s
-user	0m15.559s
-sys	0m0.895s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m9.816s
+user	0m8.783s
+sys	0m1.028s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.773s
-user	0m9.432s
-sys	0m1.302s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m8.909s
+user	0m7.359s
+sys	0m0.849s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.328s
-user	0m9.011s
-sys	0m1.293s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m8.025s
+user	0m6.978s
+sys	0m0.832s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.178s
-user	0m9.330s
-sys	0m0.966s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.272s
+user	0m8.426s
+sys	0m0.811s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.195s
-user	0m9.412s
-sys	0m0.960s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m2.226s
+user	0m8.234s
+sys	0m0.813s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.546s
-user	0m9.231s
-sys	0m1.294s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.320s
+user	0m6.800s
+sys	0m0.779s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.338s
-user	0m9.011s
-sys	0m1.276s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.067s
+user	0m6.549s
+sys	0m0.771s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.158s
-user	0m9.320s
-sys	0m0.949s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.224s
+user	0m8.308s
+sys	0m0.786s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.307s
-user	0m9.953s
-sys	0m0.972s
+real	0m2.345s
+user	0m8.329s
+sys	0m0.813s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m2.361s
-user	0m1.927s
-sys	0m0.431s
+real	0m2.551s
+user	0m2.075s
+sys	0m0.473s
 + set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.321s
-user	0m9.257s
-sys	0m1.062s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m12.498s
+user	0m11.271s
+sys	0m1.223s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.296s
-user	0m9.245s
-sys	0m1.049s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m12.570s
+user	0m11.330s
+sys	0m1.237s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m16.488s
-user	0m15.560s
-sys	0m0.924s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.231s
+user	0m8.202s
+sys	0m1.024s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m16.442s
-user	0m15.558s
-sys	0m0.881s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m7.571s
-user	0m9.220s
-sys	0m1.322s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m7.313s
-user	0m8.972s
-sys	0m1.299s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m2.182s
-user	0m9.334s
-sys	0m0.965s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m2.194s
-user	0m9.418s
-sys	0m0.961s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m7.606s
-user	0m9.285s
-sys	0m1.293s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m7.392s
-user	0m9.087s
-sys	0m1.291s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
-
-real	0m2.229s
-user	0m9.597s
-sys	0m0.989s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
-
-real	0m2.186s
-user	0m9.429s
+real	0m9.099s
+user	0m8.129s
 sys	0m0.968s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.401s
+user	0m6.864s
+sys	0m0.793s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.083s
+user	0m6.549s
+sys	0m0.789s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m2.237s
+user	0m8.283s
+sys	0m0.805s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m2.244s
+user	0m8.311s
+sys	0m0.808s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m7.464s
+user	0m6.912s
+sys	0m0.813s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m7.311s
+user	0m6.766s
+sys	0m0.813s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+
+real	0m2.308s
+user	0m8.262s
+sys	0m0.804s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+
+real	0m2.355s
+user	0m8.401s
+sys	0m0.811s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m2.332s
-user	0m1.901s
-sys	0m0.430s
+real	0m2.511s
+user	0m2.044s
+sys	0m0.465s
 + set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.303s
-user	0m9.242s
-sys	0m1.058s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m11.404s
+user	0m10.234s
+sys	0m1.169s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.239s
-user	0m9.189s
-sys	0m1.048s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m11.603s
+user	0m10.418s
+sys	0m1.182s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m16.399s
-user	0m15.497s
-sys	0m0.897s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.584s
+user	0m8.533s
+sys	0m1.047s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m16.488s
-user	0m15.580s
-sys	0m0.904s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m9.354s
+user	0m8.342s
+sys	0m1.009s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.541s
-user	0m9.250s
-sys	0m1.311s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m8.005s
+user	0m7.272s
+sys	0m0.848s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.323s
-user	0m9.021s
-sys	0m1.273s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.705s
+user	0m6.903s
+sys	0m0.832s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.188s
-user	0m9.375s
-sys	0m0.958s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.202s
+user	0m7.880s
+sys	0m0.815s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.079s
-user	0m8.916s
-sys	0m0.934s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m2.336s
+user	0m8.302s
+sys	0m0.810s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.543s
-user	0m9.234s
-sys	0m1.277s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.764s
+user	0m7.166s
+sys	0m0.811s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.298s
-user	0m8.993s
-sys	0m1.252s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.639s
+user	0m6.938s
+sys	0m0.837s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.196s
-user	0m9.471s
-sys	0m0.963s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.519s
+user	0m8.287s
+sys	0m0.806s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.176s
-user	0m9.389s
-sys	0m0.969s
+real	0m2.729s
+user	0m8.027s
+sys	0m0.803s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m2.317s
-user	0m1.888s
-sys	0m0.427s
+real	0m2.561s
+user	0m2.083s
+sys	0m0.476s
 + set +x
-+ mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
++ ../mawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m10.390s
-user	0m9.322s
-sys	0m1.065s
-+ mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m11.705s
+user	0m10.499s
+sys	0m1.204s
++ ../mawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m10.418s
-user	0m9.350s
-sys	0m1.066s
-+ gawk -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m12.041s
+user	0m10.826s
+sys	0m1.212s
++ ../gawk -b -F, '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m16.369s
-user	0m15.459s
-sys	0m0.906s
-+ gawk '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m9.362s
+user	0m8.345s
+sys	0m1.012s
++ ../gawk -b '-F\t' '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m16.564s
-user	0m15.653s
-sys	0m0.908s
-+ frawk -bllvm -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m9.347s
+user	0m8.314s
+sys	0m1.031s
++ ../frawk -bllvm -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.488s
-user	0m9.141s
-sys	0m1.277s
-+ frawk -bllvm -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.621s
+user	0m7.044s
+sys	0m0.823s
++ ../frawk -bllvm -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.292s
-user	0m8.975s
-sys	0m1.273s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.400s
+user	0m6.765s
+sys	0m0.826s
++ ../frawk -bllvm -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.173s
-user	0m9.331s
-sys	0m0.944s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m2.306s
+user	0m8.231s
+sys	0m0.815s
++ ../frawk -bllvm -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.217s
-user	0m9.499s
-sys	0m0.961s
-+ frawk -bcranelift -icsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m2.228s
+user	0m7.745s
+sys	0m0.817s
++ ../frawk -bcranelift -icsv '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m7.582s
-user	0m9.267s
-sys	0m1.300s
-+ frawk -bcranelift -itsv --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m7.921s
+user	0m7.250s
+sys	0m0.843s
++ ../frawk -bcranelift -itsv '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m7.364s
-user	0m9.043s
-sys	0m1.282s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
+real	0m7.727s
+user	0m7.085s
+sys	0m0.858s
++ ../frawk -bcranelift -icsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.csv
 
-real	0m2.183s
-user	0m9.430s
-sys	0m0.960s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
+real	0m3.006s
+user	0m8.336s
+sys	0m0.806s
++ ../frawk -bcranelift -itsv -pr -j3 '$4 > 0.000024 && $16 > 0.3' ../all_train.tsv
 
-real	0m2.191s
-user	0m9.435s
-sys	0m0.970s
+real	0m2.824s
+user	0m8.134s
+sys	0m0.805s
 + ../bin/tsv-filter -H --gt 4:0.000025 --gt 16:0.3 ../all_train.tsv
 
-real	0m2.311s
-user	0m1.883s
-sys	0m0.426s
+real	0m2.624s
+user	0m2.142s
+sys	0m0.478s
 + set +x

--- a/info/scripts/groupby.sh
+++ b/info/scripts/groupby.sh
@@ -1,13 +1,14 @@
-MAWK=mawk
-GAWK=gawk
+MAWK=../mawk
+GAWK="../gawk -b"
 TSV_UTILS_BIN=../bin
-FRAWK=frawk
+FRAWK=../frawk
 
 CSV=../TREE_GRM_ESTN.csv
 TSV=../TREE_GRM_ESTN.tsv
 
 AWK_SCRIPT='
-NR > 1 { N[$6]++; SUM[$6]+=$2; }
+BEGIN { getline; }
+{ N[$6]++; SUM[$6]+=$2; }
 END {
     OFS="\t"
     for (k in N) {

--- a/info/scripts/groupby.sh.out
+++ b/info/scripts/groupby.sh.out
@@ -1,395 +1,395 @@
-+ mawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.7952
 TIMBERLAND	29.1807
 
-real	0m48.883s
-user	0m46.811s
-sys	0m2.072s
-+ gawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m53.584s
+user	0m51.573s
+sys	0m2.008s
++ ../gawk -b '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.1807
 FORESTLAND	29.7952
 
-real	1m13.486s
-user	1m11.510s
-sys	0m1.976s
-+ frawk -bllvm -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m25.160s
-user	0m23.653s
-sys	0m1.508s
-+ frawk -bllvm -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m29.656s
-user	0m28.214s
-sys	0m1.440s
-+ frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m7.431s
-user	0m27.304s
-sys	0m2.248s
-+ frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m9.524s
-user	0m34.556s
-sys	0m3.279s
-+ frawk -bcranelift -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m24.508s
-user	0m23.032s
-sys	0m1.476s
-+ frawk -bcranelift -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m29.738s
-user	0m28.134s
-sys	0m1.604s
-+ frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m7.533s
-user	0m27.704s
-sys	0m2.325s
-+ frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m9.722s
-user	0m35.405s
-sys	0m3.363s
-+ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
-LAND_BASIS	STATECD_mean
-TIMBERLAND	29.1807099973
-FORESTLAND	29.795231198
-
-real	0m6.091s
-user	0m4.623s
-sys	0m1.468s
-+ set +x
-+ mawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.7952
-TIMBERLAND	29.1807
-
-real	0m47.291s
-user	0m45.499s
-sys	0m1.777s
-+ gawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.1807
-FORESTLAND	29.7952
-
-real	1m11.618s
-user	1m9.970s
+real	0m23.638s
+user	0m21.991s
 sys	0m1.648s
-+ frawk -bllvm -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
++ ../frawk -bllvm -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m24.512s
-user	0m22.875s
-sys	0m1.637s
-+ frawk -bllvm -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m24.771s
+user	0m22.910s
+sys	0m1.860s
++ ../frawk -bllvm -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m31.289s
+user	0m29.437s
+sys	0m1.852s
++ ../frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m29.582s
-user	0m27.546s
-sys	0m2.036s
-+ frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m7.566s
+user	0m28.051s
+sys	0m1.999s
++ ../frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
 
-real	0m7.476s
-user	0m27.521s
+real	0m9.729s
+user	0m34.874s
+sys	0m3.705s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m25.424s
+user	0m23.599s
+sys	0m1.825s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m30.544s
+user	0m28.747s
+sys	0m1.796s
++ ../frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m7.517s
+user	0m27.633s
+sys	0m2.316s
++ ../frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m9.819s
+user	0m35.668s
+sys	0m3.403s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m6.004s
+user	0m4.511s
+sys	0m1.492s
++ set +x
++ ../mawk '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m50.116s
+user	0m48.399s
+sys	0m1.716s
++ ../gawk -b '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	0m24.235s
+user	0m22.278s
+sys	0m1.956s
++ ../frawk -bllvm -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m24.202s
+user	0m22.542s
+sys	0m1.660s
++ ../frawk -bllvm -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m30.852s
+user	0m28.740s
+sys	0m2.112s
++ ../frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.454s
+user	0m27.288s
+sys	0m2.333s
++ ../frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m9.768s
+user	0m35.208s
+sys	0m3.575s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m28.097s
+user	0m26.209s
+sys	0m1.888s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m30.086s
+user	0m28.242s
+sys	0m1.844s
++ ../frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m7.369s
+user	0m27.405s
+sys	0m2.002s
++ ../frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m9.416s
+user	0m35.167s
+sys	0m2.419s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m5.753s
+user	0m4.464s
+sys	0m1.288s
++ set +x
++ ../mawk '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m51.557s
+user	0m49.777s
+sys	0m1.780s
++ ../gawk -b '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	0m23.963s
+user	0m21.931s
+sys	0m2.032s
++ ../frawk -bllvm -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.373s
+user	0m22.921s
+sys	0m1.452s
++ ../frawk -bllvm -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m31.559s
+user	0m29.307s
+sys	0m2.252s
++ ../frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.478s
+user	0m27.886s
+sys	0m1.839s
++ ../frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m9.818s
+user	0m35.288s
+sys	0m3.680s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m24.836s
+user	0m23.311s
+sys	0m1.525s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m30.967s
+user	0m28.826s
+sys	0m2.140s
++ ../frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m7.289s
+user	0m26.884s
 sys	0m2.201s
-+ frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m10.066s
-user	0m35.575s
-sys	0m4.163s
-+ frawk -bcranelift -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
++ ../frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m24.985s
-user	0m23.609s
-sys	0m1.376s
-+ frawk -bcranelift -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m30.665s
-user	0m28.817s
-sys	0m1.848s
-+ frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m7.538s
-user	0m27.875s
-sys	0m2.185s
-+ frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m9.546s
-user	0m35.131s
-sys	0m2.928s
+real	0m9.917s
+user	0m36.093s
+sys	0m3.225s
 + ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
 LAND_BASIS	STATECD_mean
 TIMBERLAND	29.1807099973
 FORESTLAND	29.795231198
 
-real	0m6.239s
-user	0m4.859s
-sys	0m1.380s
+real	0m5.714s
+user	0m4.439s
+sys	0m1.274s
 + set +x
-+ mawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.7952
 TIMBERLAND	29.1807
 
-real	0m47.705s
-user	0m45.949s
-sys	0m1.756s
-+ gawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m51.427s
+user	0m49.298s
+sys	0m2.128s
++ ../gawk -b '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.1807
 FORESTLAND	29.7952
 
-real	1m12.811s
-user	1m10.911s
-sys	0m1.900s
-+ frawk -bllvm -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m23.385s
+user	0m21.726s
+sys	0m1.657s
++ ../frawk -bllvm -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m24.787s
-user	0m23.254s
-sys	0m1.532s
-+ frawk -bllvm -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m24.908s
+user	0m23.020s
+sys	0m1.888s
++ ../frawk -bllvm -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m29.292s
-user	0m27.792s
-sys	0m1.500s
-+ frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m7.441s
-user	0m27.336s
-sys	0m2.238s
-+ frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m9.689s
-user	0m35.205s
-sys	0m3.280s
-+ frawk -bcranelift -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m24.752s
-user	0m23.352s
-sys	0m1.400s
-+ frawk -bcranelift -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m29.864s
+user	0m28.192s
+sys	0m1.672s
++ ../frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m30.456s
-user	0m28.636s
+real	0m7.393s
+user	0m27.384s
+sys	0m2.012s
++ ../frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m9.457s
+user	0m34.932s
+sys	0m2.696s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m25.154s
+user	0m23.334s
 sys	0m1.820s
-+ frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
++ ../frawk -bcranelift -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
 
-real	0m7.582s
-user	0m27.761s
-sys	0m2.459s
-+ frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m30.386s
+user	0m28.650s
+sys	0m1.736s
++ ../frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
 
-real	0m9.343s
-user	0m34.709s
-sys	0m2.575s
+real	0m7.315s
+user	0m26.969s
+sys	0m2.224s
++ ../frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m9.315s
+user	0m34.470s
+sys	0m2.712s
 + ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
 LAND_BASIS	STATECD_mean
 TIMBERLAND	29.1807099973
 FORESTLAND	29.795231198
 
-real	0m6.059s
-user	0m4.659s
-sys	0m1.400s
+real	0m6.038s
+user	0m4.546s
+sys	0m1.491s
 + set +x
-+ mawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.7952
 TIMBERLAND	29.1807
 
-real	0m50.594s
-user	0m48.609s
-sys	0m1.984s
-+ gawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m51.195s
+user	0m49.423s
+sys	0m1.772s
++ ../gawk -b '-F\t' -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.1807
 FORESTLAND	29.7952
 
-real	1m12.756s
-user	1m11.119s
-sys	0m1.636s
-+ frawk -bllvm -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180709997271897
-
-real	0m24.200s
-user	0m22.608s
-sys	0m1.592s
-+ frawk -bllvm -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m23.844s
+user	0m21.879s
+sys	0m1.964s
++ ../frawk -bllvm -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m29.443s
-user	0m28.010s
-sys	0m1.432s
-+ frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m24.221s
+user	0m22.665s
+sys	0m1.556s
++ ../frawk -bllvm -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
 FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
+TIMBERLAND	29.180709997271897
 
-real	0m7.564s
-user	0m27.680s
-sys	0m2.372s
-+ frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
+real	0m30.514s
+user	0m28.558s
+sys	0m1.956s
++ ../frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
 
-real	0m9.418s
-user	0m34.744s
-sys	0m2.705s
-+ frawk -bcranelift -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
+real	0m7.129s
+user	0m26.440s
+sys	0m1.907s
++ ../frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m9.744s
+user	0m35.436s
+sys	0m3.296s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m25.709s
-user	0m23.989s
-sys	0m1.720s
-+ frawk -bcranelift -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m24.932s
+user	0m23.466s
+sys	0m1.464s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m30.389s
-user	0m28.333s
-sys	0m2.056s
-+ frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
+real	0m30.815s
+user	0m28.795s
+sys	0m2.020s
++ ../frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m7.506s
-user	0m27.915s
-sys	0m2.005s
-+ frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
+real	0m7.568s
+user	0m27.901s
+sys	0m2.246s
++ ../frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.bcsvhnxWnD ../TREE_GRM_ESTN.csv
 FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
+TIMBERLAND	29.180709997271897
 
-real	0m9.594s
-user	0m35.128s
-sys	0m3.119s
+real	0m9.635s
+user	0m35.142s
+sys	0m3.249s
 + ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
 LAND_BASIS	STATECD_mean
 TIMBERLAND	29.1807099973
 FORESTLAND	29.795231198
 
-real	0m5.789s
-user	0m4.585s
-sys	0m1.204s
-+ set +x
-+ mawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.7952
-TIMBERLAND	29.1807
-
-real	0m49.577s
-user	0m47.480s
-sys	0m2.096s
-+ gawk '-F\t' -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.1807
-FORESTLAND	29.7952
-
-real	1m11.970s
-user	1m10.290s
-sys	0m1.680s
-+ frawk -bllvm -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m24.290s
-user	0m22.646s
-sys	0m1.644s
-+ frawk -bllvm -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m29.776s
-user	0m28.152s
-sys	0m1.624s
-+ frawk -bllvm -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m7.343s
-user	0m26.931s
-sys	0m2.279s
-+ frawk -bllvm -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m10.287s
-user	0m35.954s
-sys	0m4.483s
-+ frawk -bcranelift -itsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180709997271897
-
-real	0m24.752s
-user	0m23.002s
-sys	0m1.748s
-+ frawk -bcranelift -icsv -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m30.460s
-user	0m28.324s
-sys	0m2.136s
-+ frawk -bcranelift -itsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m7.230s
-user	0m27.059s
-sys	0m1.773s
-+ frawk -bcranelift -icsv -pr -j3 -f /tmp/tmp.JkYFA0QnQ5 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m9.436s
-user	0m34.504s
-sys	0m3.112s
-+ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
-LAND_BASIS	STATECD_mean
-TIMBERLAND	29.1807099973
-FORESTLAND	29.795231198
-
-real	0m6.256s
-user	0m4.776s
-sys	0m1.480s
+real	0m5.724s
+user	0m4.496s
+sys	0m1.228s
 + set +x

--- a/info/scripts/groupby.sh.out.mac
+++ b/info/scripts/groupby.sh.out.mac
@@ -1,395 +1,395 @@
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.7952
 TIMBERLAND	29.1807
 
-real	0m44.037s
-user	0m42.268s
-sys	0m1.760s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
+real	0m43.797s
+user	0m42.216s
+sys	0m1.571s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.1807
 FORESTLAND	29.7952
 
-real	0m27.806s
-user	0m26.480s
-sys	0m1.320s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
+real	0m15.134s
+user	0m13.770s
+sys	0m1.357s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m19.196s
-user	0m18.187s
-sys	0m1.003s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m22.700s
-user	0m21.583s
-sys	0m1.114s
-+ frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.091s
-user	0m22.892s
-sys	0m1.209s
-+ frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.563s
-user	0m24.926s
-sys	0m1.195s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
+real	0m20.567s
+user	0m19.538s
+sys	0m1.023s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m19.764s
-user	0m18.787s
-sys	0m0.974s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
+real	0m23.710s
+user	0m22.549s
+sys	0m1.155s
++ ../frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m23.040s
-user	0m21.883s
-sys	0m1.149s
-+ frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.499s
-user	0m24.404s
-sys	0m1.311s
-+ frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.727s
-user	0m25.640s
-sys	0m1.214s
-+ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
-LAND_BASIS	STATECD_mean
-TIMBERLAND	29.1807099973
-FORESTLAND	29.795231198
-
-real	0m4.939s
-user	0m4.287s
-sys	0m0.638s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.7952
-TIMBERLAND	29.1807
-
-real	0m44.557s
-user	0m43.006s
-sys	0m1.545s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.1807
-FORESTLAND	29.7952
-
-real	0m28.624s
-user	0m27.281s
-sys	0m1.334s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
+real	0m6.521s
+user	0m24.459s
+sys	0m1.267s
++ ../frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m19.412s
-user	0m18.387s
-sys	0m1.020s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
+real	0m7.341s
+user	0m27.917s
+sys	0m1.280s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
 
-real	0m22.433s
-user	0m21.292s
-sys	0m1.137s
-+ frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.176s
-user	0m23.196s
-sys	0m1.232s
-+ frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.701s
-user	0m25.436s
-sys	0m1.225s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m20.033s
-user	0m19.039s
-sys	0m0.991s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m22.891s
-user	0m21.758s
-sys	0m1.127s
-+ frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.403s
-user	0m24.100s
-sys	0m1.270s
-+ frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.820s
-user	0m26.009s
-sys	0m1.222s
-+ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
-LAND_BASIS	STATECD_mean
-TIMBERLAND	29.1807099973
-FORESTLAND	29.795231198
-
-real	0m4.957s
-user	0m4.318s
-sys	0m0.637s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.7952
-TIMBERLAND	29.1807
-
-real	0m44.213s
-user	0m42.675s
-sys	0m1.533s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.1807
-FORESTLAND	29.7952
-
-real	0m28.215s
-user	0m26.860s
-sys	0m1.347s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180709997271897
-
-real	0m19.950s
-user	0m18.936s
-sys	0m1.008s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m22.212s
-user	0m21.075s
-sys	0m1.133s
-+ frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.134s
-user	0m23.057s
-sys	0m1.208s
-+ frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.474s
-user	0m24.562s
-sys	0m1.191s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m19.920s
-user	0m18.924s
-sys	0m0.992s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
-
-real	0m22.821s
-user	0m21.680s
-sys	0m1.135s
-+ frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.291s
-user	0m23.672s
-sys	0m1.239s
-+ frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.729s
-user	0m25.646s
-sys	0m1.217s
-+ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
-LAND_BASIS	STATECD_mean
-TIMBERLAND	29.1807099973
-FORESTLAND	29.795231198
-
-real	0m4.915s
-user	0m4.277s
-sys	0m0.637s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.7952
-TIMBERLAND	29.1807
-
-real	0m44.151s
-user	0m42.621s
-sys	0m1.525s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.1807
-FORESTLAND	29.7952
-
-real	0m28.046s
-user	0m26.714s
-sys	0m1.324s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180709997271897
-
-real	0m19.387s
-user	0m18.363s
+real	0m20.830s
+user	0m19.806s
 sys	0m1.019s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m22.281s
-user	0m21.133s
-sys	0m1.143s
-+ frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
+real	0m23.936s
+user	0m22.751s
+sys	0m1.180s
++ ../frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.795231197974125
-
-real	0m6.115s
-user	0m22.980s
-sys	0m1.218s
-+ frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.498s
-user	0m24.657s
-sys	0m1.193s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
 
-real	0m20.014s
-user	0m19.015s
-sys	0m0.996s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
+real	0m6.617s
+user	0m24.927s
+sys	0m1.277s
++ ../frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
 TIMBERLAND	29.180709997271897
-FORESTLAND	29.795231197974125
 
-real	0m22.846s
-user	0m21.718s
-sys	0m1.123s
-+ frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.315s
-user	0m23.758s
-sys	0m1.244s
-+ frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
-
-real	0m6.718s
-user	0m25.602s
-sys	0m1.215s
+real	0m7.237s
+user	0m27.631s
+sys	0m1.260s
 + ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
 LAND_BASIS	STATECD_mean
 TIMBERLAND	29.1807099973
 FORESTLAND	29.795231198
 
-real	0m4.905s
-user	0m4.269s
-sys	0m0.635s
+real	0m4.944s
+user	0m4.285s
+sys	0m0.657s
 + set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 FORESTLAND	29.7952
 TIMBERLAND	29.1807
 
-real	0m44.072s
-user	0m42.557s
-sys	0m1.510s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
+real	0m43.382s
+user	0m41.841s
+sys	0m1.537s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.1807
 FORESTLAND	29.7952
 
-real	0m27.992s
-user	0m26.630s
-sys	0m1.355s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
+real	0m15.068s
+user	0m13.710s
+sys	0m1.351s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m19.977s
-user	0m18.951s
-sys	0m1.021s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180709997271897
-
-real	0m22.288s
-user	0m21.156s
-sys	0m1.128s
-+ frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.092s
-user	0m22.895s
-sys	0m1.208s
-+ frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
-TIMBERLAND	29.180712732725496
-FORESTLAND	29.795231197974125
-
-real	0m6.481s
-user	0m24.592s
-sys	0m1.193s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-FORESTLAND	29.795231197974125
-TIMBERLAND	29.180709997271897
-
-real	0m19.881s
-user	0m18.886s
-sys	0m0.992s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
+real	0m20.568s
+user	0m19.547s
+sys	0m1.015s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
 TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m22.816s
-user	0m21.686s
-sys	0m1.126s
-+ frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.tsv
-TIMBERLAND	29.180712732725496
+real	0m23.659s
+user	0m22.515s
+sys	0m1.155s
++ ../frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m6.592s
+user	0m24.839s
+sys	0m1.239s
++ ../frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
 
-real	0m6.275s
-user	0m23.620s
-sys	0m1.236s
-+ frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.IMTT1nv8 ../TREE_GRM_ESTN.csv
+real	0m7.083s
+user	0m26.947s
+sys	0m1.242s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
 FORESTLAND	29.795231197974125
-TIMBERLAND	29.180712732725496
 
-real	0m6.787s
-user	0m25.887s
-sys	0m1.206s
+real	0m21.044s
+user	0m20.009s
+sys	0m1.034s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m24.019s
+user	0m22.847s
+sys	0m1.167s
++ ../frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m6.627s
+user	0m24.950s
+sys	0m1.287s
++ ../frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m7.096s
+user	0m27.080s
+sys	0m1.242s
 + ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
 LAND_BASIS	STATECD_mean
 TIMBERLAND	29.1807099973
 FORESTLAND	29.795231198
 
-real	0m4.915s
-user	0m4.277s
-sys	0m0.637s
+real	0m5.187s
+user	0m4.521s
+sys	0m0.665s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m43.236s
+user	0m41.683s
+sys	0m1.548s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	0m15.021s
+user	0m13.670s
+sys	0m1.346s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m20.609s
+user	0m19.581s
+sys	0m1.021s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m23.669s
+user	0m22.503s
+sys	0m1.160s
++ ../frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m6.530s
+user	0m24.526s
+sys	0m1.262s
++ ../frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.231s
+user	0m27.489s
+sys	0m1.270s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m20.957s
+user	0m19.921s
+sys	0m1.032s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m23.973s
+user	0m22.803s
+sys	0m1.165s
++ ../frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m6.565s
+user	0m24.723s
+sys	0m1.269s
++ ../frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.203s
+user	0m27.504s
+sys	0m1.249s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m4.970s
+user	0m4.311s
+sys	0m0.657s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m43.276s
+user	0m41.730s
+sys	0m1.541s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	0m15.107s
+user	0m13.741s
+sys	0m1.359s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m20.512s
+user	0m19.488s
+sys	0m1.018s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m23.748s
+user	0m22.559s
+sys	0m1.183s
++ ../frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m6.540s
+user	0m24.564s
+sys	0m1.263s
++ ../frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.107s
+user	0m27.030s
+sys	0m1.245s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m20.842s
+user	0m19.809s
+sys	0m1.030s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m23.893s
+user	0m22.719s
+sys	0m1.168s
++ ../frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m6.607s
+user	0m24.878s
+sys	0m1.284s
++ ../frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.240s
+user	0m27.632s
+sys	0m1.265s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m4.948s
+user	0m4.287s
+sys	0m0.659s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.7952
+TIMBERLAND	29.1807
+
+real	0m43.197s
+user	0m41.648s
+sys	0m1.543s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.1807
+FORESTLAND	29.7952
+
+real	0m15.098s
+user	0m13.715s
+sys	0m1.378s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m20.562s
+user	0m19.540s
+sys	0m1.016s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m23.649s
+user	0m22.465s
+sys	0m1.178s
++ ../frawk -bllvm -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m6.533s
+user	0m24.624s
+sys	0m1.218s
++ ../frawk -bllvm -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m7.020s
+user	0m26.698s
+sys	0m1.230s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m20.832s
+user	0m19.812s
+sys	0m1.016s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m23.935s
+user	0m22.768s
+sys	0m1.162s
++ ../frawk -bcranelift -itsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.tsv
+FORESTLAND	29.795231197974125
+TIMBERLAND	29.180709997271897
+
+real	0m6.611s
+user	0m24.905s
+sys	0m1.273s
++ ../frawk -bcranelift -icsv -pr -j3 -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.WEKZIUfs ../TREE_GRM_ESTN.csv
+TIMBERLAND	29.180709997271897
+FORESTLAND	29.795231197974125
+
+real	0m7.127s
+user	0m27.206s
+sys	0m1.243s
++ ../bin/tsv-summarize -H --group-by 6 --mean 2 ../TREE_GRM_ESTN.tsv
+LAND_BASIS	STATECD_mean
+TIMBERLAND	29.1807099973
+FORESTLAND	29.795231198
+
+real	0m4.960s
+user	0m4.296s
+sys	0m0.662s
 + set +x

--- a/info/scripts/select.sh
+++ b/info/scripts/select.sh
@@ -1,9 +1,9 @@
 # Select fields 1,8,19 from the all_train dataset
-MAWK=mawk
-GAWK=gawk
+MAWK=../mawk
+GAWK="../gawk -b"
 TSV_UTILS_BIN=../bin
 XSV=xsv
-FRAWK=frawk
+FRAWK=../frawk
 
 CSV1=../all_train.csv
 CSV2=../TREE_GRM_ESTN.csv
@@ -21,14 +21,14 @@ for i in {1..5}; do
 	time $MAWK -F'\t' "$AWK_SCRIPT_TSV" "$TSV1" > /dev/null
 	time $GAWK -F,    "$AWK_SCRIPT_CSV" "$CSV1" > /dev/null
 	time $GAWK -F'\t' "$AWK_SCRIPT_TSV" "$TSV1" > /dev/null
-	time $FRAWK -bllvm -icsv --out-file=/dev/null "$AWK_SCRIPT_CSV" "$CSV1" 
-	time $FRAWK -bllvm -itsv --out-file=/dev/null "$AWK_SCRIPT_TSV" "$TSV1" 
-	time $FRAWK -bllvm -icsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT_CSV" "$CSV1" 
-	time $FRAWK -bllvm -itsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT_TSV" "$TSV1" 
-	time $FRAWK -bcranelift -icsv --out-file=/dev/null "$AWK_SCRIPT_CSV" "$CSV1" 
-	time $FRAWK -bcranelift -itsv --out-file=/dev/null "$AWK_SCRIPT_TSV" "$TSV1" 
-	time $FRAWK -bcranelift -icsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT_CSV" "$CSV1" 
-	time $FRAWK -bcranelift -itsv -pr -j3 --out-file=/dev/null "$AWK_SCRIPT_TSV" "$TSV1" 
+	time $FRAWK -bllvm -icsv "$AWK_SCRIPT_CSV" "$CSV1" > /dev/null
+	time $FRAWK -bllvm -itsv "$AWK_SCRIPT_TSV" "$TSV1" > /dev/null
+	time $FRAWK -bllvm -icsv -pr -j3 "$AWK_SCRIPT_CSV" "$CSV1" > /dev/null
+	time $FRAWK -bllvm -itsv -pr -j3 "$AWK_SCRIPT_TSV" "$TSV1" > /dev/null
+	time $FRAWK -bcranelift -icsv "$AWK_SCRIPT_CSV" "$CSV1" > /dev/null
+	time $FRAWK -bcranelift -itsv "$AWK_SCRIPT_TSV" "$TSV1" > /dev/null
+	time $FRAWK -bcranelift -icsv -pr -j3 "$AWK_SCRIPT_CSV" "$CSV1" > /dev/null
+	time $FRAWK -bcranelift -itsv -pr -j3 "$AWK_SCRIPT_TSV" "$TSV1" > /dev/null
 	time xsv select 1,8,19  "$CSV1" > /dev/null
 	time xsv select -d'\t' 1,8,19  "$TSV1" > /dev/null
 	time $TSV_UTILS_BIN/tsv-select -f 1,8,19 "$TSV1" > /dev/null

--- a/info/scripts/select.sh.out
+++ b/info/scripts/select.sh.out
@@ -1,380 +1,380 @@
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m8.685s
-user	0m7.385s
-sys	0m1.300s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m8.307s
+user	0m6.907s
+sys	0m1.400s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m8.176s
-user	0m6.856s
-sys	0m1.320s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m8.308s
+user	0m7.072s
+sys	0m1.236s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	1m11.603s
-user	1m10.558s
-sys	0m1.044s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m10.031s
+user	0m8.783s
+sys	0m1.248s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	1m12.559s
-user	1m11.318s
-sys	0m1.240s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m9.990s
+user	0m8.786s
+sys	0m1.204s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.939s
-user	0m5.707s
-sys	0m1.866s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m6.072s
+user	0m5.062s
+sys	0m1.215s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.859s
-user	0m5.529s
-sys	0m1.977s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m5.380s
+user	0m4.476s
+sys	0m1.153s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.079s
-user	0m12.827s
-sys	0m5.487s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.453s
+user	0m12.898s
+sys	0m4.838s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.351s
-user	0m13.341s
-sys	0m5.602s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m5.302s
+user	0m12.729s
+sys	0m4.662s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.634s
-user	0m5.694s
-sys	0m1.727s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.724s
+user	0m4.640s
+sys	0m1.287s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.537s
-user	0m5.478s
-sys	0m1.787s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m5.438s
+user	0m4.426s
+sys	0m1.264s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.334s
-user	0m13.283s
-sys	0m5.442s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.692s
+user	0m13.350s
+sys	0m5.028s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.156s
-user	0m12.944s
-sys	0m5.390s
+real	0m5.404s
+user	0m12.971s
+sys	0m4.869s
 + xsv select 1,8,19 ../all_train.csv
 
-real	0m8.311s
-user	0m7.259s
-sys	0m1.052s
+real	0m8.541s
+user	0m7.608s
+sys	0m0.920s
 + xsv select '-d\t' 1,8,19 ../all_train.tsv
 
-real	0m8.305s
-user	0m7.157s
-sys	0m1.148s
+real	0m8.205s
+user	0m7.316s
+sys	0m0.888s
 + ../bin/tsv-select -f 1,8,19 ../all_train.tsv
 
-real	0m3.045s
-user	0m2.087s
-sys	0m0.948s
+real	0m3.014s
+user	0m1.967s
+sys	0m1.036s
 + set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m8.173s
-user	0m6.612s
-sys	0m1.560s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m8.416s
+user	0m7.075s
+sys	0m1.341s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m8.358s
-user	0m6.954s
-sys	0m1.405s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m8.254s
+user	0m6.814s
+sys	0m1.440s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	1m11.833s
-user	1m10.612s
-sys	0m1.220s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m9.918s
+user	0m8.689s
+sys	0m1.228s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	1m11.567s
-user	1m10.394s
-sys	0m1.172s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m9.632s
+user	0m8.360s
+sys	0m1.272s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.622s
-user	0m5.516s
-sys	0m1.880s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.784s
+user	0m4.687s
+sys	0m1.350s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.342s
-user	0m5.315s
-sys	0m1.833s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.371s
-user	0m13.451s
-sys	0m5.431s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.914s
-user	0m12.425s
-sys	0m5.405s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.841s
-user	0m5.737s
-sys	0m1.926s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m5.658s
-user	0m5.477s
-sys	0m1.882s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.446s
-user	0m13.461s
-sys	0m5.411s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.866s
-user	0m13.048s
-sys	0m4.729s
-+ xsv select 1,8,19 ../all_train.csv
-
-real	0m8.381s
-user	0m7.297s
-sys	0m1.084s
-+ xsv select '-d\t' 1,8,19 ../all_train.tsv
-
-real	0m8.207s
-user	0m7.242s
-sys	0m0.965s
-+ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
-
-real	0m3.080s
-user	0m2.028s
-sys	0m1.052s
-+ set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m8.170s
-user	0m6.714s
-sys	0m1.456s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m8.095s
-user	0m6.774s
-sys	0m1.320s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	1m11.842s
-user	1m10.513s
-sys	0m1.328s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	1m12.638s
-user	1m11.246s
-sys	0m1.392s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.774s
-user	0m5.465s
-sys	0m2.146s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m5.565s
-user	0m5.275s
-sys	0m1.997s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.274s
-user	0m13.244s
-sys	0m5.321s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m5.057s
-user	0m13.111s
-sys	0m5.057s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.755s
-user	0m5.581s
-sys	0m1.933s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.629s
+user	0m4.424s
+sys	0m1.466s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
 real	0m5.572s
-user	0m5.433s
-sys	0m1.921s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+user	0m12.865s
+sys	0m4.858s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.249s
-user	0m13.476s
-sys	0m5.052s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.122s
+user	0m12.283s
+sys	0m4.555s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m4.917s
-user	0m13.178s
-sys	0m4.870s
+real	0m5.252s
+user	0m4.389s
+sys	0m1.120s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.184s
+user	0m4.391s
+sys	0m1.047s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.405s
+user	0m12.933s
+sys	0m4.675s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.287s
+user	0m12.526s
+sys	0m4.859s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.352s
+user	0m7.195s
+sys	0m1.156s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.303s
+user	0m7.138s
+sys	0m1.164s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m2.857s
+user	0m2.041s
+sys	0m0.817s
++ set +x
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.954s
+user	0m7.634s
+sys	0m1.320s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m8.293s
+user	0m7.161s
+sys	0m1.132s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m9.330s
+user	0m8.377s
+sys	0m0.952s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m9.515s
+user	0m8.438s
+sys	0m1.076s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.092s
+user	0m4.268s
+sys	0m1.078s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.065s
+user	0m4.327s
+sys	0m1.003s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.686s
+user	0m12.791s
+sys	0m5.381s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.224s
+user	0m12.673s
+sys	0m4.670s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.466s
+user	0m4.455s
+sys	0m1.265s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.276s
+user	0m4.440s
+sys	0m1.095s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.793s
+user	0m13.629s
+sys	0m5.129s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.047s
+user	0m12.451s
+sys	0m4.486s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m8.236s
+user	0m7.171s
+sys	0m1.064s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m8.110s
+user	0m7.134s
+sys	0m0.976s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m3.040s
+user	0m1.916s
+sys	0m1.124s
++ set +x
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.388s
+user	0m6.887s
+sys	0m1.500s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m8.231s
+user	0m6.831s
+sys	0m1.400s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m9.647s
+user	0m8.398s
+sys	0m1.249s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m10.099s
+user	0m8.814s
+sys	0m1.284s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.524s
+user	0m4.430s
+sys	0m1.344s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.415s
+user	0m4.414s
+sys	0m1.260s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.409s
+user	0m12.638s
+sys	0m4.757s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.932s
+user	0m12.184s
+sys	0m4.393s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.273s
+user	0m4.641s
+sys	0m0.888s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.181s
+user	0m4.350s
+sys	0m1.087s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m5.631s
+user	0m12.927s
+sys	0m5.021s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m5.061s
+user	0m12.447s
+sys	0m4.643s
 + xsv select 1,8,19 ../all_train.csv
 
 real	0m8.447s
-user	0m7.335s
-sys	0m1.112s
-+ xsv select '-d\t' 1,8,19 ../all_train.tsv
-
-real	0m8.280s
 user	0m7.273s
-sys	0m0.996s
-+ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
-
-real	0m3.010s
-user	0m2.039s
-sys	0m0.972s
-+ set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m8.119s
-user	0m6.646s
-sys	0m1.473s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m8.263s
-user	0m6.815s
-sys	0m1.449s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	1m11.420s
-user	1m10.075s
-sys	0m1.344s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	1m12.846s
-user	1m11.633s
-sys	0m1.212s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.654s
-user	0m5.367s
-sys	0m2.006s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m5.375s
-user	0m5.192s
-sys	0m1.943s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.400s
-user	0m13.505s
-sys	0m5.497s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.893s
-user	0m12.818s
-sys	0m5.354s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.970s
-user	0m5.660s
-sys	0m2.127s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m5.576s
-user	0m5.313s
-sys	0m1.937s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m5.464s
-user	0m13.564s
-sys	0m5.461s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.970s
-user	0m13.147s
-sys	0m4.977s
-+ xsv select 1,8,19 ../all_train.csv
-
-real	0m8.892s
-user	0m7.740s
-sys	0m1.152s
+sys	0m1.172s
 + xsv select '-d\t' 1,8,19 ../all_train.tsv
 
-real	0m8.680s
-user	0m7.764s
-sys	0m0.916s
+real	0m8.264s
+user	0m7.199s
+sys	0m1.065s
 + ../bin/tsv-select -f 1,8,19 ../all_train.tsv
 
-real	0m3.302s
-user	0m2.278s
-sys	0m1.024s
+real	0m2.852s
+user	0m1.992s
+sys	0m0.860s
 + set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m8.469s
-user	0m7.116s
-sys	0m1.352s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m8.252s
+user	0m6.804s
+sys	0m1.448s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m8.403s
-user	0m6.975s
-sys	0m1.428s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m8.253s
+user	0m6.893s
+sys	0m1.360s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	1m13.263s
-user	1m12.063s
-sys	0m1.196s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m9.762s
+user	0m8.526s
+sys	0m1.236s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	1m11.921s
-user	1m10.884s
-sys	0m1.036s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m9.675s
+user	0m8.391s
+sys	0m1.284s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.652s
-user	0m5.451s
-sys	0m1.973s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.610s
+user	0m4.514s
+sys	0m1.349s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.380s
-user	0m5.400s
-sys	0m1.732s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m5.207s
+user	0m4.102s
+sys	0m1.291s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.571s
-user	0m13.543s
-sys	0m5.680s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.756s
+user	0m12.978s
+sys	0m5.223s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.160s
-user	0m12.824s
-sys	0m5.499s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m5.374s
+user	0m12.756s
+sys	0m4.851s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.833s
-user	0m5.808s
-sys	0m1.872s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.242s
+user	0m4.447s
+sys	0m1.051s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.687s
-user	0m5.336s
-sys	0m1.772s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m5.134s
+user	0m4.273s
+sys	0m1.116s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m5.571s
-user	0m13.813s
-sys	0m5.574s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m5.500s
+user	0m12.783s
+sys	0m4.841s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m4.863s
-user	0m12.648s
-sys	0m5.008s
+real	0m5.010s
+user	0m12.365s
+sys	0m4.446s
 + xsv select 1,8,19 ../all_train.csv
 
-real	0m8.405s
-user	0m7.380s
-sys	0m1.024s
+real	0m8.231s
+user	0m7.123s
+sys	0m1.108s
 + xsv select '-d\t' 1,8,19 ../all_train.tsv
 
-real	0m8.372s
-user	0m7.267s
-sys	0m1.104s
+real	0m8.317s
+user	0m7.245s
+sys	0m1.072s
 + ../bin/tsv-select -f 1,8,19 ../all_train.tsv
 
-real	0m2.858s
-user	0m1.985s
-sys	0m0.873s
+real	0m2.899s
+user	0m2.139s
+sys	0m0.760s
 + set +x

--- a/info/scripts/select.sh.out.mac
+++ b/info/scripts/select.sh.out.mac
@@ -1,380 +1,380 @@
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m8.668s
-user	0m7.625s
-sys	0m1.040s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m9.673s
+user	0m8.505s
+sys	0m1.163s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m8.564s
-user	0m7.545s
-sys	0m1.017s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m9.816s
+user	0m8.354s
+sys	0m1.443s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m23.325s
-user	0m22.427s
-sys	0m0.891s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m23.325s
-user	0m22.441s
-sys	0m0.879s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.323s
-user	0m5.154s
-sys	0m1.086s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.043s
-user	0m4.881s
-sys	0m1.058s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.175s
-user	0m8.880s
-sys	0m1.111s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.838s
-user	0m7.503s
-sys	0m1.012s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.417s
-user	0m5.235s
-sys	0m1.063s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.143s
-user	0m4.982s
-sys	0m1.057s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.097s
-user	0m8.639s
-sys	0m1.083s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.858s
-user	0m7.644s
-sys	0m1.038s
-+ xsv select 1,8,19 ../all_train.csv
-
-real	0m5.566s
-user	0m4.895s
-sys	0m0.655s
-+ xsv select '-d\t' 1,8,19 ../all_train.tsv
-
-real	0m5.438s
-user	0m4.803s
-sys	0m0.633s
-+ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
-
-real	0m2.015s
-user	0m1.556s
-sys	0m0.443s
-+ set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m8.563s
-user	0m7.527s
-sys	0m1.034s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m8.581s
-user	0m7.554s
-sys	0m1.026s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m23.286s
-user	0m22.389s
-sys	0m0.892s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m23.375s
-user	0m22.480s
-sys	0m0.888s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.139s
-user	0m4.960s
-sys	0m1.056s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.059s
-user	0m4.894s
-sys	0m1.059s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.204s
-user	0m8.988s
-sys	0m1.131s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.831s
-user	0m7.472s
-sys	0m1.009s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.235s
-user	0m5.064s
-sys	0m1.057s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.220s
-user	0m5.053s
-sys	0m1.056s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.104s
-user	0m8.673s
-sys	0m1.082s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.820s
-user	0m7.496s
+real	0m9.255s
+user	0m8.244s
 sys	0m1.007s
-+ xsv select 1,8,19 ../all_train.csv
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m5.495s
-user	0m4.843s
-sys	0m0.649s
-+ xsv select '-d\t' 1,8,19 ../all_train.tsv
-
-real	0m5.408s
-user	0m4.778s
-sys	0m0.629s
-+ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
-
-real	0m1.970s
-user	0m1.540s
-sys	0m0.429s
-+ set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m8.526s
-user	0m7.497s
-sys	0m1.026s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m8.613s
-user	0m7.583s
-sys	0m1.029s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m23.249s
-user	0m22.360s
-sys	0m0.884s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m23.247s
-user	0m22.371s
-sys	0m0.872s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.135s
-user	0m4.953s
-sys	0m1.064s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.025s
-user	0m4.851s
-sys	0m1.054s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.138s
-user	0m8.736s
-sys	0m1.096s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.860s
-user	0m7.593s
-sys	0m1.027s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.211s
-user	0m5.023s
-sys	0m1.050s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.085s
-user	0m4.918s
-sys	0m1.037s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.166s
-user	0m8.919s
-sys	0m1.110s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.840s
-user	0m7.574s
-sys	0m1.022s
-+ xsv select 1,8,19 ../all_train.csv
-
-real	0m5.520s
-user	0m4.869s
-sys	0m0.648s
-+ xsv select '-d\t' 1,8,19 ../all_train.tsv
-
-real	0m5.421s
-user	0m4.784s
-sys	0m0.635s
-+ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
-
-real	0m1.940s
-user	0m1.511s
-sys	0m0.428s
-+ set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m8.594s
-user	0m7.572s
-sys	0m1.019s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m8.638s
-user	0m7.589s
-sys	0m1.044s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m23.440s
-user	0m22.534s
-sys	0m0.901s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m23.330s
-user	0m22.447s
-sys	0m0.880s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.157s
-user	0m4.973s
-sys	0m1.066s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m4.007s
-user	0m4.833s
-sys	0m1.044s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m2.192s
-user	0m8.959s
-sys	0m1.117s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
-
-real	0m1.845s
-user	0m7.527s
-sys	0m1.023s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
-
-real	0m4.231s
-user	0m5.054s
-sys	0m1.051s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m9.208s
+user	0m8.216s
+sys	0m0.990s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
 real	0m4.128s
-user	0m4.943s
-sys	0m1.056s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+user	0m3.426s
+sys	0m0.755s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m2.144s
-user	0m8.813s
-sys	0m1.110s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m4.543s
+user	0m3.530s
+sys	0m0.796s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m1.843s
-user	0m7.584s
-sys	0m1.028s
+real	0m2.731s
+user	0m7.972s
+sys	0m0.947s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.536s
+user	0m7.123s
+sys	0m0.963s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m4.238s
+user	0m3.615s
+sys	0m0.764s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.455s
+user	0m3.540s
+sys	0m0.777s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.984s
+user	0m7.926s
+sys	0m0.941s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.660s
+user	0m7.179s
+sys	0m0.983s
 + xsv select 1,8,19 ../all_train.csv
 
-real	0m5.578s
-user	0m4.918s
-sys	0m0.656s
+real	0m6.574s
+user	0m5.818s
+sys	0m0.741s
 + xsv select '-d\t' 1,8,19 ../all_train.tsv
 
-real	0m5.479s
-user	0m4.838s
-sys	0m0.639s
+real	0m6.503s
+user	0m5.761s
+sys	0m0.738s
 + ../bin/tsv-select -f 1,8,19 ../all_train.tsv
 
-real	0m2.013s
-user	0m1.570s
-sys	0m0.441s
+real	0m2.050s
+user	0m1.584s
+sys	0m0.457s
 + set +x
-+ mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m8.653s
-user	0m7.613s
-sys	0m1.047s
-+ mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m9.674s
+user	0m8.508s
+sys	0m1.163s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m8.641s
-user	0m7.612s
-sys	0m1.037s
-+ gawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m10.224s
+user	0m9.006s
+sys	0m1.213s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m23.318s
-user	0m22.414s
-sys	0m0.908s
-+ gawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m9.492s
+user	0m8.462s
+sys	0m1.022s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m23.367s
-user	0m22.481s
-sys	0m0.883s
-+ frawk -bllvm -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m9.038s
+user	0m8.049s
+sys	0m0.985s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m4.153s
-user	0m4.976s
-sys	0m1.046s
-+ frawk -bllvm -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m4.587s
+user	0m3.639s
+sys	0m0.785s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m4.072s
-user	0m4.916s
-sys	0m1.054s
-+ frawk -bllvm -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m4.391s
+user	0m3.493s
+sys	0m0.796s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m2.157s
-user	0m8.824s
-sys	0m1.091s
-+ frawk -bllvm -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m2.494s
+user	0m8.288s
+sys	0m0.994s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m1.863s
-user	0m7.618s
-sys	0m1.005s
-+ frawk -bcranelift -icsv --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m2.215s
+user	0m7.384s
+sys	0m1.003s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m4.201s
-user	0m5.046s
-sys	0m1.031s
-+ frawk -bcranelift -itsv --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m4.759s
+user	0m3.781s
+sys	0m0.781s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m4.132s
-user	0m4.963s
-sys	0m1.052s
-+ frawk -bcranelift -icsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+real	0m4.317s
+user	0m3.550s
+sys	0m0.785s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
 
-real	0m2.132s
-user	0m8.792s
-sys	0m1.085s
-+ frawk -bcranelift -itsv -pr -j3 --out-file=/dev/null 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+real	0m2.597s
+user	0m8.163s
+sys	0m0.990s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
 
-real	0m1.840s
-user	0m7.572s
-sys	0m1.020s
+real	0m2.266s
+user	0m7.357s
+sys	0m1.010s
 + xsv select 1,8,19 ../all_train.csv
 
-real	0m5.524s
-user	0m4.873s
-sys	0m0.648s
+real	0m6.455s
+user	0m5.715s
+sys	0m0.735s
 + xsv select '-d\t' 1,8,19 ../all_train.tsv
 
-real	0m5.413s
-user	0m4.781s
-sys	0m0.630s
+real	0m6.177s
+user	0m5.449s
+sys	0m0.725s
 + ../bin/tsv-select -f 1,8,19 ../all_train.tsv
 
-real	0m2.101s
-user	0m1.640s
-sys	0m0.459s
+real	0m2.098s
+user	0m1.623s
+sys	0m0.473s
++ set +x
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m9.858s
+user	0m8.678s
+sys	0m1.178s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m9.440s
+user	0m8.304s
+sys	0m1.134s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m8.787s
+user	0m7.830s
+sys	0m0.952s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m9.525s
+user	0m8.503s
+sys	0m1.019s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m4.555s
+user	0m3.724s
+sys	0m0.793s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.109s
+user	0m3.470s
+sys	0m0.769s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.465s
+user	0m8.380s
+sys	0m1.005s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.068s
+user	0m7.329s
+sys	0m0.978s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m3.871s
+user	0m3.322s
+sys	0m0.698s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m3.741s
+user	0m3.178s
+sys	0m0.713s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.230s
+user	0m8.087s
+sys	0m0.946s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m1.969s
+user	0m7.049s
+sys	0m0.936s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m6.496s
+user	0m5.679s
+sys	0m0.793s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m6.337s
+user	0m5.586s
+sys	0m0.749s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m2.172s
+user	0m1.680s
+sys	0m0.488s
++ set +x
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m10.100s
+user	0m8.870s
+sys	0m1.224s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m10.631s
+user	0m9.279s
+sys	0m1.335s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m10.367s
+user	0m9.111s
+sys	0m1.225s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m9.898s
+user	0m8.725s
+sys	0m1.149s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m4.322s
+user	0m3.665s
+sys	0m0.813s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.109s
+user	0m3.484s
+sys	0m0.796s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.166s
+user	0m7.785s
+sys	0m0.890s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.060s
+user	0m7.300s
+sys	0m0.957s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m4.443s
+user	0m3.829s
+sys	0m0.798s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.377s
+user	0m3.732s
+sys	0m0.832s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.193s
+user	0m7.943s
+sys	0m0.917s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.001s
+user	0m7.145s
+sys	0m0.952s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m6.652s
+user	0m5.890s
+sys	0m0.758s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m6.665s
+user	0m5.888s
+sys	0m0.774s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m2.353s
+user	0m1.840s
+sys	0m0.512s
++ set +x
++ ../mawk -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m11.042s
+user	0m9.715s
+sys	0m1.324s
++ ../mawk '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m11.158s
+user	0m9.750s
+sys	0m1.397s
++ ../gawk -b -F, 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m10.366s
+user	0m9.159s
+sys	0m1.186s
++ ../gawk -b '-F\t' 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m10.183s
+user	0m8.999s
+sys	0m1.164s
++ ../frawk -bllvm -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m4.501s
+user	0m3.848s
+sys	0m0.829s
++ ../frawk -bllvm -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.191s
+user	0m3.549s
+sys	0m0.808s
++ ../frawk -bllvm -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.324s
+user	0m8.273s
+sys	0m1.002s
++ ../frawk -bllvm -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.169s
+user	0m7.593s
+sys	0m1.057s
++ ../frawk -bcranelift -icsv 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m4.803s
+user	0m4.098s
+sys	0m0.871s
++ ../frawk -bcranelift -itsv 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m4.209s
+user	0m3.574s
+sys	0m0.792s
++ ../frawk -bcranelift -icsv -pr -j3 'BEGIN { OFS="," } { print $1,$8,$19 }' ../all_train.csv
+
+real	0m2.385s
+user	0m8.479s
+sys	0m1.047s
++ ../frawk -bcranelift -itsv -pr -j3 'BEGIN { OFS="\t" } { print $1,$8,$19 }' ../all_train.tsv
+
+real	0m2.089s
+user	0m7.425s
+sys	0m1.015s
++ xsv select 1,8,19 ../all_train.csv
+
+real	0m6.250s
+user	0m5.507s
+sys	0m0.721s
++ xsv select '-d\t' 1,8,19 ../all_train.tsv
+
+real	0m6.243s
+user	0m5.521s
+sys	0m0.719s
++ ../bin/tsv-select -f 1,8,19 ../all_train.tsv
+
+real	0m2.250s
+user	0m1.749s
+sys	0m0.487s
 + set +x

--- a/info/scripts/stat_2.sh
+++ b/info/scripts/stat_2.sh
@@ -1,9 +1,9 @@
 # Compute the statistics computed by XSV on a string column and numeric column
-MAWK=mawk
-GAWK=gawk
+MAWK=../mawk
+GAWK="../gawk -b"
 TSV_UTILS_BIN=../bin
 XSV=xsv
-FRAWK=frawk
+FRAWK=../frawk
 
 CSV1=../all_train.csv
 CSV2=../TREE_GRM_ESTN.csv

--- a/info/scripts/stat_2.sh.out
+++ b/info/scripts/stat_2.sh.out
@@ -1,520 +1,520 @@
-+ mawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	1m17.570s
-user	1m14.822s
-sys	0m2.736s
-+ gawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	2m14.520s
-user	2m12.386s
-sys	0m2.132s
-+ frawk -bllvm -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m22.575s
-user	0m20.935s
-sys	0m1.640s
-+ frawk -bllvm -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m29.769s
-user	0m28.225s
-sys	0m1.544s
-+ frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851365e21 2222953010690.0 733769247290487.0 13 15 248282826052427.03 180596235718150.3
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.244s
-user	0m26.152s
-sys	0m2.378s
-+ frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851171e21 2222953010690.0 733769247290487.0 13 15 248282826052421.7 180596235717887.5
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m9.951s
-user	0m34.757s
-sys	0m4.145s
-+ frawk -bcranelift -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m30.719s
-user	0m29.202s
-sys	0m1.516s
-+ frawk -bcranelift -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m38.160s
-user	0m36.356s
-sys	0m1.804s
-+ frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202386885225e21 2222953010690.0 733769247290487.0 13 15 248282826052451.38 180596235718779.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m8.139s
-user	0m30.093s
-sys	0m2.265s
-+ frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851682e21 2222953010690.0 733769247290487.0 13 15 248282826052435.75 180596235718162.62
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m9.686s
-user	0m36.343s
-sys	0m2.291s
-+ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.098s
-user	0m33.347s
-sys	0m1.740s
-+ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m32.547s
-user	0m31.043s
-sys	0m1.508s
-+ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
-TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
-9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
-
-real	0m15.944s
-user	0m14.482s
-sys	0m1.444s
-+ set +x
-+ mawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m16.341s
-user	1m14.472s
-sys	0m1.868s
-+ gawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	2m12.405s
-user	2m10.684s
-sys	0m1.720s
-+ frawk -bllvm -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m22.473s
-user	0m21.053s
-sys	0m1.420s
-+ frawk -bllvm -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m30.297s
-user	0m28.469s
+real	1m25.802s
+user	1m23.973s
 sys	0m1.828s
-+ frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202386885143e21 2222953010690.0 733769247290487.0 13 15 248282826052428.8 180596235718092.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.264s
-user	0m26.019s
-sys	0m2.584s
-+ frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851259e21 2222953010690.0 733769247290487.0 13 15 248282826052424.1 180596235718004.53
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m9.665s
-user	0m34.744s
-sys	0m3.301s
-+ frawk -bcranelift -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m31.207s
-user	0m29.675s
-sys	0m1.532s
-+ frawk -bcranelift -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m37.122s
-user	0m35.678s
-sys	0m1.444s
-+ frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851373e21 2222953010690.0 733769247290487.0 13 15 248282826052427.25 180596235717886.75
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.947s
-user	0m29.307s
-sys	0m2.305s
-+ frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851197e21 2222953010690.0 733769247290487.0 13 15 248282826052422.4 180596235718080.84
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m9.771s
-user	0m36.437s
-sys	0m2.540s
-+ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.216s
-user	0m33.445s
-sys	0m1.777s
-+ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m32.481s
-user	0m30.902s
-sys	0m1.584s
-+ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
-TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
-9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
-
-real	0m15.178s
-user	0m13.902s
-sys	0m1.276s
-+ set +x
-+ mawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m17.709s
-user	1m15.560s
-sys	0m2.148s
-+ gawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
++ ../gawk -b '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	2m10.303s
-user	2m8.658s
-sys	0m1.644s
-+ frawk -bllvm -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
+real	1m15.419s
+user	1m13.594s
+sys	0m1.824s
++ ../frawk -bllvm -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m22.733s
-user	0m20.801s
-sys	0m1.932s
-+ frawk -bllvm -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
+real	0m23.620s
+user	0m21.966s
+sys	0m1.652s
++ ../frawk -bllvm -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m29.553s
-user	0m27.410s
-sys	0m2.140s
-+ frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
+real	0m29.242s
+user	0m27.289s
+sys	0m1.952s
++ ../frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851079e21 2222953010690.0 733769247290487.0 13 15 248282826052419.16 180596235718469.44
+TRE_CN 9.022023868851476e21 2222953010690.0 733769247290487.0 13 15 248282826052430.06 180596235718401.44
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m6.972s
-user	0m25.591s
-sys	0m1.855s
-+ frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
+real	0m7.330s
+user	0m26.770s
+sys	0m2.076s
++ ../frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851474e21 2222953010690.0 733769247290487.0 13 15 248282826052430.03 180596235719549.84
+TRE_CN 9.022023868851584e21 2222953010690.0 733769247290487.0 13 15 248282826052433.06 180596235717246.9
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m9.996s
-user	0m34.734s
-sys	0m4.261s
-+ frawk -bcranelift -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m31.131s
-user	0m29.646s
-sys	0m1.484s
-+ frawk -bcranelift -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
+real	0m10.001s
+user	0m35.745s
+sys	0m3.481s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m37.063s
-user	0m35.494s
-sys	0m1.568s
-+ frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
+real	0m36.511s
+user	0m35.086s
+sys	0m1.424s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851247e21 2222953010690.0 733769247290487.0 13 15 248282826052423.78 180596235718298.5
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m7.975s
-user	0m29.368s
-sys	0m2.381s
-+ frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
+real	0m38.407s
+user	0m36.224s
+sys	0m2.180s
++ ../frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851373e21 2222953010690.0 733769247290487.0 13 15 248282826052427.25 180596235717960.78
+TRE_CN 9.022023868851672e21 2222953010690.0 733769247290487.0 13 15 248282826052435.47 180596235718334.34
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m9.665s
-user	0m36.131s
-sys	0m2.418s
+real	0m8.439s
+user	0m31.195s
+sys	0m2.307s
++ ../frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851176e21 2222953010690.0 733769247290487.0 13 15 248282826052421.8 180596235718099.6
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.791s
+user	0m36.774s
+sys	0m2.241s
 + xsv stats -s5,6 ../TREE_GRM_ESTN.csv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m35.746s
-user	0m33.931s
-sys	0m1.821s
+real	0m34.452s
+user	0m32.555s
+sys	0m1.896s
 + xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m32.271s
-user	0m30.651s
-sys	0m1.624s
+real	0m32.761s
+user	0m31.381s
+sys	0m1.385s
 + ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
 TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
 9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
 
-real	0m15.720s
-user	0m14.212s
+real	0m15.469s
+user	0m13.960s
 sys	0m1.508s
 + set +x
-+ mawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	1m16.158s
-user	1m14.244s
-sys	0m1.908s
-+ gawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
+real	1m25.239s
+user	1m23.434s
+sys	0m1.804s
++ ../gawk -b '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	2m25.987s
-user	2m23.990s
-sys	0m1.996s
-+ frawk -bllvm -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
+real	1m15.069s
+user	1m13.112s
+sys	0m1.956s
++ ../frawk -bllvm -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m22.549s
-user	0m21.077s
-sys	0m1.472s
-+ frawk -bllvm -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
+real	0m23.770s
+user	0m22.261s
+sys	0m1.508s
++ ../frawk -bllvm -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m29.625s
-user	0m27.494s
-sys	0m2.132s
-+ frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
+real	0m29.801s
+user	0m27.640s
+sys	0m2.160s
++ ../frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851434e21 2222953010690.0 733769247290487.0 13 15 248282826052428.9 180596235718084.44
+TRE_CN 9.02202386885136e21 2222953010690.0 733769247290487.0 13 15 248282826052426.9 180596235718082.03
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m7.135s
-user	0m25.872s
-sys	0m2.219s
-+ frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
+real	0m7.254s
+user	0m26.669s
+sys	0m1.877s
++ ../frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851219e21 2222953010690.0 733769247290487.0 13 15 248282826052423.0 180596235718086.9
+TRE_CN 9.022023868851029e21 2222953010690.0 733769247290487.0 13 15 248282826052417.78 180596235717511.2
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m9.515s
-user	0m33.901s
-sys	0m3.475s
-+ frawk -bcranelift -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m30.819s
-user	0m29.323s
-sys	0m1.496s
-+ frawk -bcranelift -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
+real	0m9.853s
+user	0m34.607s
+sys	0m3.897s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m37.686s
-user	0m36.163s
-sys	0m1.524s
-+ frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
+real	0m32.379s
+user	0m30.830s
+sys	0m1.548s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851954e21 2222953010690.0 733769247290487.0 13 15 248282826052443.22 180596235718311.22
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m8.106s
-user	0m29.995s
-sys	0m2.236s
-+ frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
+real	0m48.370s
+user	0m46.294s
+sys	0m2.076s
++ ../frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.0220238688513e21 2222953010690.0 733769247290487.0 13 15 248282826052425.22 180596235718064.56
+TRE_CN 9.022023868851589e21 2222953010690.0 733769247290487.0 13 15 248282826052433.2 180596235717071.66
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m9.612s
-user	0m36.049s
-sys	0m2.298s
+real	0m8.663s
+user	0m31.822s
+sys	0m2.544s
++ ../frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851504e21 2222953010690.0 733769247290487.0 13 15 248282826052430.84 180596235717810.06
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m10.427s
+user	0m38.793s
+sys	0m2.765s
 + xsv stats -s5,6 ../TREE_GRM_ESTN.csv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m34.872s
-user	0m33.356s
-sys	0m1.520s
+real	0m34.533s
+user	0m32.801s
+sys	0m1.737s
 + xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m32.688s
-user	0m31.252s
-sys	0m1.440s
+real	0m32.489s
+user	0m31.085s
+sys	0m1.408s
 + ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
 TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
 9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
 
-real	0m15.706s
-user	0m14.390s
-sys	0m1.316s
+real	0m15.455s
+user	0m13.919s
+sys	0m1.536s
 + set +x
-+ mawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	1m17.200s
-user	1m15.232s
-sys	0m1.968s
-+ gawk '-F\t' -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
+real	1m25.280s
+user	1m23.495s
+sys	0m1.784s
++ ../gawk -b '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	2m12.471s
-user	2m10.798s
-sys	0m1.672s
-+ frawk -bllvm -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
+real	1m16.415s
+user	1m14.250s
+sys	0m2.164s
++ ../frawk -bllvm -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m22.969s
-user	0m21.321s
-sys	0m1.648s
-+ frawk -bllvm -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
+real	0m23.274s
+user	0m21.762s
+sys	0m1.512s
++ ../frawk -bllvm -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m29.706s
-user	0m27.742s
-sys	0m1.964s
-+ frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
+real	0m30.243s
+user	0m27.927s
+sys	0m2.316s
++ ../frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851273e21 2222953010690.0 733769247290487.0 13 15 248282826052424.5 180596235718098.16
+TRE_CN 9.02202386885098e21 2222953010690.0 733769247290487.0 13 15 248282826052416.44 180596235718163.66
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m7.357s
-user	0m26.607s
-sys	0m2.336s
-+ frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
+real	0m6.999s
+user	0m25.577s
+sys	0m1.955s
++ ../frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851377e21 2222953010690.0 733769247290487.0 13 15 248282826052427.38 180596235718008.28
+TRE_CN 9.022023868851647e21 2222953010690.0 733769247290487.0 13 15 248282826052434.78 180596235717977.44
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m9.566s
-user	0m34.637s
-sys	0m2.945s
-+ frawk -bcranelift -itsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m32.297s
-user	0m30.445s
-sys	0m1.852s
-+ frawk -bcranelift -icsv -f /tmp/tmp.FsxH0vlPWn ../TREE_GRM_ESTN.csv
+real	0m9.590s
+user	0m34.170s
+sys	0m3.405s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m39.018s
-user	0m37.337s
-sys	0m1.680s
-+ frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.tsv
+real	0m32.622s
+user	0m30.762s
+sys	0m1.860s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851578e21 2222953010690.0 733769247290487.0 13 15 248282826052432.9 180596235718803.22
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m7.982s
-user	0m29.486s
-sys	0m2.251s
-+ frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.FsoodauiQe ../TREE_GRM_ESTN.csv
+real	0m38.074s
+user	0m36.451s
+sys	0m1.620s
++ ../frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851463e21 2222953010690.0 733769247290487.0 13 15 248282826052429.72 180596235718114.47
+TRE_CN 9.022023868851354e21 2222953010690.0 733769247290487.0 13 15 248282826052426.72 180596235718134.9
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m9.782s
-user	0m36.774s
-sys	0m2.247s
+real	0m8.116s
+user	0m29.933s
+sys	0m2.342s
++ ../frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851067e21 2222953010690.0 733769247290487.0 13 15 248282826052418.8 180596235718204.3
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.572s
+user	0m35.868s
+sys	0m2.294s
 + xsv stats -s5,6 ../TREE_GRM_ESTN.csv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m35.593s
-user	0m34.259s
-sys	0m1.336s
+real	0m35.568s
+user	0m33.758s
+sys	0m1.812s
 + xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m33.563s
-user	0m32.036s
-sys	0m1.532s
+real	0m32.155s
+user	0m30.800s
+sys	0m1.356s
 + ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
 TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
 9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
 
-real	0m15.679s
-user	0m14.478s
-sys	0m1.200s
+real	0m15.173s
+user	0m13.839s
+sys	0m1.332s
++ set +x
++ ../mawk '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m26.677s
+user	1m24.636s
+sys	0m2.040s
++ ../gawk -b '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m14.848s
+user	1m13.205s
+sys	0m1.636s
++ ../frawk -bllvm -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m24.356s
+user	0m22.427s
+sys	0m1.928s
++ ../frawk -bllvm -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m29.069s
+user	0m27.313s
+sys	0m1.756s
++ ../frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851289e21 2222953010690.0 733769247290487.0 13 15 248282826052424.94 180596235718054.44
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.326s
+user	0m26.428s
+sys	0m2.389s
++ ../frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851258e21 2222953010690.0 733769247290487.0 13 15 248282826052424.06 180596235717631.44
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.552s
+user	0m34.792s
+sys	0m2.821s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m32.741s
+user	0m30.909s
+sys	0m1.832s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m37.997s
+user	0m36.265s
+sys	0m1.732s
++ ../frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851364e21 2222953010690.0 733769247290487.0 13 15 248282826052427.0 180596235718137.94
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m8.210s
+user	0m30.266s
+sys	0m2.354s
++ ../frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851566e21 2222953010690.0 733769247290487.0 13 15 248282826052432.56 180596235718164.06
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m14.287s
+user	0m51.647s
+sys	0m3.819s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.547s
+user	0m33.023s
+sys	0m1.528s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m32.883s
+user	0m31.278s
+sys	0m1.609s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.150s
+user	0m14.014s
+sys	0m1.136s
++ set +x
++ ../mawk '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m28.030s
+user	1m25.746s
+sys	0m2.264s
++ ../gawk -b '-F\t' -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m14.286s
+user	1m12.650s
+sys	0m1.636s
++ ../frawk -bllvm -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m24.074s
+user	0m22.135s
+sys	0m1.940s
++ ../frawk -bllvm -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m28.816s
+user	0m27.060s
+sys	0m1.756s
++ ../frawk -bllvm -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851294e21 2222953010690.0 733769247290487.0 13 15 248282826052425.1 180596235718227.44
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.377s
+user	0m26.937s
+sys	0m2.105s
++ ../frawk -bllvm -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851783e21 2222953010690.0 733769247290487.0 13 15 248282826052438.53 180596235718069.66
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m10.115s
+user	0m35.064s
+sys	0m4.208s
++ ../frawk -bcranelift -itsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m33.613s
+user	0m31.925s
+sys	0m1.688s
++ ../frawk -bcranelift -icsv -f /tmp/tmp.wutEByQ1BZ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m38.597s
+user	0m36.797s
+sys	0m1.800s
++ ../frawk -bcranelift -pr -j3 -itsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202386885144e21 2222953010690.0 733769247290487.0 13 15 248282826052429.1 180596235718224.75
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m8.044s
+user	0m29.689s
+sys	0m2.318s
++ ../frawk -bcranelift -pr -j3 -icsv -f /tmp/tmp.tczoevwKNQ ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851222e21 2222953010690.0 733769247290487.0 13 15 248282826052423.1 180596235717967.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m9.726s
+user	0m36.341s
+sys	0m2.434s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.106s
+user	0m32.526s
+sys	0m1.584s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m31.810s
+user	0m30.590s
+sys	0m1.224s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m15.509s
+user	0m14.076s
+sys	0m1.432s
 + set +x

--- a/info/scripts/stat_2.sh.out.mac
+++ b/info/scripts/stat_2.sh.out.mac
@@ -1,520 +1,520 @@
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	1m15.433s
-user	1m13.888s
-sys	0m1.538s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
+real	1m27.206s
+user	1m24.545s
+sys	0m2.492s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	1m37.279s
-user	1m35.804s
-sys	0m1.461s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m17.869s
-user	0m16.853s
-sys	0m1.011s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m21.236s
-user	0m20.090s
-sys	0m1.142s
-+ frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202386885136e21 2222953010690.0 733769247290487.0 13 15 248282826052426.9 180596235718121.4
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m5.426s
-user	0m20.150s
-sys	0m1.080s
-+ frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851368e21 2222953010690.0 733769247290487.0 13 15 248282826052427.1 180596235718114.12
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.239s
-user	0m23.326s
-sys	0m1.210s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m23.217s
-user	0m22.226s
-sys	0m0.986s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m26.877s
-user	0m25.729s
-sys	0m1.141s
-+ frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851362e21 2222953010690.0 733769247290487.0 13 15 248282826052426.97 180596235718117.56
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.436s
-user	0m24.191s
-sys	0m1.255s
-+ frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851353e21 2222953010690.0 733769247290487.0 13 15 248282826052426.7 180596235718110.94
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.188s
-user	0m27.417s
-sys	0m1.251s
-+ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.598s
-user	0m34.487s
-sys	0m1.106s
-+ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.084s
-user	0m34.116s
-sys	0m0.964s
-+ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
-TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
-9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
-
-real	0m10.014s
-user	0m9.377s
-sys	0m0.634s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m14.280s
-user	1m12.693s
-sys	0m1.579s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m35.863s
-user	1m34.392s
-sys	0m1.457s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m17.775s
-user	0m16.764s
-sys	0m1.005s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m21.285s
-user	0m20.154s
-sys	0m1.127s
-+ frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851358e21 2222953010690.0 733769247290487.0 13 15 248282826052426.84 180596235718123.5
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m5.485s
-user	0m20.404s
-sys	0m1.099s
-+ frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851301e21 2222953010690.0 733769247290487.0 13 15 248282826052425.25 180596235718116.8
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.200s
-user	0m23.174s
-sys	0m1.206s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m23.289s
-user	0m22.257s
-sys	0m1.028s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m26.691s
-user	0m25.559s
-sys	0m1.127s
-+ frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851391e21 2222953010690.0 733769247290487.0 13 15 248282826052427.75 180596235718080.03
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.432s
-user	0m24.184s
-sys	0m1.238s
-+ frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851426e21 2222953010690.0 733769247290487.0 13 15 248282826052428.72 180596235718115.66
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.008s
-user	0m26.726s
-sys	0m1.228s
-+ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.126s
-user	0m34.028s
-sys	0m1.094s
-+ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m33.607s
-user	0m32.636s
-sys	0m0.967s
-+ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
-TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
-9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
-
-real	0m10.128s
-user	0m9.488s
-sys	0m0.635s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m13.730s
-user	1m12.190s
-sys	0m1.531s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m35.077s
-user	1m33.614s
-sys	0m1.449s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m17.750s
-user	0m16.752s
-sys	0m0.992s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m21.210s
-user	0m20.085s
-sys	0m1.119s
-+ frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851307e21 2222953010690.0 733769247290487.0 13 15 248282826052425.44 180596235718113.84
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m5.361s
-user	0m19.965s
-sys	0m1.067s
-+ frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851354e21 2222953010690.0 733769247290487.0 13 15 248282826052426.72 180596235718120.84
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.323s
-user	0m23.661s
-sys	0m1.212s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m23.184s
-user	0m22.182s
-sys	0m1.000s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m26.741s
-user	0m25.599s
-sys	0m1.137s
-+ frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851402e21 2222953010690.0 733769247290487.0 13 15 248282826052428.06 180596235718107.78
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.375s
-user	0m23.984s
-sys	0m1.227s
-+ frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202386885145e21 2222953010690.0 733769247290487.0 13 15 248282826052429.34 180596235718108.44
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.107s
-user	0m27.126s
-sys	0m1.225s
-+ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.024s
-user	0m33.930s
-sys	0m1.092s
-+ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m33.749s
-user	0m32.782s
-sys	0m0.961s
-+ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
-TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
-9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
-
-real	0m10.024s
-user	0m9.394s
-sys	0m0.627s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m15.018s
-user	1m13.446s
-sys	0m1.563s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m36.447s
-user	1m34.932s
-sys	0m1.501s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m17.685s
-user	0m16.670s
-sys	0m1.009s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m21.435s
-user	0m20.308s
-sys	0m1.123s
-+ frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202386885133e21 2222953010690.0 733769247290487.0 13 15 248282826052426.06 180596235718114.06
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m5.341s
-user	0m19.868s
-sys	0m1.074s
-+ frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851262e21 2222953010690.0 733769247290487.0 13 15 248282826052424.2 180596235718105.56
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.185s
-user	0m23.135s
-sys	0m1.182s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m23.112s
-user	0m22.123s
-sys	0m0.987s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m26.641s
-user	0m25.507s
-sys	0m1.128s
-+ frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851274e21 2222953010690.0 733769247290487.0 13 15 248282826052424.53 180596235718122.22
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m6.400s
-user	0m24.061s
-sys	0m1.235s
-+ frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851264e21 2222953010690.0 733769247290487.0 13 15 248282826052424.25 180596235718128.66
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m7.058s
-user	0m26.918s
-sys	0m1.239s
-+ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m35.191s
-user	0m34.082s
-sys	0m1.105s
-+ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
-field,type,sum,min,max,min_length,max_length,mean,stddev
-TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
-LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
-
-real	0m32.987s
-user	0m32.028s
-sys	0m0.955s
-+ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
-TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
-9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
-
-real	0m9.975s
-user	0m9.345s
-sys	0m0.626s
-+ set +x
-+ mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m14.765s
-user	1m13.214s
-sys	0m1.545s
-+ gawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	1m34.907s
-user	1m33.405s
+real	1m15.747s
+user	1m14.227s
 sys	0m1.490s
-+ frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m17.710s
-user	0m16.694s
-sys	0m1.010s
-+ frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
+real	0m18.385s
+user	0m17.213s
+sys	0m1.046s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m21.204s
-user	0m20.074s
-sys	0m1.126s
-+ frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
+real	0m22.931s
+user	0m21.199s
+sys	0m1.705s
++ ../frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851337e21 2222953010690.0 733769247290487.0 13 15 248282826052426.28 180596235718114.16
+TRE_CN 9.022023868851483e21 2222953010690.0 733769247290487.0 13 15 248282826052430.28 180596235718120.88
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m5.358s
-user	0m19.952s
-sys	0m1.064s
-+ frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
+real	0m5.828s
+user	0m21.628s
+sys	0m1.165s
++ ../frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851256e21 2222953010690.0 733769247290487.0 13 15 248282826052424.0 180596235718112.97
+TRE_CN 9.022023868851487e21 2222953010690.0 733769247290487.0 13 15 248282826052430.4 180596235718119.44
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m6.110s
-user	0m22.840s
-sys	0m1.189s
-+ frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.tsv
-field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
-LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
-
-real	0m23.728s
-user	0m22.669s
-sys	0m1.048s
-+ frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.71o1UlWv ../TREE_GRM_ESTN.csv
+real	0m6.669s
+user	0m24.935s
+sys	0m1.286s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
 TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m27.660s
-user	0m26.445s
-sys	0m1.205s
-+ frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.tsv
+real	0m25.271s
+user	0m24.198s
+sys	0m1.059s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851253e21 2222953010690.0 733769247290487.0 13 15 248282826052423.97 180596235718123.94
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m6.649s
-user	0m25.049s
-sys	0m1.250s
-+ frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.GpqVZZeg ../TREE_GRM_ESTN.csv
+real	0m28.580s
+user	0m27.387s
+sys	0m1.188s
++ ../frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
 field sum min max min_length max_length mean stddev
-TRE_CN 9.022023868851216e21 2222953010690.0 733769247290487.0 13 15 248282826052422.9 180596235718116.75
+TRE_CN 9.022023868851318e21 2222953010690.0 733769247290487.0 13 15 248282826052425.75 180596235718118.34
 LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
 
-real	0m7.241s
-user	0m27.643s
-sys	0m1.245s
+real	0m6.610s
+user	0m24.892s
+sys	0m1.303s
++ ../frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851284e21 2222953010690.0 733769247290487.0 13 15 248282826052424.78 180596235718119.25
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.552s
+user	0m28.827s
+sys	0m1.301s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m35.429s
+user	0m34.258s
+sys	0m1.150s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m35.088s
+user	0m34.038s
+sys	0m1.047s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m10.609s
+user	0m9.887s
+sys	0m0.702s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m17.540s
+user	1m15.862s
+sys	0m1.659s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m17.451s
+user	1m15.872s
+sys	0m1.538s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m18.813s
+user	0m17.619s
+sys	0m1.072s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.033s
+user	0m21.331s
+sys	0m1.678s
++ ../frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851532e21 2222953010690.0 733769247290487.0 13 15 248282826052431.62 180596235718127.8
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.126s
+user	0m22.738s
+sys	0m1.222s
++ ../frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851478e21 2222953010690.0 733769247290487.0 13 15 248282826052430.12 180596235718119.8
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.803s
+user	0m25.427s
+sys	0m1.331s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m25.999s
+user	0m24.856s
+sys	0m1.101s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m32.528s
+user	0m31.146s
+sys	0m1.369s
++ ../frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851346e21 2222953010690.0 733769247290487.0 13 15 248282826052426.5 180596235718110.44
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.145s
+user	0m26.835s
+sys	0m1.423s
++ ../frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851276e21 2222953010690.0 733769247290487.0 13 15 248282826052424.6 180596235718110.16
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m8.014s
+user	0m30.488s
+sys	0m1.417s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m39.832s
+user	0m38.536s
+sys	0m1.278s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m37.532s
+user	0m36.384s
+sys	0m1.129s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m11.008s
+user	0m10.285s
+sys	0m0.706s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m17.037s
+user	1m15.397s
+sys	0m1.625s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m13.492s
+user	1m12.011s
+sys	0m1.450s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m17.923s
+user	0m16.902s
+sys	0m1.013s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m21.682s
+user	0m20.523s
+sys	0m1.154s
++ ../frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851306e21 2222953010690.0 733769247290487.0 13 15 248282826052425.4 180596235718108.53
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m5.498s
+user	0m20.444s
+sys	0m1.091s
++ ../frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202386885134e21 2222953010690.0 733769247290487.0 13 15 248282826052426.34 180596235718111.1
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.336s
+user	0m23.662s
+sys	0m1.234s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.873s
+user	0m22.850s
+sys	0m1.019s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m27.897s
+user	0m26.728s
+sys	0m1.163s
++ ../frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851348e21 2222953010690.0 733769247290487.0 13 15 248282826052426.56 180596235718116.66
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.430s
+user	0m24.224s
+sys	0m1.263s
++ ../frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851331e21 2222953010690.0 733769247290487.0 13 15 248282826052426.1 180596235718122.34
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.392s
+user	0m28.185s
+sys	0m1.293s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m35.392s
+user	0m34.277s
+sys	0m1.120s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m33.925s
+user	0m32.945s
+sys	0m1.000s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m10.043s
+user	0m9.388s
+sys	0m0.653s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m14.687s
+user	1m13.115s
+sys	0m1.567s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m15.114s
+user	1m13.631s
+sys	0m1.472s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m17.914s
+user	0m16.897s
+sys	0m1.012s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m21.695s
+user	0m20.531s
+sys	0m1.158s
++ ../frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851417e21 2222953010690.0 733769247290487.0 13 15 248282826052428.47 180596235718122.75
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m5.476s
+user	0m20.360s
+sys	0m1.081s
++ ../frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851238e21 2222953010690.0 733769247290487.0 13 15 248282826052423.53 180596235718113.03
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.290s
+user	0m23.495s
+sys	0m1.221s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m24.126s
+user	0m23.092s
+sys	0m1.029s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m27.817s
+user	0m26.641s
+sys	0m1.169s
++ ../frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851332e21 2222953010690.0 733769247290487.0 13 15 248282826052426.12 180596235718109.75
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.374s
+user	0m24.018s
+sys	0m1.254s
++ ../frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851306e21 2222953010690.0 733769247290487.0 13 15 248282826052425.4 180596235718116.3
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.249s
+user	0m27.652s
+sys	0m1.264s
 + xsv stats -s5,6 ../TREE_GRM_ESTN.csv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
 real	0m35.361s
-user	0m34.259s
-sys	0m1.098s
+user	0m34.242s
+sys	0m1.117s
 + xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
 field,type,sum,min,max,min_length,max_length,mean,stddev
 TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
 LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
 
-real	0m33.352s
-user	0m32.385s
-sys	0m0.962s
+real	0m33.462s
+user	0m32.469s
+sys	0m0.988s
 + ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
 TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
 9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
 
-real	0m9.954s
-user	0m9.324s
-sys	0m0.627s
+real	0m9.958s
+user	0m9.310s
+sys	0m0.644s
++ set +x
++ ../mawk '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202e+21 2.22295e+12 7.33769e+14 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m14.218s
+user	1m12.634s
+sys	0m1.577s
++ ../gawk -b '-F\t' -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9022023868854687498240 2222953010690 733769247290487 13 15 2.48283e+14 1.80596e+14
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	1m12.807s
+user	1m11.373s
+sys	0m1.426s
++ ../frawk -bllvm -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m17.829s
+user	0m16.818s
+sys	0m1.006s
++ ../frawk -bllvm -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m21.839s
+user	0m20.674s
+sys	0m1.160s
++ ../frawk -bllvm -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851382e21 2222953010690.0 733769247290487.0 13 15 248282826052427.5 180596235718119.2
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m5.494s
+user	0m20.406s
+sys	0m1.103s
++ ../frawk -bllvm -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851354e21 2222953010690.0 733769247290487.0 13 15 248282826052426.72 180596235718119.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.247s
+user	0m23.310s
+sys	0m1.234s
++ ../frawk -bcranelift -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m23.887s
+user	0m22.858s
+sys	0m1.025s
++ ../frawk -bcranelift -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.sk4jkmSl ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868854687e21 2222953010690.0 733769247290487.0 13 15 248282826052518.47 180596230748189.72
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m27.357s
+user	0m26.191s
+sys	0m1.160s
++ ../frawk -bcranelift -pr -j3 -itsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.tsv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.022023868851365e21 2222953010690.0 733769247290487.0 13 15 248282826052427.03 180596235718107.47
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m6.443s
+user	0m24.262s
+sys	0m1.269s
++ ../frawk -bcranelift -pr -j3 -icsv -f /var/folders/lk/z180jcy521q16mmx05sxfwh00000gn/T/tmp.1p69Q89k ../TREE_GRM_ESTN.csv
+field sum min max min_length max_length mean stddev
+TRE_CN 9.02202386885136e21 2222953010690.0 733769247290487.0 13 15 248282826052426.9 180596235718109.16
+LAND_BASIS NA FORESTLAND TIMBERLAND 10 10 NA NA
+
+real	0m7.208s
+user	0m27.489s
+sys	0m1.264s
++ xsv stats -s5,6 ../TREE_GRM_ESTN.csv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m34.911s
+user	0m33.787s
+sys	0m1.123s
++ xsv stats -s5,6 '-d\t' ../TREE_GRM_ESTN.tsv
+field,type,sum,min,max,min_length,max_length,mean,stddev
+TRE_CN,Integer,1566016807328529198,2222953010690,733769247290487,13,15,248282826052421.97,180596228263218.22
+LAND_BASIS,Unicode,,FORESTLAND,TIMBERLAND,10,10,,
+
+real	0m33.437s
+user	0m32.455s
+sys	0m0.978s
++ ../bin/tsv-summarize -H --sum 5 --mean 5 --min 5 --max 5 --stdev 5 --mean 5 ../TREE_GRM_ESTN.tsv
+TRE_CN_sum	TRE_CN_mean	TRE_CN_min	TRE_CN_max	TRE_CN_stdev	TRE_CN_mean
+9.02202386885e+21	2.48282826053e+14	2222953010690	733769247290487	1.80596230748e+14	2.48282826053e+14
+
+real	0m10.130s
+user	0m9.475s
+sys	0m0.652s
 + set +x

--- a/info/scripts/sum2.sh
+++ b/info/scripts/sum2.sh
@@ -1,10 +1,10 @@
 # Sum 2 numeric fields
 
-MAWK=mawk
-GAWK=gawk
+MAWK=../mawk
+GAWK="../gawk -b"
 TSV_UTILS_BIN=../bin
 XSV=xsv
-FRAWK=frawk
+FRAWK=../frawk
 
 CSV1=../all_train.csv
 CSV2=../TREE_GRM_ESTN.csv

--- a/info/scripts/sum2.sh.out
+++ b/info/scripts/sum2.sh.out
@@ -1,735 +1,735 @@
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m10.253s
-user	0m8.853s
-sys	0m1.400s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m10.327s
+user	0m9.171s
+sys	0m1.156s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.26983e+21 9.02202e+21
 
-real	0m51.419s
-user	0m49.455s
-sys	0m1.960s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m55.451s
+user	0m53.691s
+sys	0m1.760s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m10.364s
-user	0m9.104s
-sys	0m1.260s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m11.108s
+user	0m9.735s
+sys	0m1.373s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	1m9.611s
-user	1m8.614s
-sys	0m0.996s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m11.445s
+user	0m10.233s
+sys	0m1.212s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	1m9.380s
-user	1m8.259s
-sys	0m1.120s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6269827758986837884928 9022023868854687498240
-
-real	1m6.159s
-user	1m4.270s
-sys	0m1.888s
-+ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
-f4_sum	f16_sum
--735.018072245	-3875.32465696
-
-real	0m4.022s
-user	0m3.114s
-sys	0m0.908s
-+ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
-PLT_CN_sum	TRE_CN_sum
-6.26982775899e+21	9.02202386885e+21
-
-real	0m7.640s
-user	0m6.344s
-sys	0m1.296s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m8.173s
-user	0m7.373s
-sys	0m0.801s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m26.423s
-user	0m24.455s
-sys	0m1.968s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m8.376s
-user	0m7.204s
-sys	0m1.172s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.609s
-user	0m18.009s
-sys	0m1.600s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.3246569558305
-
-real	0m4.788s
-user	0m13.841s
-sys	0m3.490s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759017031e21 9.022023868851365e21
-
-real	0m10.230s
-user	0m34.100s
-sys	0m5.141s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018072244639 -3875.3246569558305
-
-real	0m4.034s
-user	0m12.744s
-sys	0m2.658s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013637e21 9.02202386885125e21
-
-real	0m7.503s
-user	0m25.793s
-sys	0m3.621s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m8.642s
-user	0m7.525s
-sys	0m1.117s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m26.540s
-user	0m24.619s
-sys	0m1.913s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m8.363s
-user	0m7.323s
-sys	0m1.040s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m20.455s
-user	0m18.963s
-sys	0m1.492s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.3246569558296
-
-real	0m4.704s
-user	0m13.661s
-sys	0m3.399s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759015126e21 9.022023868850528e21
-
-real	0m10.235s
-user	0m34.204s
-sys	0m5.302s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446387 -3875.32465695583
-
-real	0m3.991s
-user	0m12.547s
-sys	0m2.739s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013885e21 9.022023868851301e21
-
-real	0m7.276s
-user	0m25.363s
-sys	0m3.432s
-+ set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m10.344s
-user	0m9.072s
-sys	0m1.272s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26983e+21 9.02202e+21
-
-real	0m51.218s
-user	0m49.430s
-sys	0m1.788s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m10.315s
-user	0m9.030s
-sys	0m1.285s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	1m11.224s
-user	1m10.231s
-sys	0m0.992s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	1m10.677s
-user	1m9.343s
-sys	0m1.332s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6269827758986837884928 9022023868854687498240
-
-real	1m3.577s
-user	1m2.024s
-sys	0m1.552s
-+ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
-f4_sum	f16_sum
--735.018072245	-3875.32465696
-
-real	0m4.030s
-user	0m3.069s
-sys	0m0.961s
-+ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
-PLT_CN_sum	TRE_CN_sum
-6.26982775899e+21	9.02202386885e+21
-
-real	0m7.616s
-user	0m6.336s
-sys	0m1.277s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m8.446s
-user	0m7.458s
-sys	0m0.988s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m26.133s
-user	0m24.057s
-sys	0m2.076s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m8.655s
-user	0m7.507s
-sys	0m1.148s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.723s
-user	0m18.219s
-sys	0m1.504s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446387 -3875.32465695583
-
-real	0m4.793s
-user	0m13.678s
-sys	0m3.707s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759014722e21 9.02202386885104e21
-
-real	0m10.083s
-user	0m33.702s
-sys	0m5.221s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446386 -3875.32465695583
-
-real	0m4.133s
-user	0m12.591s
-sys	0m2.962s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013752e21 9.022023868851098e21
-
-real	0m6.934s
-user	0m24.678s
-sys	0m2.802s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m8.654s
-user	0m7.430s
-sys	0m1.224s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m26.082s
-user	0m24.526s
-sys	0m1.556s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m8.120s
-user	0m6.923s
-sys	0m1.197s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m20.676s
-user	0m18.860s
-sys	0m1.816s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018072244638 -3875.3246569558305
-
-real	0m4.739s
-user	0m13.670s
-sys	0m3.565s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013543e21 9.022023868851497e21
-
-real	0m9.977s
-user	0m34.340s
-sys	0m4.633s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558314
-
-real	0m4.390s
-user	0m13.166s
-sys	0m3.373s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013627e21 9.022023868851387e21
-
-real	0m6.980s
-user	0m24.954s
-sys	0m2.806s
-+ set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m10.276s
-user	0m8.920s
-sys	0m1.356s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26983e+21 9.02202e+21
-
-real	0m53.439s
-user	0m51.439s
-sys	0m2.000s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m10.421s
-user	0m9.281s
-sys	0m1.140s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	1m9.870s
-user	1m8.565s
+real	0m11.505s
+user	0m10.200s
 sys	0m1.304s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	1m10.119s
-user	1m8.818s
-sys	0m1.300s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6269827758986837884928 9022023868854687498240
 
-real	1m5.089s
-user	1m3.452s
-sys	0m1.636s
+real	0m22.928s
+user	0m21.259s
+sys	0m1.668s
 + ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
 f4_sum	f16_sum
 -735.018072245	-3875.32465696
 
-real	0m4.112s
-user	0m3.188s
-sys	0m0.924s
+real	0m3.944s
+user	0m2.884s
+sys	0m1.060s
 + ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
 PLT_CN_sum	TRE_CN_sum
 6.26982775899e+21	9.02202386885e+21
 
-real	0m7.833s
-user	0m6.553s
-sys	0m1.280s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m7.873s
+user	0m6.660s
+sys	0m1.212s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.240s
-user	0m7.160s
-sys	0m1.080s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m8.680s
+user	0m7.472s
+sys	0m1.208s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m32.545s
-user	0m30.425s
-sys	0m2.120s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m25.182s
+user	0m23.566s
+sys	0m1.616s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.152s
-user	0m6.937s
-sys	0m1.216s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m8.112s
+user	0m6.824s
+sys	0m1.288s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m19.689s
-user	0m18.269s
-sys	0m1.420s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.3246569558305
+real	0m23.381s
+user	0m21.839s
+sys	0m1.540s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446387 -3875.3246569558305
 
-real	0m5.097s
-user	0m14.319s
-sys	0m3.783s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759017729e21 9.022023868851269e21
+real	0m4.787s
+user	0m13.510s
+sys	0m3.563s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759015834e21 9.022023868851663e21
 
-real	0m10.236s
-user	0m33.412s
-sys	0m5.814s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558296
+real	0m10.195s
+user	0m33.386s
+sys	0m5.423s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446387 -3875.32465695583
 
-real	0m4.516s
-user	0m13.130s
-sys	0m3.378s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013821e21 9.022023868851195e21
+real	0m4.106s
+user	0m12.726s
+sys	0m2.762s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759014262e21 9.022023868851677e21
 
-real	0m7.534s
-user	0m25.845s
-sys	0m3.708s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m7.095s
+user	0m25.020s
+sys	0m2.867s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.464s
-user	0m7.260s
-sys	0m1.204s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m8.327s
+user	0m7.127s
+sys	0m1.200s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m26.819s
-user	0m24.661s
-sys	0m2.156s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m26.245s
+user	0m24.225s
+sys	0m2.020s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.322s
-user	0m7.105s
-sys	0m1.217s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m7.946s
+user	0m7.094s
+sys	0m0.852s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m20.289s
-user	0m18.697s
-sys	0m1.592s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446387 -3875.3246569558314
+real	0m20.115s
+user	0m18.467s
+sys	0m1.648s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446391 -3875.3246569558305
 
-real	0m4.769s
-user	0m13.932s
-sys	0m3.532s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759015467e21 9.022023868850991e21
+real	0m4.727s
+user	0m13.835s
+sys	0m3.312s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013926e21 9.022023868851753e21
 
-real	0m10.416s
-user	0m34.877s
-sys	0m5.190s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.32465695583
+real	0m9.995s
+user	0m33.662s
+sys	0m4.850s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446391 -3875.324656955831
 
-real	0m4.236s
-user	0m12.757s
-sys	0m3.107s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013559e21 9.022023868851204e21
+real	0m4.772s
+user	0m13.980s
+sys	0m3.471s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013546e21 9.02202386885106e21
 
-real	0m6.875s
-user	0m24.593s
-sys	0m2.733s
+real	0m7.147s
+user	0m24.973s
+sys	0m3.186s
 + set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m10.508s
-user	0m9.111s
-sys	0m1.397s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m10.645s
+user	0m9.521s
+sys	0m1.124s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.26983e+21 9.02202e+21
 
-real	0m50.968s
-user	0m48.979s
-sys	0m1.988s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m54.888s
+user	0m53.276s
+sys	0m1.612s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m10.321s
-user	0m8.904s
-sys	0m1.417s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m10.727s
+user	0m9.343s
+sys	0m1.384s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	1m10.154s
-user	1m8.921s
-sys	0m1.232s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m11.490s
+user	0m10.142s
+sys	0m1.348s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	1m11.540s
-user	1m10.243s
-sys	0m1.296s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m11.558s
+user	0m10.454s
+sys	0m1.104s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6269827758986837884928 9022023868854687498240
 
-real	1m5.224s
-user	1m3.515s
-sys	0m1.708s
+real	0m22.988s
+user	0m21.572s
+sys	0m1.416s
 + ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
 f4_sum	f16_sum
 -735.018072245	-3875.32465696
 
-real	0m3.989s
-user	0m3.066s
-sys	0m0.924s
+real	0m3.919s
+user	0m2.963s
+sys	0m0.956s
 + ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
 PLT_CN_sum	TRE_CN_sum
 6.26982775899e+21	9.02202386885e+21
 
-real	0m7.831s
-user	0m6.599s
-sys	0m1.233s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m7.553s
+user	0m6.420s
+sys	0m1.132s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.281s
-user	0m7.112s
-sys	0m1.168s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m8.247s
+user	0m7.239s
+sys	0m1.008s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m26.442s
-user	0m24.310s
-sys	0m2.132s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m25.190s
+user	0m23.367s
+sys	0m1.824s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.248s
-user	0m7.176s
-sys	0m1.072s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m8.204s
+user	0m7.028s
+sys	0m1.176s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m19.807s
-user	0m18.315s
-sys	0m1.492s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m19.650s
+user	0m18.174s
+sys	0m1.476s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.3246569558305
+
+real	0m4.672s
+user	0m13.427s
+sys	0m3.385s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.26982775901368e21 9.022023868850723e21
+
+real	0m9.779s
+user	0m32.681s
+sys	0m4.917s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446385 -3875.32465695583
+
+real	0m4.361s
+user	0m12.807s
+sys	0m3.124s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26982775901376e21 9.022023868851208e21
+
+real	0m7.389s
+user	0m25.094s
+sys	0m3.730s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.323s
+user	0m7.067s
+sys	0m1.256s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.735s
+user	0m23.579s
+sys	0m2.144s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.482s
+user	0m7.518s
+sys	0m0.964s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.059s
+user	0m18.307s
+sys	0m1.752s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446386 -3875.3246569558305
+
+real	0m4.557s
+user	0m13.251s
+sys	0m3.285s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759014706e21 9.022023868851074e21
+
+real	0m10.078s
+user	0m33.407s
+sys	0m5.325s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446385 -3875.3246569558305
+
+real	0m3.979s
+user	0m12.782s
+sys	0m2.645s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759014562e21 9.022023868851187e21
+
+real	0m6.902s
+user	0m24.601s
+sys	0m2.706s
++ set +x
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.254s
+user	0m9.106s
+sys	0m1.148s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m54.757s
+user	0m53.009s
+sys	0m1.748s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.917s
+user	0m9.476s
+sys	0m1.440s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m11.640s
+user	0m10.528s
+sys	0m1.112s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m11.590s
+user	0m10.254s
+sys	0m1.336s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	0m23.366s
+user	0m21.890s
+sys	0m1.476s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m3.906s
+user	0m2.974s
+sys	0m0.932s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.547s
+user	0m6.199s
+sys	0m1.348s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.250s
+user	0m7.278s
+sys	0m0.972s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.811s
+user	0m24.183s
+sys	0m1.628s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.399s
+user	0m7.223s
+sys	0m1.177s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.615s
+user	0m18.059s
+sys	0m1.556s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446386 -3875.324656955831
+
+real	0m5.046s
+user	0m14.466s
+sys	0m3.533s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759014702e21 9.022023868852036e21
+
+real	0m10.380s
+user	0m33.746s
+sys	0m5.829s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m4.336s
+user	0m12.882s
+sys	0m3.208s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013914e21 9.022023868850916e21
+
+real	0m7.336s
+user	0m25.377s
+sys	0m3.473s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.611s
+user	0m7.320s
+sys	0m1.292s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m26.076s
+user	0m24.108s
+sys	0m1.968s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.980s
+user	0m6.964s
+sys	0m1.016s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.042s
+user	0m18.238s
+sys	0m1.804s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446388 -3875.3246569558305
 
-real	0m4.803s
-user	0m14.008s
-sys	0m3.559s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759015729e21 9.022023868851616e21
+real	0m4.546s
+user	0m13.692s
+sys	0m3.223s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759014243e21 9.022023868851015e21
 
-real	0m10.084s
-user	0m33.997s
-sys	0m4.970s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446387 -3875.3246569558305
+real	0m9.862s
+user	0m33.789s
+sys	0m4.469s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446387 -3875.32465695583
 
-real	0m4.176s
-user	0m12.792s
-sys	0m2.857s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013446e21 9.022023868851042e21
+real	0m3.989s
+user	0m12.709s
+sys	0m2.662s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013782e21 9.022023868851849e21
 
-real	0m7.421s
-user	0m25.534s
-sys	0m3.594s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m8.704s
-user	0m7.576s
-sys	0m1.128s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m26.722s
-user	0m24.687s
-sys	0m2.032s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m8.638s
-user	0m7.542s
-sys	0m1.096s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m20.993s
-user	0m19.172s
-sys	0m1.820s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446387 -3875.3246569558305
-
-real	0m4.534s
-user	0m13.776s
-sys	0m3.116s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.26982775901529e21 9.022023868851587e21
-
-real	0m10.306s
-user	0m34.807s
-sys	0m5.113s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558305
-
-real	0m4.524s
-user	0m13.414s
-sys	0m3.409s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26982775901347e21 9.022023868851534e21
-
-real	0m6.856s
-user	0m24.768s
-sys	0m2.556s
+real	0m7.256s
+user	0m25.412s
+sys	0m3.171s
 + set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m10.260s
-user	0m8.988s
-sys	0m1.272s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m10.402s
+user	0m9.373s
+sys	0m1.028s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.26983e+21 9.02202e+21
 
-real	0m51.004s
-user	0m48.943s
-sys	0m2.060s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m55.292s
+user	0m53.428s
+sys	0m1.864s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m10.513s
-user	0m9.396s
-sys	0m1.116s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m11.050s
+user	0m9.770s
+sys	0m1.280s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	1m10.374s
-user	1m9.233s
-sys	0m1.140s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m11.626s
+user	0m10.366s
+sys	0m1.261s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	1m10.613s
-user	1m9.480s
-sys	0m1.132s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m11.517s
+user	0m10.109s
+sys	0m1.408s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6269827758986837884928 9022023868854687498240
 
-real	1m4.328s
-user	1m2.391s
-sys	0m1.936s
+real	0m23.243s
+user	0m21.582s
+sys	0m1.660s
 + ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
 f4_sum	f16_sum
 -735.018072245	-3875.32465696
 
-real	0m3.805s
-user	0m2.921s
-sys	0m0.885s
+real	0m3.896s
+user	0m2.944s
+sys	0m0.952s
 + ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
 PLT_CN_sum	TRE_CN_sum
 6.26982775899e+21	9.02202386885e+21
 
-real	0m7.833s
-user	0m6.424s
-sys	0m1.408s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m7.746s
+user	0m6.526s
+sys	0m1.220s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.379s
-user	0m7.187s
-sys	0m1.192s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m8.184s
+user	0m7.036s
+sys	0m1.148s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m26.540s
-user	0m24.608s
-sys	0m1.932s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m25.984s
+user	0m24.351s
+sys	0m1.633s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.057s
-user	0m6.977s
-sys	0m1.080s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m8.119s
+user	0m7.014s
+sys	0m1.105s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m19.998s
-user	0m18.193s
-sys	0m1.804s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m19.572s
+user	0m18.128s
+sys	0m1.444s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446394 -3875.3246569558305
+
+real	0m4.562s
+user	0m13.866s
+sys	0m3.196s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013686e21 9.022023868851564e21
+
+real	0m10.249s
+user	0m34.257s
+sys	0m5.091s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446387 -3875.3246569558305
 
-real	0m4.616s
-user	0m13.159s
-sys	0m3.582s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759017687e21 9.022023868850967e21
+real	0m4.107s
+user	0m12.952s
+sys	0m2.731s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759014428e21 9.022023868851117e21
 
-real	0m10.029s
-user	0m33.713s
-sys	0m5.003s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.32465695583
-
-real	0m4.981s
-user	0m14.115s
-sys	0m3.763s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013387e21 9.022023868851365e21
-
-real	0m7.566s
-user	0m26.194s
-sys	0m3.476s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m7.434s
+user	0m25.646s
+sys	0m3.525s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.365s
-user	0m7.121s
-sys	0m1.244s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m8.127s
+user	0m7.111s
+sys	0m1.016s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m27.767s
-user	0m25.883s
-sys	0m1.884s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m25.543s
+user	0m23.851s
+sys	0m1.692s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.316s
-user	0m7.348s
-sys	0m0.968s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m8.127s
+user	0m6.815s
+sys	0m1.312s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m20.774s
-user	0m19.018s
-sys	0m1.756s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446385 -3875.3246569558314
+real	0m21.434s
+user	0m19.858s
+sys	0m1.576s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446388 -3875.3246569558305
 
-real	0m4.287s
-user	0m12.939s
-sys	0m3.232s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759015193e21 9.022023868851205e21
+real	0m4.717s
+user	0m13.600s
+sys	0m3.521s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013988e21 9.02202386885095e21
 
-real	0m10.114s
-user	0m34.081s
-sys	0m5.174s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m9.704s
+user	0m33.161s
+sys	0m4.646s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446391 -3875.324656955831
+
+real	0m4.017s
+user	0m12.663s
+sys	0m2.715s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26982775901362e21 9.022023868851029e21
+
+real	0m7.572s
+user	0m26.196s
+sys	0m3.522s
++ set +x
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.867s
+user	0m9.595s
+sys	0m1.272s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m55.481s
+user	0m53.705s
+sys	0m1.776s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m11.126s
+user	0m9.606s
+sys	0m1.520s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m11.460s
+user	0m10.304s
+sys	0m1.156s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m12.105s
+user	0m10.705s
+sys	0m1.400s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	0m22.971s
+user	0m21.239s
+sys	0m1.732s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m4.044s
+user	0m3.056s
+sys	0m0.988s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m7.530s
+user	0m6.461s
+sys	0m1.068s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.662s
+user	0m7.603s
+sys	0m1.059s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m25.143s
+user	0m23.647s
+sys	0m1.496s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.156s
+user	0m6.968s
+sys	0m1.188s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.664s
+user	0m17.980s
+sys	0m1.684s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446386 -3875.3246569558314
+
+real	0m4.859s
+user	0m14.058s
+sys	0m3.571s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.26982775901381e21 9.022023868850857e21
+
+real	0m9.849s
+user	0m33.682s
+sys	0m4.613s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446391 -3875.3246569558305
+
+real	0m4.384s
+user	0m13.243s
+sys	0m3.158s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013733e21 9.022023868851954e21
+
+real	0m6.837s
+user	0m24.645s
+sys	0m2.463s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.289s
+user	0m7.245s
+sys	0m1.044s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m26.369s
+user	0m24.272s
+sys	0m2.096s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.123s
+user	0m7.063s
+sys	0m1.060s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m20.140s
+user	0m18.356s
+sys	0m1.784s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446396 -3875.3246569558305
+
+real	0m4.603s
+user	0m13.225s
+sys	0m3.482s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013751e21 9.022023868851245e21
+
+real	0m9.945s
+user	0m34.657s
+sys	0m4.209s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.3246569558305
 
-real	0m4.206s
-user	0m12.981s
-sys	0m2.984s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013752e21 9.022023868851201e21
+real	0m3.980s
+user	0m12.725s
+sys	0m2.623s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013911e21 9.022023868851482e21
 
-real	0m7.236s
-user	0m25.474s
-sys	0m3.252s
+real	0m6.862s
+user	0m24.854s
+sys	0m2.423s
 + set +x

--- a/info/scripts/sum2.sh.out.mac
+++ b/info/scripts/sum2.sh.out.mac
@@ -1,735 +1,735 @@
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m11.034s
-user	0m9.965s
-sys	0m1.066s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m11.515s
+user	0m10.132s
+sys	0m1.361s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.26983e+21 9.02202e+21
 
-real	0m43.034s
-user	0m41.529s
-sys	0m1.499s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m42.704s
+user	0m41.173s
+sys	0m1.528s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m11.026s
-user	0m9.966s
-sys	0m1.055s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m11.546s
+user	0m10.166s
+sys	0m1.358s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m24.934s
-user	0m24.041s
-sys	0m0.888s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m10.373s
+user	0m9.431s
+sys	0m0.937s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m24.998s
-user	0m24.099s
-sys	0m0.892s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m10.437s
+user	0m9.528s
+sys	0m0.904s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6269827758986837884928 9022023868854687498240
 
-real	0m23.831s
-user	0m22.509s
-sys	0m1.315s
+real	0m14.225s
+user	0m12.881s
+sys	0m1.341s
 + ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
 f4_sum	f16_sum
 -735.018072245	-3875.32465696
 
-real	0m2.679s
-user	0m2.259s
-sys	0m0.418s
+real	0m2.687s
+user	0m2.251s
+sys	0m0.433s
 + ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
 PLT_CN_sum	TRE_CN_sum
 6.26982775899e+21	9.02202386885e+21
 
-real	0m5.566s
-user	0m4.934s
-sys	0m0.630s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m5.661s
+user	0m5.004s
+sys	0m0.655s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m8.089s
-user	0m7.418s
-sys	0m0.668s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m7.859s
+user	0m7.183s
+sys	0m0.673s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m19.340s
-user	0m18.219s
-sys	0m1.119s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m19.393s
+user	0m18.247s
+sys	0m1.143s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m7.550s
-user	0m6.898s
-sys	0m0.648s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m7.731s
+user	0m7.062s
+sys	0m0.666s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m15.937s
-user	0m14.934s
-sys	0m1.000s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446385 -3875.3246569558305
-
-real	0m2.449s
-user	0m8.991s
-sys	0m0.698s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013417e21 9.022023868851308e21
-
-real	0m5.484s
-user	0m20.653s
-sys	0m1.179s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m15.714s
+user	0m14.691s
+sys	0m1.019s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.3246569558305
 
-real	0m2.451s
-user	0m9.024s
-sys	0m0.687s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013458e21 9.022023868851333e21
+real	0m2.420s
+user	0m8.886s
+sys	0m0.691s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013437e21 9.022023868851395e21
 
-real	0m5.025s
-user	0m18.891s
-sys	0m1.089s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.920s
-user	0m7.249s
-sys	0m0.669s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.637s
-user	0m18.516s
-sys	0m1.117s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.784s
-user	0m7.129s
-sys	0m0.651s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m16.310s
-user	0m15.298s
-sys	0m1.008s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446394 -3875.324656955831
-
-real	0m2.423s
-user	0m8.973s
-sys	0m0.682s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013461e21 9.022023868851236e21
-
-real	0m5.544s
-user	0m20.974s
-sys	0m1.188s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558305
-
-real	0m2.386s
-user	0m8.849s
-sys	0m0.681s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013486e21 9.022023868851394e21
-
-real	0m5.052s
-user	0m19.123s
-sys	0m1.080s
-+ set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m11.146s
-user	0m10.086s
-sys	0m1.070s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26983e+21 9.02202e+21
-
-real	0m43.094s
-user	0m41.597s
-sys	0m1.503s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m10.980s
-user	0m9.916s
-sys	0m1.058s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m25.042s
-user	0m24.141s
-sys	0m0.895s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m25.064s
-user	0m24.160s
-sys	0m0.897s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6269827758986837884928 9022023868854687498240
-
-real	0m23.835s
-user	0m22.484s
-sys	0m1.344s
-+ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
-f4_sum	f16_sum
--735.018072245	-3875.32465696
-
-real	0m2.661s
-user	0m2.241s
-sys	0m0.417s
-+ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
-PLT_CN_sum	TRE_CN_sum
-6.26982775899e+21	9.02202386885e+21
-
-real	0m5.639s
-user	0m5.002s
-sys	0m0.635s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.876s
-user	0m7.201s
-sys	0m0.672s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.402s
-user	0m18.276s
-sys	0m1.122s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.596s
-user	0m6.941s
-sys	0m0.651s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m15.931s
-user	0m14.932s
-sys	0m0.996s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.3246569558305
-
-real	0m2.457s
-user	0m9.039s
-sys	0m0.684s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013407e21 9.022023868851283e21
-
-real	0m5.477s
-user	0m20.616s
-sys	0m1.191s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446382 -3875.3246569558314
-
-real	0m2.428s
-user	0m8.937s
-sys	0m0.676s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013472e21 9.022023868851291e21
-
-real	0m4.891s
-user	0m18.394s
-sys	0m1.066s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.936s
-user	0m7.273s
-sys	0m0.661s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.606s
-user	0m18.482s
-sys	0m1.121s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.839s
-user	0m7.165s
-sys	0m0.670s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m16.298s
-user	0m15.266s
-sys	0m1.030s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446391 -3875.3246569558305
-
-real	0m2.428s
-user	0m8.995s
-sys	0m0.681s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013464e21 9.022023868851408e21
-
-real	0m5.606s
-user	0m21.182s
-sys	0m1.198s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446382 -3875.324656955831
-
-real	0m2.358s
-user	0m8.717s
-sys	0m0.677s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013458e21 9.022023868851329e21
-
-real	0m5.027s
-user	0m18.995s
-sys	0m1.070s
-+ set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m11.210s
-user	0m10.139s
-sys	0m1.069s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26983e+21 9.02202e+21
-
-real	0m42.856s
-user	0m41.342s
-sys	0m1.509s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m11.226s
-user	0m10.143s
-sys	0m1.081s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m25.045s
-user	0m24.134s
-sys	0m0.906s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m25.043s
-user	0m24.151s
-sys	0m0.886s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6269827758986837884928 9022023868854687498240
-
-real	0m23.800s
-user	0m22.480s
-sys	0m1.313s
-+ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
-f4_sum	f16_sum
--735.018072245	-3875.32465696
-
-real	0m2.662s
-user	0m2.239s
-sys	0m0.420s
-+ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
-PLT_CN_sum	TRE_CN_sum
-6.26982775899e+21	9.02202386885e+21
-
-real	0m5.576s
-user	0m4.950s
-sys	0m0.625s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.869s
-user	0m7.201s
-sys	0m0.665s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.371s
-user	0m18.248s
-sys	0m1.120s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.690s
-user	0m7.014s
-sys	0m0.674s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m15.915s
-user	0m14.897s
-sys	0m1.015s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018072244639 -3875.32465695583
-
-real	0m2.417s
-user	0m8.879s
-sys	0m0.685s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.26982775901347e21 9.022023868851312e21
-
-real	0m5.474s
-user	0m20.601s
-sys	0m1.185s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558296
-
-real	0m2.432s
-user	0m8.951s
-sys	0m0.676s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26982775901345e21 9.02202386885132e21
-
-real	0m4.894s
-user	0m18.401s
-sys	0m1.068s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m8.011s
-user	0m7.346s
-sys	0m0.663s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.745s
-user	0m18.603s
-sys	0m1.138s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.623s
-user	0m6.964s
-sys	0m0.656s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m16.251s
-user	0m15.238s
-sys	0m1.009s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m5.460s
+user	0m20.493s
+sys	0m1.241s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446388 -3875.3246569558305
 
-real	0m2.498s
-user	0m9.224s
-sys	0m0.714s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013448e21 9.022023868851291e21
-
-real	0m5.505s
-user	0m20.797s
-sys	0m1.182s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558305
-
-real	0m2.373s
-user	0m8.790s
-sys	0m0.671s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013502e21 9.022023868851261e21
-
-real	0m5.116s
-user	0m19.341s
-sys	0m1.081s
-+ set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m11.078s
-user	0m10.004s
-sys	0m1.071s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.26983e+21 9.02202e+21
-
-real	0m42.820s
-user	0m41.314s
-sys	0m1.502s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m11.092s
-user	0m10.015s
-sys	0m1.070s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.018 -3875.32
-
-real	0m25.121s
-user	0m24.202s
-sys	0m0.914s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.018 -3875.32
-
-real	0m25.362s
-user	0m24.423s
-sys	0m0.933s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6269827758986837884928 9022023868854687498240
-
-real	0m23.914s
-user	0m22.587s
-sys	0m1.320s
-+ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
-f4_sum	f16_sum
--735.018072245	-3875.32465696
-
-real	0m2.655s
-user	0m2.237s
-sys	0m0.416s
-+ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
-PLT_CN_sum	TRE_CN_sum
-6.26982775899e+21	9.02202386885e+21
-
-real	0m5.581s
-user	0m4.950s
-sys	0m0.630s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.857s
-user	0m7.184s
-sys	0m0.669s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.351s
-user	0m18.220s
-sys	0m1.128s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.610s
-user	0m6.942s
-sys	0m0.664s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m15.949s
-user	0m14.941s
-sys	0m1.006s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.3246569558296
-
-real	0m2.338s
-user	0m8.559s
-sys	0m0.687s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013463e21 9.022023868851259e21
-
-real	0m5.469s
-user	0m20.598s
-sys	0m1.178s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446385 -3875.3246569558314
-
-real	0m2.439s
-user	0m8.977s
-sys	0m0.677s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013476e21 9.022023868851352e21
-
-real	0m4.996s
-user	0m18.798s
-sys	0m1.080s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.877s
-user	0m7.216s
-sys	0m0.658s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.639s
-user	0m18.513s
-sys	0m1.122s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.684s
-user	0m7.013s
-sys	0m0.668s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m16.432s
-user	0m15.415s
-sys	0m1.013s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446391 -3875.324656955832
-
-real	0m2.436s
-user	0m9.025s
-sys	0m0.685s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.26982775901349e21 9.022023868851232e21
-
-real	0m5.529s
-user	0m20.893s
-sys	0m1.181s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.3246569558305
-
-real	0m2.415s
-user	0m8.923s
+real	0m2.422s
+user	0m8.898s
 sys	0m0.686s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013538e21 9.022023868851262e21
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013461e21 9.022023868851359e21
 
-real	0m5.067s
-user	0m19.146s
-sys	0m1.076s
+real	0m4.909s
+user	0m18.410s
+sys	0m1.114s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.021s
+user	0m7.337s
+sys	0m0.681s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.517s
+user	0m18.372s
+sys	0m1.141s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.824s
+user	0m7.147s
+sys	0m0.673s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.886s
+user	0m14.865s
+sys	0m1.018s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.3246569558314
+
+real	0m2.474s
+user	0m9.135s
+sys	0m0.715s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013456e21 9.02202386885126e21
+
+real	0m5.486s
+user	0m20.708s
+sys	0m1.199s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446387 -3875.324656955831
+
+real	0m2.449s
+user	0m9.067s
+sys	0m0.692s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013537e21 9.022023868851281e21
+
+real	0m4.932s
+user	0m18.569s
+sys	0m1.114s
 + set +x
-+ mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m11.097s
-user	0m10.043s
-sys	0m1.052s
-+ mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m11.292s
+user	0m10.215s
+sys	0m1.075s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6.26983e+21 9.02202e+21
 
-real	0m43.870s
-user	0m42.343s
-sys	0m1.521s
-+ mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m43.037s
+user	0m41.503s
+sys	0m1.527s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m11.108s
-user	0m10.032s
-sys	0m1.071s
-+ gawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m11.106s
+user	0m10.021s
+sys	0m1.083s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.018 -3875.32
 
-real	0m25.101s
-user	0m24.194s
-sys	0m0.900s
-+ gawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m10.302s
+user	0m9.400s
+sys	0m0.897s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.018 -3875.32
 
-real	0m25.061s
-user	0m24.157s
-sys	0m0.898s
-+ gawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+real	0m10.327s
+user	0m9.413s
+sys	0m0.909s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
 6269827758986837884928 9022023868854687498240
 
-real	0m23.902s
-user	0m22.552s
-sys	0m1.343s
+real	0m14.218s
+user	0m12.863s
+sys	0m1.350s
 + ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
 f4_sum	f16_sum
 -735.018072245	-3875.32465696
 
-real	0m2.652s
-user	0m2.234s
-sys	0m0.415s
+real	0m2.676s
+user	0m2.239s
+sys	0m0.434s
 + ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
 PLT_CN_sum	TRE_CN_sum
 6.26982775899e+21	9.02202386885e+21
 
-real	0m5.621s
-user	0m4.984s
-sys	0m0.635s
-+ frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+real	0m5.664s
+user	0m5.008s
+sys	0m0.655s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446389 -3875.324656955831
 
-real	0m7.833s
-user	0m7.176s
-sys	0m0.654s
-+ frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+real	0m7.948s
+user	0m7.246s
+sys	0m0.699s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m19.364s
-user	0m18.237s
-sys	0m1.125s
-+ frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m19.428s
+user	0m18.276s
+sys	0m1.149s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.324656955831
 
-real	0m7.661s
-user	0m6.981s
+real	0m7.754s
+user	0m7.065s
+sys	0m0.685s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.823s
+user	0m14.787s
+sys	0m1.033s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446387 -3875.32465695583
+
+real	0m2.343s
+user	0m8.575s
+sys	0m0.691s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013488e21 9.022023868851348e21
+
+real	0m5.486s
+user	0m20.608s
+sys	0m1.218s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446388 -3875.3246569558305
+
+real	0m2.417s
+user	0m8.882s
+sys	0m0.686s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013625e21 9.022023868851333e21
+
+real	0m4.849s
+user	0m18.199s
+sys	0m1.096s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.999s
+user	0m7.321s
 sys	0m0.676s
-+ frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
 6.269827758986838e21 9.022023868854687e21
 
-real	0m15.889s
-user	0m14.892s
-sys	0m0.994s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.32465695583
+real	0m19.598s
+user	0m18.466s
+sys	0m1.144s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
 
-real	0m2.324s
-user	0m8.503s
-sys	0m0.690s
-+ frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013466e21 9.022023868851369e21
+real	0m7.755s
+user	0m7.079s
+sys	0m0.674s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
 
-real	0m5.470s
-user	0m20.600s
-sys	0m1.179s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m15.865s
+user	0m14.854s
+sys	0m1.011s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
 -735.0180722446387 -3875.3246569558305
 
-real	0m2.520s
-user	0m9.282s
-sys	0m0.701s
-+ frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013477e21 9.022023868851372e21
+real	0m2.399s
+user	0m8.870s
+sys	0m0.690s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013458e21 9.022023868851313e21
 
-real	0m5.030s
-user	0m18.922s
-sys	0m1.091s
-+ frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446389 -3875.324656955831
-
-real	0m7.984s
-user	0m7.309s
-sys	0m0.673s
-+ frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m19.700s
-user	0m18.568s
-sys	0m1.130s
-+ frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
--735.0180722446389 -3875.324656955831
-
-real	0m7.710s
-user	0m7.030s
-sys	0m0.676s
-+ frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827758986838e21 9.022023868854687e21
-
-real	0m16.271s
-user	0m15.260s
-sys	0m1.007s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
--735.0180722446385 -3875.3246569558314
-
-real	0m2.355s
-user	0m8.700s
-sys	0m0.683s
-+ frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
-6.269827759013414e21 9.022023868851369e21
-
-real	0m5.577s
-user	0m21.068s
-sys	0m1.199s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+real	0m5.491s
+user	0m20.726s
+sys	0m1.201s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
 -735.0180722446389 -3875.3246569558305
 
-real	0m2.455s
-user	0m9.095s
-sys	0m0.692s
-+ frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
-6.269827759013545e21 9.022023868851266e21
+real	0m2.462s
+user	0m9.137s
+sys	0m0.681s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013464e21 9.022023868851322e21
 
-real	0m5.019s
-user	0m18.966s
-sys	0m1.069s
+real	0m4.853s
+user	0m18.303s
+sys	0m1.078s
++ set +x
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m11.129s
+user	0m10.052s
+sys	0m1.073s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m42.947s
+user	0m41.418s
+sys	0m1.526s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m11.051s
+user	0m9.960s
+sys	0m1.089s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.261s
+user	0m9.350s
+sys	0m0.905s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.258s
+user	0m9.354s
+sys	0m0.902s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	0m14.149s
+user	0m12.809s
+sys	0m1.338s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m2.650s
+user	0m2.224s
+sys	0m0.425s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m5.755s
+user	0m5.084s
+sys	0m0.670s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.921s
+user	0m7.245s
+sys	0m0.672s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.348s
+user	0m18.208s
+sys	0m1.137s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.715s
+user	0m7.033s
+sys	0m0.676s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.663s
+user	0m14.651s
+sys	0m1.008s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446391 -3875.32465695583
+
+real	0m2.384s
+user	0m8.756s
+sys	0m0.679s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.26982775901343e21 9.022023868851314e21
+
+real	0m5.446s
+user	0m20.477s
+sys	0m1.197s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446391 -3875.3246569558305
+
+real	0m2.439s
+user	0m8.970s
+sys	0m0.685s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013464e21 9.022023868851329e21
+
+real	0m4.834s
+user	0m18.151s
+sys	0m1.087s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.998s
+user	0m7.323s
+sys	0m0.673s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.473s
+user	0m18.336s
+sys	0m1.135s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.942s
+user	0m7.226s
+sys	0m0.706s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.942s
+user	0m14.919s
+sys	0m1.019s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446387 -3875.324656955831
+
+real	0m2.399s
+user	0m8.855s
+sys	0m0.697s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013469e21 9.022023868851361e21
+
+real	0m5.498s
+user	0m20.750s
+sys	0m1.202s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446387 -3875.32465695583
+
+real	0m2.400s
+user	0m8.868s
+sys	0m0.694s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013525e21 9.022023868851356e21
+
+real	0m4.918s
+user	0m18.524s
+sys	0m1.110s
++ set +x
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m11.223s
+user	0m10.136s
+sys	0m1.085s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m43.045s
+user	0m41.482s
+sys	0m1.558s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m11.064s
+user	0m9.978s
+sys	0m1.084s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.469s
+user	0m9.565s
+sys	0m0.898s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.350s
+user	0m9.442s
+sys	0m0.903s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	0m14.172s
+user	0m12.795s
+sys	0m1.373s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m2.688s
+user	0m2.251s
+sys	0m0.435s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m5.701s
+user	0m5.036s
+sys	0m0.663s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.921s
+user	0m7.226s
+sys	0m0.691s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.433s
+user	0m18.277s
+sys	0m1.153s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.911s
+user	0m7.203s
+sys	0m0.704s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.801s
+user	0m14.771s
+sys	0m1.025s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.32465695583
+
+real	0m2.447s
+user	0m8.954s
+sys	0m0.708s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013466e21 9.022023868851337e21
+
+real	0m5.468s
+user	0m20.551s
+sys	0m1.203s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m2.485s
+user	0m9.144s
+sys	0m0.696s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013481e21 9.022023868851369e21
+
+real	0m4.860s
+user	0m18.229s
+sys	0m1.102s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.090s
+user	0m7.403s
+sys	0m0.685s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.571s
+user	0m18.426s
+sys	0m1.141s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.771s
+user	0m7.099s
+sys	0m0.667s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.974s
+user	0m14.955s
+sys	0m1.016s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446385 -3875.3246569558296
+
+real	0m2.448s
+user	0m9.049s
+sys	0m0.701s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013473e21 9.022023868851358e21
+
+real	0m5.475s
+user	0m20.665s
+sys	0m1.196s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446386 -3875.3246569558296
+
+real	0m2.468s
+user	0m9.126s
+sys	0m0.707s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013497e21 9.022023868851352e21
+
+real	0m4.920s
+user	0m18.528s
+sys	0m1.107s
++ set +x
++ ../mawk -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m11.148s
+user	0m10.075s
+sys	0m1.071s
++ ../mawk '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.26983e+21 9.02202e+21
+
+real	0m42.899s
+user	0m41.350s
+sys	0m1.543s
++ ../mawk '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m11.070s
+user	0m9.983s
+sys	0m1.086s
++ ../gawk -b -F, '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018 -3875.32
+
+real	0m10.270s
+user	0m9.359s
+sys	0m0.906s
++ ../gawk -b '-F\t' '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.018 -3875.32
+
+real	0m10.340s
+user	0m9.435s
+sys	0m0.900s
++ ../gawk -b '-F\t' '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6269827758986837884928 9022023868854687498240
+
+real	0m14.605s
+user	0m13.224s
+sys	0m1.376s
++ ../bin/tsv-summarize -H --sum 6,18 ../all_train.tsv
+f4_sum	f16_sum
+-735.018072245	-3875.32465696
+
+real	0m2.678s
+user	0m2.243s
+sys	0m0.432s
++ ../bin/tsv-summarize -H --sum 4,5 ../TREE_GRM_ESTN.tsv
+PLT_CN_sum	TRE_CN_sum
+6.26982775899e+21	9.02202386885e+21
+
+real	0m5.690s
+user	0m5.026s
+sys	0m0.662s
++ ../frawk -bllvm -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.949s
+user	0m7.247s
+sys	0m0.700s
++ ../frawk -bllvm -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.383s
+user	0m18.231s
+sys	0m1.148s
++ ../frawk -bllvm -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.760s
+user	0m7.082s
+sys	0m0.674s
++ ../frawk -bllvm -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.695s
+user	0m14.674s
+sys	0m1.017s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.018072244639 -3875.3246569558305
+
+real	0m2.421s
+user	0m8.886s
+sys	0m0.691s
++ ../frawk -bllvm -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013399e21 9.022023868851364e21
+
+real	0m5.990s
+user	0m22.460s
+sys	0m1.338s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446385 -3875.3246569558305
+
+real	0m2.653s
+user	0m9.678s
+sys	0m0.805s
++ ../frawk -bllvm -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013454e21 9.022023868851375e21
+
+real	0m4.824s
+user	0m18.071s
+sys	0m1.116s
++ ../frawk -bcranelift -icsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.324656955831
+
+real	0m8.168s
+user	0m7.454s
+sys	0m0.711s
++ ../frawk -bcranelift -icsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m19.703s
+user	0m18.523s
+sys	0m1.177s
++ ../frawk -bcranelift -itsv '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446389 -3875.324656955831
+
+real	0m7.760s
+user	0m7.070s
+sys	0m0.686s
++ ../frawk -bcranelift -itsv '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827758986838e21 9.022023868854687e21
+
+real	0m15.958s
+user	0m14.935s
+sys	0m1.020s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.csv
+-735.0180722446389 -3875.3246569558305
+
+real	0m2.436s
+user	0m9.003s
+sys	0m0.697s
++ ../frawk -bcranelift -icsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.csv
+6.269827759013458e21 9.022023868851293e21
+
+real	0m5.522s
+user	0m20.841s
+sys	0m1.204s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $6; sum2 += $18;} END { print sum1,sum2}' ../all_train.tsv
+-735.0180722446388 -3875.3246569558305
+
+real	0m2.422s
+user	0m8.962s
+sys	0m0.688s
++ ../frawk -bcranelift -itsv -pr -j3 '{sum1 += $4; sum2 += $5;} END { print sum1,sum2}' ../TREE_GRM_ESTN.tsv
+6.269827759013517e21 9.022023868851365e21
+
+real	0m4.869s
+user	0m18.337s
+sys	0m1.096s
 + set +x

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -113,6 +113,7 @@ pub(crate) enum Instr<'a> {
 
     // String processing
     Concat(Reg<Str<'a>>, Reg<Str<'a>>, Reg<Str<'a>>),
+    StartsWithConst(Reg<Int>, Reg<Str<'a>>, Arc<[u8]>),
     IsMatch(Reg<Int>, Reg<Str<'a>>, Reg<Str<'a>>),
     IsMatchConst(Reg<Int>, Reg<Str<'a>>, Arc<Regex>),
     Match(Reg<Int>, Reg<Str<'a>>, Reg<Str<'a>>),
@@ -499,6 +500,10 @@ impl<'a> Instr<'a> {
                 seed.accum(&mut f)
             }
             ReseedRng(res) => res.accum(&mut f),
+            StartsWithConst(res, s, _) => {
+                res.accum(&mut f);
+                s.accum(&mut f);
+            }
             Concat(res, l, r) => {
                 res.accum(&mut f);
                 l.accum(&mut f);

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -39,6 +39,8 @@ impl<I: fmt::Display> fmt::Display for FunctionName<I> {
 
 impl<I> FunctionName<I> {
     fn is_main(&self) -> bool {
+        // TODO: does the slot mechanism mean that we can have this hold for any not-named
+        // FunctionName?
         matches!(self, FunctionName::MainLoop)
     }
 }

--- a/src/codegen/clif.rs
+++ b/src/codegen/clif.rs
@@ -67,8 +67,30 @@ struct Prelude {
 #[derive(Clone)]
 struct VarRef {
     var: Variable,
-    is_global: bool,
-    skip_drop: bool,
+    kind: VarKind,
+}
+
+/// The different kinds of variables we track
+#[derive(Copy, Clone)]
+enum VarKind {
+    /// Variables defined locally in the a function. Under some circumstances, we do not drop these
+    /// variables (e.g. at join points, or when returning them from a function).
+    Local { skip_drop: bool },
+    /// frawk-level function parameters. These are treated very similarly to local variables with
+    /// skip_drop set to true, the only difference is that parameters are reffed before being
+    /// returned from a function, whereas we simply skip dropping.
+    Param,
+    /// Global variables. These are treated specially throughout, as even integers and floats are
+    /// passed by reference. Like params, these are reffed before being returned.
+    Global,
+}
+
+impl VarKind {
+    fn skip_drop(&mut self) {
+        if let VarKind::Local { skip_drop } = self {
+            *skip_drop = true;
+        }
+    }
 }
 
 /// Iterator-specific variable state. This is treated differently from [`VarRef`] because iterators
@@ -289,8 +311,7 @@ impl Generator {
                 (reg, ty),
                 VarRef {
                     var,
-                    is_global: true,
-                    skip_drop: true,
+                    kind: VarKind::Global,
                 },
             );
         }
@@ -582,19 +603,17 @@ impl<'a> View<'a> {
                     rf,
                     VarRef {
                         var,
-                        is_global: true,
-                        skip_drop: false,
+                        kind: VarKind::Global,
                     },
                 );
             } else {
-                // normal arg. These behave like normal params, except we do not drop them (they
+                // normal arg. These behave like normal variables, except we do not drop them (they
                 // are, in effect, borrowed).
                 self.f.vars.insert(
                     rf,
                     VarRef {
                         var,
-                        is_global: false,
-                        skip_drop: true,
+                        kind: VarKind::Param,
                     },
                 );
             }
@@ -606,16 +625,8 @@ impl<'a> View<'a> {
     /// drop procedure and (b) have not been marked `skip_drop`.
     fn drop_all(&mut self) {
         let mut drops = Vec::new();
-        for (
-            (_, ty),
-            VarRef {
-                var,
-                is_global,
-                skip_drop,
-            },
-        ) in self.f.vars.iter()
-        {
-            if !is_global && !skip_drop {
+        for ((_, ty), VarRef { var, kind }) in self.f.vars.iter() {
+            if let VarKind::Local { skip_drop: false } = kind {
                 use compile::Ty::*;
                 let drop_fn = match ty {
                     MapIntInt => external!(drop_intint),
@@ -653,7 +664,11 @@ impl<'a> View<'a> {
             // We don't use get_val here because we want to pass the pointer to the global, and
             // get_val will issue a load.
             match self.f.vars.get(global) {
-                Some(VarRef { var, is_global, .. }) if *is_global => {
+                Some(VarRef {
+                    var,
+                    kind: VarKind::Global,
+                    ..
+                }) => {
                     to_pass.push(self.builder.use_var(*var));
                 }
                 _ => return err!("internal error, functions disagree on if reference is global"),
@@ -693,7 +708,18 @@ impl<'a> View<'a> {
             }
             Ret(reg, ty) => {
                 let mut v = self.get_val((*reg, *ty))?;
-                self.ref_val(*ty, v);
+                if matches!(
+                    self.f.vars.get_mut(&(*reg, *ty)).map(|x| {
+                        // if this is a local, we want to avoid dropping it.
+                        x.kind.skip_drop();
+                        &x.kind
+                    }),
+                    Some(VarKind::Param) | Some(VarKind::Global)
+                ) {
+                    // This was passed in as a parameter, so us returning it will introduce a new
+                    // reference.
+                    self.ref_val(*ty, v);
+                }
                 if let compile::Ty::Str = ty {
                     let str_ty = self.get_ty(*ty);
                     v = self.builder.ins().load(str_ty, MemFlags::trusted(), v, 0);
@@ -1058,8 +1084,7 @@ impl<'a> View<'a> {
             let var = self.declare_local(r.1)?;
             let vref = VarRef {
                 var,
-                skip_drop,
-                is_global: false,
+                kind: VarKind::Local { skip_drop },
             };
             self.f.vars.insert(r, vref.clone());
             Ok(vref)
@@ -1068,10 +1093,10 @@ impl<'a> View<'a> {
 
     fn bind_val_inner(&mut self, r: Ref, v: Value, skip_drop: bool) -> Result<()> {
         use compile::Ty::*;
-        let VarRef { var, is_global, .. } = self.get_var_default_local(r, skip_drop)?;
+        let VarRef { var, kind } = self.get_var_default_local(r, skip_drop)?;
         match r.1 {
             Int | Float => {
-                if is_global {
+                if let VarKind::Global = kind {
                     let p = self.builder.use_var(var);
                     self.builder.ins().store(MemFlags::trusted(), v, p, 0);
                 } else {
@@ -1088,9 +1113,7 @@ impl<'a> View<'a> {
             }
             MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat | MapStrStr => {
                 // first, ref the new value
-                // NB: we used to have a ref here, but it appears to be unnecessary
-                //   self.ref_val(r.1, v);
-                if is_global {
+                if let VarKind::Global = kind {
                     // then, drop the value currently in the pointer
                     let p = self.builder.use_var(var);
                     let pointee = self
@@ -1272,8 +1295,8 @@ impl<'a> CodeGenerator for View<'a> {
             return Ok(self.const_int(0));
         }
 
-        let VarRef { var, is_global, .. } =
-            self.get_var_default_local(r, /*skip_drop=*/ false)?;
+        let VarRef { var, kind, .. } = self.get_var_default_local(r, /*skip_drop=*/ false)?;
+        let is_global = matches!(kind, VarKind::Global);
         let val = self.builder.use_var(var);
 
         match r.1 {
@@ -1498,12 +1521,6 @@ impl<'a> CodeGenerator for View<'a> {
         self.bind_val(dst, contents)?;
         let dst_ptr = self.get_val(dst)?;
         self.ref_val(dst.1, dst_ptr);
-        Ok(())
-    }
-
-    fn var_loaded(&mut self, _dst: Ref) -> Result<()> {
-        // The LLVM backend refs maps more aggressively, so we use this as a hook to insert drops.
-        // They don't appear to be needed for cranelift
         Ok(())
     }
 }

--- a/src/codegen/clif.rs
+++ b/src/codegen/clif.rs
@@ -529,7 +529,7 @@ impl<'a> View<'a> {
                                     None
                                 }
                             }) {
-                                self.mov_inner(*ty, *dst_reg, src_reg, /*skip_drop=*/ true)?;
+                                self.mov_inner(*ty, *dst_reg, src_reg, /*skip_drop=*/ false)?;
                             }
                         } else {
                             // We can bail out once we see the first non-phi instruction. Those all go
@@ -1112,9 +1112,8 @@ impl<'a> View<'a> {
                 self.builder.ins().store(MemFlags::trusted(), v, p, 0);
             }
             MapIntInt | MapIntFloat | MapIntStr | MapStrInt | MapStrFloat | MapStrStr => {
-                // first, ref the new value
                 if let VarKind::Global = kind {
-                    // then, drop the value currently in the pointer
+                    // Drop the value currently in the pointer
                     let p = self.builder.use_var(var);
                     let pointee = self
                         .builder

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -1199,7 +1199,7 @@ macro_rules! convert_in_val {
         $e
     };
     (Map, $e:expr) => {
-        mem::transmute::<*mut c_void, runtime::SharedMap<_, _>>($e)
+        mem::transmute::<&*mut c_void, &runtime::SharedMap<_, _>>(&$e).clone()
     };
 }
 

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -810,7 +810,9 @@ unsafe fn ref_map_generic<K, V>(m: *mut c_void) {
 }
 
 unsafe fn drop_map_generic<K, V>(m: *mut c_void) {
-    mem::drop(mem::transmute::<*mut c_void, runtime::SharedMap<K, V>>(m))
+    let map_ref = mem::transmute::<*mut c_void, runtime::SharedMap<K, V>>(m);
+    debug_assert!(std::rc::Rc::strong_count(&map_ref.0) > 0);
+    mem::drop(map_ref)
 }
 
 // XXX: relying on this doing the same thing regardless of type. We probably want a custom Rc to

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -103,6 +103,7 @@ pub(crate) fn register_all(cg: &mut impl Backend) -> Result<()> {
         [ReadOnly] hex_str_to_int(str_ref_ty) -> int_ty;
         [ReadOnly] str_to_float(str_ref_ty) -> float_ty;
         [ReadOnly] str_len(str_ref_ty) -> int_ty;
+        starts_with_const(str_ref_ty, rt_ty, int_ty) -> int_ty;
         concat(str_ref_ty, str_ref_ty) -> str_ty;
         [ReadOnly] match_pat(rt_ty, str_ref_ty, str_ref_ty) -> int_ty;
         [ReadOnly] match_const_pat(str_ref_ty, rt_ty) -> int_ty;
@@ -639,6 +640,18 @@ pub(crate) unsafe extern "C" fn str_len(s: *mut c_void) -> usize {
     let res = s.len();
     mem::forget(s);
     res
+}
+
+pub(crate) unsafe extern "C" fn starts_with_const(
+    s1: *mut c_void,
+    base: *const u8,
+    len: Int,
+) -> Int {
+    debug_assert!(len >= 0);
+    let other = slice::from_raw_parts(base, len as usize);
+    let s1 = &*(s1 as *const Str);
+    let s1_bytes = &*s1.get_bytes();
+    ((s1_bytes.len() >= other.len()) && &s1_bytes[..other.len()] == other) as Int
 }
 
 pub(crate) unsafe extern "C" fn concat(s1: *mut c_void, s2: *mut c_void) -> U128 {

--- a/src/codegen/llvm/intrinsics.rs
+++ b/src/codegen/llvm/intrinsics.rs
@@ -52,6 +52,7 @@ impl IntrinsicMap {
             _ => return None,
         }
     }
+
     pub(crate) fn register(
         &mut self,
         name: &str,

--- a/src/codegen/llvm/intrinsics.rs
+++ b/src/codegen/llvm/intrinsics.rs
@@ -5,6 +5,7 @@
 use super::attr;
 use crate::codegen::FunctionAttr;
 use crate::common::Either;
+use crate::compile::Ty;
 use crate::libc::c_void;
 
 use hashbrown::HashMap;
@@ -36,6 +37,19 @@ impl IntrinsicMap {
             ctx,
             module,
             map: Default::default(),
+        }
+    }
+
+    pub(crate) unsafe fn map_drop_fn(&self, ty: Ty) -> Option<LLVMValueRef> {
+        use Ty::*;
+        match ty {
+            MapIntInt => Some(self.get(external!(drop_intint))),
+            MapIntFloat => Some(self.get(external!(drop_intfloat))),
+            MapIntStr => Some(self.get(external!(drop_intstr))),
+            MapStrInt => Some(self.get(external!(drop_strint))),
+            MapStrFloat => Some(self.get(external!(drop_strfloat))),
+            MapStrStr => Some(self.get(external!(drop_strstr))),
+            _ => return None,
         }
     }
     pub(crate) fn register(

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -24,6 +24,12 @@ pub struct Config {
     pub num_workers: usize,
 }
 
+macro_rules! external {
+    ($name:ident) => {
+        crate::codegen::intrinsics::$name as *const u8
+    };
+}
+
 #[macro_use]
 pub(crate) mod intrinsics;
 pub(crate) mod clif;
@@ -39,12 +45,6 @@ pub(crate) struct Sig<'a, C: Backend + ?Sized> {
     pub attrs: &'a [FunctionAttr],
     pub args: &'a mut [C::Ty],
     pub ret: Option<C::Ty>,
-}
-
-macro_rules! external {
-    ($name:ident) => {
-        crate::codegen::intrinsics::$name as *const u8
-    };
 }
 
 macro_rules! intrinsic {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -353,14 +353,6 @@ pub(crate) trait CodeGenerator: Backend {
     /// Advances the iterator in `iter` to the next element and stores the current element in `dst`
     fn iter_getnext(&mut self, dst: Ref, iter: Ref) -> Result<()>;
 
-    // The plumbing for builtin variable manipulation is mostly pretty wrote ... anything we can do
-    // here?
-
-    /// Method called after loading a builtin variable into `dst`.
-    ///
-    /// This is included to help clean up ref-counts on string or map builtins, if necessary.
-    fn var_loaded(&mut self, dst: Ref) -> Result<()>;
-
     // derived functions
 
     /// Loads contents of given slot into dst.
@@ -841,8 +833,7 @@ pub(crate) trait CodeGenerator: Backend {
                 let varv = self.const_int(*var as i64);
                 let res = self.call_intrinsic(intrinsic!(load_var_str), &mut [rt, varv])?;
                 let dref = dst.reflect();
-                self.bind_val(dref, res)?;
-                self.var_loaded(dref)
+                self.bind_val(dref, res)
             }
             StoreVarStr(var, src) => {
                 let rt = self.runtime_val();
@@ -856,8 +847,7 @@ pub(crate) trait CodeGenerator: Backend {
                 let varv = self.const_int(*var as i64);
                 let res = self.call_intrinsic(intrinsic!(load_var_int), &mut [rt, varv])?;
                 let dref = dst.reflect();
-                self.bind_val(dref, res)?;
-                self.var_loaded(dref)
+                self.bind_val(dref, res)
             }
             StoreVarInt(var, src) => {
                 let rt = self.runtime_val();
@@ -871,23 +861,20 @@ pub(crate) trait CodeGenerator: Backend {
                 let varv = self.const_int(*var as i64);
                 let res = self.call_intrinsic(intrinsic!(load_var_intmap), &mut [rt, varv])?;
                 let dref = dst.reflect();
-                self.bind_val(dref, res)?;
-                self.var_loaded(dref)
+                self.bind_val(dref, res)
             }
             StoreVarIntMap(var, src) => {
                 let rt = self.runtime_val();
                 let varv = self.const_int(*var as i64);
                 let srcv = self.get_val(src.reflect())?;
-                self.call_void(external!(store_var_intmap), &mut [rt, varv, srcv])?;
-                Ok(())
+                self.call_void(external!(store_var_intmap), &mut [rt, varv, srcv])
             }
             LoadVarStrMap(dst, var) => {
                 let rt = self.runtime_val();
                 let varv = self.const_int(*var as i64);
                 let res = self.call_intrinsic(intrinsic!(load_var_strmap), &mut [rt, varv])?;
                 let dref = dst.reflect();
-                self.bind_val(dref, res)?;
-                self.var_loaded(dref)
+                self.bind_val(dref, res)
             }
             StoreVarStrMap(var, src) => {
                 let rt = self.runtime_val();

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -234,6 +234,7 @@ pub(crate) mod boilerplate {
                 f(dst.into(), Some(x.into()));
                 f(dst.into(), Some(y.into()));
             }
+            StartsWithConst(dst, x, _) => f(dst.into(), Some(x.into())),
 
             // NB: this assumes that regexes that have been constant-folded are not tainted by
             // user-input. That is certainly true today, but any kind of dynamic simplification or

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1274,6 +1274,12 @@ this as well"#
     );
 
     test_program!(
+        global_variable_only_printed,
+        r#"function unused() { return xyz; } BEGIN { print "hi", xyz; }"#,
+        "hi \n"
+    );
+
+    test_program!(
         int_conversions,
         r#"BEGIN {
         x="123.456"

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -794,6 +794,11 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                     ReseedRng(res) => {
                         *index_mut(&mut self.ints, res) = self.core.reseed_random() as Int;
                     }
+                    StartsWithConst(res, s, bs) => {
+                        let s_bytes = unsafe { &*index(&self.strs, s).get_bytes() };
+                        *index_mut(&mut self.ints, res) =
+                            (bs.len() <= s_bytes.len() && &s_bytes[..bs.len()] == &**bs) as Int;
+                    }
                     Concat(res, l, r) => {
                         let res = *res;
                         let l = self.get(*l).clone();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -549,7 +549,7 @@ where
 // NB These are repr(transparent) because we pass them around as void* when compiling with LLVM.
 #[repr(transparent)]
 #[derive(Debug)]
-pub(crate) struct SharedMap<K, V>(Rc<RefCell<HashMap<K, V>>>);
+pub(crate) struct SharedMap<K, V>(pub(crate) Rc<RefCell<HashMap<K, V>>>);
 
 impl<K, V> Default for SharedMap<K, V> {
     fn default() -> SharedMap<K, V> {

--- a/src/runtime/splitter/mod.rs
+++ b/src/runtime/splitter/mod.rs
@@ -135,6 +135,7 @@ impl<'a> Line<'a> for DefaultLine {
         Ok(sep
             .clone()
             .unmoor()
+            // TODO: update join_slice to work for this case
             .join(self.fields[start..end].iter().cloned().map(trans))
             .upcast())
     }
@@ -171,7 +172,7 @@ impl<'a> Line<'a> for DefaultLine {
                 }
                 self.fields = new_vec;
             }
-            let res = ofs.clone().unmoor().join(self.fields.iter().cloned());
+            let res = ofs.join_slice(&self.fields[..]);
             self.line = res.clone();
             self.diverged = false;
             res

--- a/src/runtime/splitter/regex.rs
+++ b/src/runtime/splitter/regex.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 
 use crate::common::Result;
 use crate::pushdown::FieldSet;
-use crate::runtime::{LazyVec, Str};
+use crate::runtime::Str;
 use regex::bytes::Regex;
 
 use super::{DefaultLine, LineReader, Reader, ReaderState};
@@ -53,7 +53,7 @@ impl<R: Read> LineReader for RegexSplitter<R> {
         self.start = false;
         let line = rc.with_regex(pat, |re| DefaultLine {
             line: self.read_line_regex(re),
-            fields: LazyVec::new(),
+            fields: Default::default(),
             used_fields: self.used_fields.clone(),
             diverged: false,
         })?;

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -447,6 +447,19 @@ impl<'a> Str<'a> {
         });
     }
 
+    pub fn join_slice<'other, 'b>(&self, inps: &[Str<'other>]) -> Str<'b> {
+        let sep_bytes: &[u8] = unsafe { &*self.get_bytes() };
+        let mut buf = DynamicBuf::new(inps.len() * sep_bytes.len());
+        for (i, inp) in inps.iter().enumerate() {
+            let inp_bytes = unsafe { &*inp.get_bytes() };
+            buf.write(inp_bytes).unwrap();
+            if i < inps.len() - 1 {
+                buf.write(sep_bytes).unwrap();
+            }
+        }
+        unsafe { buf.into_str() }
+    }
+
     pub fn join(&self, mut ss: impl Iterator<Item = Str<'a>>) -> Str<'a> {
         let mut res = if let Some(s) = ss.next() {
             s

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -1172,7 +1172,14 @@ impl Buf {
         let len = to.saturating_sub(from);
         if len == 0 {
             Str::default()
-        } else if likely(from <= u32::max_value() as usize && to <= u32::max_value() as usize) {
+        } else /*if len <= MAX_INLINE_SIZE {
+            unsafe {
+                Str::from_rep(
+                    Inline::from_raw(self.as_ptr().offset(std::cmp::max(0, from as isize)), len)
+                        .into(),
+                )
+            }
+        } else*/ if likely(from <= u32::max_value() as usize && to <= u32::max_value() as usize) {
             Str::from_rep(
                 Shared {
                     buf: self.clone(),

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -1180,14 +1180,14 @@ impl Buf {
          * of indirection leads to a marginal performance hit when reading this data. For now, we
          * opt for the faster `slice` operation, but there's a solid case for either one, to the
          * point where we may want this to be configurable.
-         * if len <= MAX_INLINE_SIZE {
+        if len <= MAX_INLINE_SIZE {
             unsafe {
                 Str::from_rep(
                     Inline::from_raw(self.as_ptr().offset(std::cmp::max(0, from as isize)), len)
                         .into(),
                 )
             }
-        } else*/
+        } else */
         if likely(from <= u32::max_value() as usize && to <= u32::max_value() as usize) {
             Str::from_rep(
                 Shared {

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -279,24 +279,6 @@ impl<'a> StrRep<'a> {
     }
 }
 
-// TODO: remove this block
-impl<'a> Str<'a> {
-    pub unsafe fn get_count(&self) -> (usize, &'static str) {
-        let rep = &mut *self.0.get();
-        let tag = rep.get_tag();
-        match tag {
-            StrTag::Inline => (!0, "INLINE"),
-            StrTag::Literal => (!0, "LITERAL"),
-            StrTag::Shared => (rep.view_as(|s: &Shared| (&*s.buf.0).count.get()), "SHARED"),
-            StrTag::Boxed => (rep.view_as(|b: &Boxed| (&*b.buf.0).count.get()), "BOXED"),
-            StrTag::Concat => (
-                rep.view_as(|c: &Concat| std::rc::Rc::strong_count(&c.inner)),
-                "CONCAT",
-            ),
-        }
-    }
-}
-
 impl<'a> Drop for StrRep<'a> {
     fn drop(&mut self) {
         // Drop shows up on a lot of profiles. It doesn't appear as though drop is particularly
@@ -1099,20 +1081,6 @@ impl Drop for UniqueBuf {
     }
 }
 
-impl Buf {
-    pub fn drop_print(&mut self, s: &str) {
-        let header: &BufHeader = unsafe { &(*self.0) };
-        let cur = header.count.get();
-        eprintln!("[{}] dropping from {}", cur, s);
-        debug_assert!(cur > 0);
-        if cur == 1 {
-            mem::drop(UniqueBuf(self.0 as *mut _));
-            return;
-        }
-        header.count.set(cur - 1);
-    }
-}
-
 impl Drop for Buf {
     fn drop(&mut self) {
         let header: &BufHeader = unsafe { &(*self.0) };
@@ -1204,7 +1172,15 @@ impl Buf {
         if len == 0 {
             Str::default()
         } else
-        /*if len <= MAX_INLINE_SIZE {
+        /* NB: we could also have the following.
+         * This creates a tradeoff: in scripts where we split several fields, performing this copy
+         * has a noticeable impact on performance.
+         *
+         * In scripts that mainly read a small number of columns, the additional indirection layer
+         * of indirection leads to a marginal performance hit when reading this data. For now, we
+         * opt for the faster `slice` operation, but there's a solid case for either one, to the
+         * point where we may want this to be configurable.
+         * if len <= MAX_INLINE_SIZE {
             unsafe {
                 Str::from_rep(
                     Inline::from_raw(self.as_ptr().offset(std::cmp::max(0, from as isize)), len)

--- a/src/runtime/writers.rs
+++ b/src/runtime/writers.rs
@@ -60,10 +60,10 @@ use crate::common::{CompileError, FileSpec, Notification, Result};
 use crate::runtime::{command::command_for_write, Str};
 
 /// The maximum number of pending requests in the per-file channels.
-const IO_CHAN_SIZE: usize = 16;
+const IO_CHAN_SIZE: usize = 8;
 
 /// The size of client-side batches.
-const BUFFER_SIZE: usize = 4 << 10;
+const BUFFER_SIZE: usize = 64 << 10;
 
 /// FileFactory abstracts over the portions of the file system used for the output of a frawk
 /// program. It includes "file objects" as well as "stdout", which both implement the io::Write

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -27,7 +27,7 @@ fn assert_folded(p: &str) {
             .stdout,
     )
     .unwrap();
-    assert!(out.contains("MatchConst"))
+    assert!(out.contains("MatchConst") || out.contains("StartsWithConst"))
 }
 
 // Compare two byte slices, up to reordering the lines of each.


### PR DESCRIPTION
This change includes a number of small improvements to speed up field mutation and `$0` reconstruction. 

One of these improvements was to change `Buf::slice_to_str` to prefer `Shared` strings rather than `Inline` strings. For strings that are only read once or twice, the extra `memcpy` of reading into an Inline string ends up being too much overhead. This change generates single-percentage-point decreases in runtime for some aggregation-heavy benchmarks, but I think the overall win for output-heavy benchmarks is enough to keep the change.

The other impact of this change was to make reference counting for many more strings in frawk scripts nontrivial. This revealed two separate bugs in the llvm and cranelift backends: both were `ref`-ing strings and maps too often, leading simple scripts to hold onto the entire input in memory. This took a while to track down, but this bug does appear to be fixed in this change.