### PR TITLE
Print Float as Int if it ends in ".0".

### DIFF
--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -898,8 +898,15 @@ impl<'a> From<Float> for Str<'a> {
         // Per ryu's documentation, we will only ever use 24 bytes when printing an f64.
         let mut ryubuf = ryu::Buffer::new();
         let s = ryubuf.format(f);
-        let mut b = DynamicBuf::new(s.len());
-        b.write(s.as_bytes()).unwrap();
+        let slen = s.len();
+        // Print Float as Int if it ends in ".0".
+        let slen = if &s.as_bytes()[slen - 2..] == b".0" {
+            slen - 2
+        } else {
+            slen
+        };
+        let mut b = DynamicBuf::new(slen);
+        b.write(&s.as_bytes()[..slen]).unwrap();
         unsafe { b.into_str() }
     }
 }


### PR DESCRIPTION
Print Float as Int if it ends in ".0" as this is the default behaviour in other
awk implementations.

Fixes issue #41: Other awks don't print trailing zeros when printing floats.

Test case:

    for AWK in frawk_old frawk_new gawk mawk goawk; do
        echo "${AWK}:";

        echo '1 9.0 5.5 6.600 1234567890' | ${AWK} '
            BEGIN { OFS="\t" }
            {
                print "column 1:", $1, $1 + 0, 0 + $1, $1 + 1.0;
                print "column 2:", $2, $2 + 0, 0 + $2, $2 + 1.0;
                print "column 3:", $3, $3 + 0, 0 + $3, $3 + 0.5;
                print "column 4:", $4, $4 + 0, 0 + $4, $4 + 0.4;
                print "column 5:", $5, $5 + 0, 0 + $5, $5 + 0.4;
            }';
        echo;
    done

Output:

frawk_old:
column 1:	1	1.0	1.0	2.0
column 2:	9.0	9.0	9.0	10.0
column 3:	5.5	5.5	5.5	6.0
column 4:	6.600	6.6	6.6	7.0
column 5:	1234567890	1234567890.0	1234567890.0	1234567890.4

frawk_new:
column 1:	1	1	1	2
column 2:	9.0	9	9	10
column 3:	5.5	5.5	5.5	6
column 4:	6.600	6.6	6.6	7
column 5:	1234567890	1234567890	1234567890	1234567890.4

gawk:
column 1:	1	1	1	2
column 2:	9.0	9	9	10
column 3:	5.5	5.5	5.5	6
column 4:	6.600	6.6	6.6	7
column 5:	1234567890	1234567890	1234567890	1.23457e+09

mawk:
column 1:	1	1	1	2
column 2:	9.0	9	9	10
column 3:	5.5	5.5	5.5	6
column 4:	6.600	6.6	6.6	7
column 5:	1234567890	1234567890	1234567890	1.23457e+09

goawk:
column 1:	1	1	1	2
column 2:	9.0	9	9	10
column 3:	5.5	5.5	5.5	6
column 4:	6.600	6.6	6.6	7
column 5:	1234567890	1234567890	1234567890	1.23457e+09