### PR TITLE
Add toupper and tolower builtin functions

### DIFF
--- a/info/reference.md
+++ b/info/reference.md
@@ -89,6 +89,10 @@ _Unary Operators:_
 * `int(s)`: Convert `s` to an integer. Floating-point numbers are also converted
   (rounded down), potentially without a round-trip through a string
   representation.
+* `tolower(s)`: Returns a copy of `s` where all uppercase ASCII characters are
+  replaced with their lowercase counterparts; other characters are unchanged.
+* `toupper(s)`: Returns a copy of `s` where all lowercase ASCII characters are
+  replaced with their uppercase counterparts; other characters are unchanged.
 
 # Other Functions
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -50,6 +50,8 @@ pub enum Function {
     // For header-parsing logic
     UpdateUsedFields,
     SetFI,
+    ToUpper,
+    ToLower,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -226,6 +228,8 @@ static_map!(
     ["rand", Function::Rand],
     ["srand", Function::Srand],
     ["index", Function::SubstrIndex],
+    ["toupper", Function::ToUpper],
+    ["tolower", Function::ToLower],
     ["system", Function::System]
 );
 
@@ -394,7 +398,7 @@ impl Function {
             Length => (smallvec![incoming[0]], Int),
             Close => (smallvec![Str], Str),
             Sub | GSub => (smallvec![Str, Str, Str], Int),
-            EscapeCSV | EscapeTSV => (smallvec![Str], Str),
+            ToUpper | ToLower | EscapeCSV | EscapeTSV => (smallvec![Str], Str),
             Substr => (smallvec![Str, Int, Int], Str),
             Match => (smallvec![Str, Str], Int),
             // Split's second input can be a map of either type
@@ -418,8 +422,9 @@ impl Function {
             IntFunc(bw) => bw.arity(),
             UpdateUsedFields | Rand | ReseedRng | ReadErrStdin | NextlineStdin | NextFile
             | ReadLineStdinFused => 0,
-            Clear | Srand | System | HexToInt | ToInt | EscapeCSV | EscapeTSV | Close | Length
-            | ReadErr | ReadErrCmd | Nextline | NextlineCmd | Unop(_) => 1,
+            ToUpper | ToLower | Clear | Srand | System | HexToInt | ToInt | EscapeCSV
+            | EscapeTSV | Close | Length | ReadErr | ReadErrCmd | Nextline | NextlineCmd
+            | Unop(_) => 1,
             SetFI | SubstrIndex | Match | Setcol | Binop(_) => 2,
             JoinCSV | JoinTSV | Delete | Contains => 2,
             JoinCols | Substr | Sub | GSub | Split => 3,
@@ -457,8 +462,8 @@ impl Function {
             | Binop(GT) | Binop(LTE) | Binop(GTE) | Binop(EQ) | Length | Split | ReadErr
             | ReadErrCmd | ReadErrStdin | Contains | Delete | Match | Sub | GSub | ToInt
             | System | HexToInt => Ok(Scalar(BaseTy::Int).abs()),
-            JoinCSV | JoinTSV | JoinCols | EscapeCSV | EscapeTSV | Substr | Unop(Column)
-            | Binop(Concat) | Nextline | NextlineCmd | NextlineStdin => {
+            ToUpper | ToLower | JoinCSV | JoinTSV | JoinCols | EscapeCSV | EscapeTSV | Substr
+            | Unop(Column) | Binop(Concat) | Nextline | NextlineCmd | NextlineStdin => {
                 Ok(Scalar(BaseTy::Str).abs())
             }
             SetFI | UpdateUsedFields | NextFile | ReadLineStdinFused | Close => Ok(None),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -294,6 +294,7 @@ impl Function {
                 let v = res;
                 ctx.nw.add_dep(k, arr, Constraint::KeyIn(()));
                 ctx.nw.add_dep(v, arr, Constraint::ValIn(()));
+                ctx.nw.add_dep(arr, v, Constraint::Val(()));
             }
             Function::Sub | Function::GSub => {
                 let out_str = args[2];

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -52,6 +52,7 @@ pub enum Function {
     SetFI,
     ToUpper,
     ToLower,
+    IncMap,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -254,7 +255,7 @@ impl<'a> IsSprintf for &'a str {
 
 impl Function {
     // feedback allows for certain functions to propagate type information back to their arguments.
-    pub(crate) fn feedback(&self, args: &[NodeIx], ctx: &mut types::TypeContext) {
+    pub(crate) fn feedback(&self, args: &[NodeIx], res: NodeIx, ctx: &mut types::TypeContext) {
         use types::{BaseTy, Constraint, TVar::*};
         if args.len() < self.arity().unwrap_or(0) {
             return;
@@ -287,6 +288,13 @@ impl Function {
                 let query = args[1];
                 ctx.nw.add_dep(query, arr, Constraint::KeyIn(()));
             }
+            Function::IncMap => {
+                let arr = args[0];
+                let k = args[1];
+                let v = res;
+                ctx.nw.add_dep(k, arr, Constraint::KeyIn(()));
+                ctx.nw.add_dep(v, arr, Constraint::ValIn(()));
+            }
             Function::Sub | Function::GSub => {
                 let out_str = args[2];
                 let str_const = ctx.constant(Scalar(BaseTy::Str).abs());
@@ -313,6 +321,13 @@ impl Function {
                     a,
                     incoming.len()
                 );
+            }
+        }
+        fn arith_sig(x: compile::Ty, y: compile::Ty) -> (SmallVec<compile::Ty>, compile::Ty) {
+            use compile::Ty::*;
+            match (x, y) {
+                (Str, _) | (_, Str) | (Float, _) | (_, Float) => (smallvec![Float; 2], Float),
+                (_, _) => (smallvec![Int; 2], Int),
             }
         }
         Ok(match self {
@@ -346,10 +361,7 @@ impl Function {
                 Int,
             ),
             Binop(Plus) | Binop(Minus) | Binop(Mod) | Binop(Mult) => {
-                match (incoming[0], incoming[1]) {
-                    (Str, _) | (_, Str) | (Float, _) | (_, Float) => (smallvec![Float; 2], Float),
-                    (_, _) => (smallvec![Int; 2], Int),
-                }
+                arith_sig(incoming[0], incoming[1])
             }
             Binop(Pow) | Binop(Div) => (smallvec![Float;2], Float),
             Contains => match incoming[0] {
@@ -362,6 +374,21 @@ impl Function {
                 MapStrInt | MapStrStr | MapStrFloat => (smallvec![incoming[0], Str], Int),
                 _ => return err!("invalid input spec fo Delete: {:?}", &incoming[..]),
             },
+            IncMap => {
+                let map = incoming[0];
+                if !map.is_array() {
+                    return err!(
+                        "first argument to inc_map must be an array type, got: {:?}",
+                        map
+                    );
+                }
+                let val = map.val().unwrap();
+                let (args, res) = arith_sig(incoming[2], val);
+                (
+                    smallvec![incoming[0], incoming[0].key().unwrap(), args[0]],
+                    res,
+                )
+            }
             Clear => {
                 if incoming.len() == 1 && incoming[0].is_array() {
                     (smallvec![incoming[0]], Int)
@@ -427,7 +454,7 @@ impl Function {
             | Unop(_) => 1,
             SetFI | SubstrIndex | Match | Setcol | Binop(_) => 2,
             JoinCSV | JoinTSV | Delete | Contains => 2,
-            JoinCols | Substr | Sub | GSub | Split => 3,
+            IncMap | JoinCols | Substr | Sub | GSub | Split => 3,
         })
     }
 
@@ -437,6 +464,16 @@ impl Function {
             types::{BaseTy, TVar::*},
             Function::*,
         };
+        fn step_arith(x: &types::State, y: &types::State) -> types::State {
+            use BaseTy::*;
+            match (x, y) {
+                (Some(Scalar(Some(Str))), _)
+                | (_, Some(Scalar(Some(Str))))
+                | (Some(Scalar(Some(Float))), _)
+                | (_, Some(Scalar(Some(Float)))) => Scalar(Float).abs(),
+                (_, _) => Scalar(Int).abs(),
+            }
+        }
         match self {
             IntFunc(bw) => Ok(bw.ret_state()),
             FloatFunc(ff) => Ok(ff.ret_state()),
@@ -447,14 +484,7 @@ impl Function {
                 x => Ok(*x),
             },
             Binop(Plus) | Binop(Minus) | Binop(Mod) | Binop(Mult) => {
-                use BaseTy::*;
-                match (&args[0], &args[1]) {
-                    (Some(Scalar(Some(Str))), _)
-                    | (_, Some(Scalar(Some(Str))))
-                    | (Some(Scalar(Some(Float))), _)
-                    | (_, Some(Scalar(Some(Float)))) => Ok(Scalar(Float).abs()),
-                    (_, _) => Ok(Scalar(Int).abs()),
-                }
+                Ok(step_arith(&args[0], &args[1]))
             }
             Rand | Binop(Div) | Binop(Pow) => Ok(Scalar(BaseTy::Float).abs()),
             Setcol => Ok(Scalar(BaseTy::Null).abs()),
@@ -466,6 +496,7 @@ impl Function {
             | Unop(Column) | Binop(Concat) | Nextline | NextlineCmd | NextlineStdin => {
                 Ok(Scalar(BaseTy::Str).abs())
             }
+            IncMap => Ok(step_arith(&types::val_of(&args[0])?, &args[2])),
             SetFI | UpdateUsedFields | NextFile | ReadLineStdinFused | Close => Ok(None),
         }
     }

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -253,6 +253,20 @@ pub(crate) enum Instr<'a> {
         key: NumTy,
         val: NumTy,
     },
+    IncInt {
+        map_ty: Ty,
+        map: NumTy,
+        key: NumTy,
+        dst: NumTy,
+        by: Reg<Int>,
+    },
+    IncFloat {
+        map_ty: Ty,
+        map: NumTy,
+        key: NumTy,
+        dst: NumTy,
+        by: Reg<Float>,
+    },
     IterBegin {
         map_ty: Ty,
         dst: NumTy,
@@ -737,6 +751,30 @@ impl<'a> Instr<'a> {
                 f(*map, *map_ty);
                 f(*key, map_ty.key().unwrap());
                 f(*val, map_ty.val().unwrap());
+            }
+            IncInt {
+                map_ty,
+                map,
+                key,
+                dst,
+                by,
+            } => {
+                f(*map, *map_ty);
+                f(*key, map_ty.key().unwrap());
+                f(*dst, map_ty.val().unwrap());
+                by.accum(&mut f);
+            }
+            IncFloat {
+                map_ty,
+                map,
+                key,
+                dst,
+                by,
+            } => {
+                f(*map, *map_ty);
+                f(*key, map_ty.key().unwrap());
+                f(*dst, map_ty.val().unwrap());
+                by.accum(&mut f);
             }
             LoadVarStr(dst, _var) => dst.accum(&mut f),
             StoreVarStr(_var, src) => src.accum(&mut f),

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -173,6 +173,8 @@ pub(crate) enum Instr<'a> {
         Reg<Int>,     /* end col */
         Reg<Str<'a>>, /* sep */
     ),
+    ToUpperAscii(Reg<Str<'a>>, Reg<Str<'a>>),
+    ToLowerAscii(Reg<Str<'a>>, Reg<Str<'a>>),
 
     // File reading.
     ReadErr(Reg<Int>, Reg<Str<'a>>, /*is_file=*/ bool),
@@ -644,6 +646,10 @@ impl<'a> Instr<'a> {
                 start.accum(&mut f);
                 end.accum(&mut f);
                 sep.accum(&mut f);
+            }
+            ToUpperAscii(dst, src) | ToLowerAscii(dst, src) => {
+                dst.accum(&mut f);
+                src.accum(&mut f);
             }
             SplitInt(flds, to_split, arr, pat) => {
                 flds.accum(&mut f);

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -119,6 +119,8 @@ pub(crate) fn register_all(cg: &mut impl Backend) -> Result<()> {
         [ReadOnly] join_csv(rt_ty, int_ty, int_ty) -> str_ty;
         [ReadOnly] join_tsv(rt_ty, int_ty, int_ty) -> str_ty;
         [ReadOnly] join_cols(rt_ty, int_ty, int_ty, str_ref_ty) -> str_ty;
+        [ReadOnly] to_upper_ascii(str_ref_ty) -> str_ty;
+        [ReadOnly] to_lower_ascii(str_ref_ty) -> str_ty;
         set_col(rt_ty, int_ty, str_ref_ty);
         split_int(rt_ty, str_ref_ty, map_ty, str_ref_ty) -> int_ty;
         split_str(rt_ty, str_ref_ty, map_ty, str_ref_ty) -> int_ty;
@@ -637,6 +639,16 @@ pub(crate) unsafe extern "C" fn join_cols(
         }),
         "join_cols:"
     );
+    mem::transmute::<Str, U128>(res)
+}
+
+pub(crate) unsafe extern "C" fn to_upper_ascii(s: *mut U128) -> U128 {
+    let res = (&*(s as *mut Str as *const Str)).to_upper_ascii();
+    mem::transmute::<Str, U128>(res)
+}
+
+pub(crate) unsafe extern "C" fn to_lower_ascii(s: *mut U128) -> U128 {
+    let res = (&*(s as *mut Str as *const Str)).to_lower_ascii();
     mem::transmute::<Str, U128>(res)
 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -566,6 +566,8 @@ pub(crate) trait CodeGenerator: Backend {
             StrToFloat(fr, sr) => self.unop(intrinsic!(str_to_float), fr, sr),
             FloatToInt(ir, fr) => self.unop(Op::FloatToInt, ir, fr),
             IntToFloat(fr, ir) => self.unop(Op::IntToFloat, fr, ir),
+            ToLowerAscii(dst, src) => self.unop(intrinsic!(to_lower_ascii), dst, src),
+            ToUpperAscii(dst, src) => self.unop(intrinsic!(to_upper_ascii), dst, src),
             AddInt(res, l, r) => self.binop(op(Arith::Add, false), res, l, r),
             AddFloat(res, l, r) => self.binop(op(Arith::Add, true), res, l, r),
             MinusInt(res, l, r) => self.binop(op(Arith::Minus, false), res, l, r),

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -529,6 +529,33 @@ pub(crate) trait CodeGenerator: Backend {
         Ok(())
     }
 
+    /// Increments the value in `map` at `key` (inserting a default value if necessary) by `by`
+    /// (either a float or int register), storing a copy of the value in `dst`.
+    fn inc_map(&mut self, map: Ref, key: Ref, by: Ref, dst: Ref) -> Result<()> {
+        use compile::Ty::*;
+        map_valid(map.1, key.1, dst.1)?;
+        let func = match (map.1, by.1) {
+            (MapIntInt, Int) => intrinsic!(inc_int_intint),
+            (MapIntFloat, Int) => intrinsic!(inc_int_intfloat),
+            (MapIntStr, Int) => intrinsic!(inc_int_intstr),
+            (MapStrInt, Int) => intrinsic!(inc_int_strint),
+            (MapStrFloat, Int) => intrinsic!(inc_int_strfloat),
+            (MapStrStr, Int) => intrinsic!(inc_int_strstr),
+            (MapIntInt, Float) => intrinsic!(inc_float_intint),
+            (MapIntFloat, Float) => intrinsic!(inc_float_intfloat),
+            (MapIntStr, Float) => intrinsic!(inc_float_intstr),
+            (MapStrInt, Float) => intrinsic!(inc_float_strint),
+            (MapStrFloat, Float) => intrinsic!(inc_float_strfloat),
+            (MapStrStr, Float) => intrinsic!(inc_float_strstr),
+            (_, x) => return err!("invalid increment type passed to inc_map: {:?}", x),
+        };
+        let mapv = self.get_val(map)?;
+        let keyv = self.get_val(key)?;
+        let byv = self.get_val(by)?;
+        let resv = self.call_intrinsic(func, &mut [mapv, keyv, byv])?;
+        self.bind_val(dst, resv)
+    }
+
     /// Wraps `call_intrinsic` for [`Op`]s that have two arguments and return a value.
     fn binop(&mut self, op: Op, dst: &impl Accum, l: &impl Accum, r: &impl Accum) -> Result<()> {
         let lv = self.get_val(l.reflect())?;
@@ -851,6 +878,30 @@ pub(crate) trait CodeGenerator: Backend {
                 (*map, *map_ty),
                 (*key, map_ty.key()?),
                 (*val, map_ty.val()?),
+            ),
+            IncInt {
+                map_ty,
+                map,
+                key,
+                dst,
+                by,
+            } => self.inc_map(
+                (*map, *map_ty),
+                (*key, map_ty.key()?),
+                by.reflect(),
+                (*dst, map_ty.val()?),
+            ),
+            IncFloat {
+                map_ty,
+                map,
+                key,
+                dst,
+                by,
+            } => self.inc_map(
+                (*map, *map_ty),
+                (*key, map_ty.key()?),
+                by.reflect(),
+                (*dst, map_ty.val()?),
             ),
             LoadVarStr(dst, var) => {
                 let rt = self.runtime_val();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1496,6 +1496,16 @@ impl<'a, 'b> View<'a, 'b> {
                     self.pushl(LL::EscapeTSV(res_reg.into(), conv_regs[0].into()))
                 }
             }
+            ToUpper => {
+                if res_reg != UNUSED {
+                    self.pushl(LL::ToUpperAscii(res_reg.into(), conv_regs[0].into()))
+                }
+            }
+            ToLower => {
+                if res_reg != UNUSED {
+                    self.pushl(LL::ToLowerAscii(res_reg.into(), conv_regs[0].into()))
+                }
+            }
             Substr => {
                 if res_reg != UNUSED {
                     self.pushl(LL::Substr(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1594,6 +1594,43 @@ impl<'a, 'b> View<'a, 'b> {
                 }),
                 _ => return err!("incorrect parameter types for Delete: {:?}", &conv_tys[..]),
             },
+            IncMap => {
+                if res_reg == UNUSED {
+                    res_reg = self.regs.stats.reg_of_ty(res_ty);
+                }
+                if !conv_tys[0].is_array()
+                    || conv_tys[0].val()? != res_ty
+                    || conv_tys[0].key()? != conv_tys[1]
+                {
+                    return err!(
+                        "IncMap called with malformed types: {:?} => {:?}",
+                        &conv_tys[..],
+                        dst_ty
+                    );
+                }
+                self.pushl(match conv_tys[2] {
+                    Ty::Int => LL::IncInt {
+                        map_ty: conv_tys[0],
+                        map: conv_regs[0],
+                        key: conv_regs[1],
+                        by: conv_regs[2].into(),
+                        dst: res_reg,
+                    },
+                    Ty::Float => LL::IncFloat {
+                        map_ty: conv_tys[0],
+                        map: conv_regs[0],
+                        key: conv_regs[1],
+                        by: conv_regs[2].into(),
+                        dst: res_reg,
+                    },
+                    _ => {
+                        return err!(
+                            "Incrementing map with non-numeric type: {:?}",
+                            &conv_tys[..]
+                        )
+                    }
+                })
+            }
             Clear => {
                 if conv_tys[0].is_array() {
                     self.pushl(LL::Clear {

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -335,6 +335,18 @@ pub(crate) mod boilerplate {
                 f(Key::MapKey(*map, *map_ty), Some(Key::Reg(*key, map_ty.key().unwrap())));
                 f(Key::MapVal(*map, *map_ty), Some(Key::Reg(*val, map_ty.val().unwrap())));
             }
+            IncInt { map_ty, map, key, dst, by } => {
+                let (reg, ty) = by.reflect();
+                f(Key::MapKey(*map, *map_ty), Some(Key::Reg(*key, map_ty.key().unwrap())));
+                f(Key::MapVal(*map, *map_ty), Some(Key::Reg(reg, ty)));
+                f(Key::Reg(*dst, map_ty.val().unwrap()), Some(Key::MapVal(*map, *map_ty)));
+            }
+            IncFloat { map_ty, map, key, dst, by } => {
+                let (reg, ty) = by.reflect();
+                f(Key::MapKey(*map, *map_ty), Some(Key::Reg(*key, map_ty.key().unwrap())));
+                f(Key::MapVal(*map, *map_ty), Some(Key::Reg(reg, ty)));
+                f(Key::Reg(*dst, map_ty.val().unwrap()), Some(Key::MapVal(*map, *map_ty)));
+            }
             IterBegin { map_ty, dst, map } => {
                 f(Key::Reg(*dst, map_ty.key_iter().unwrap()), Some(Key::MapKey(*map, *map_ty)))
             }
@@ -361,6 +373,7 @@ pub(crate) mod boilerplate {
             },
             StoreVarStr(v, src) => f(Key::Var(*v), Some(src.into())),
             StoreVarInt(v, src) => f(Key::Var(*v), Some(src.into())),
+            
             LoadSlot{ty,slot,dst} =>
                 f(Key::Reg(*dst, *ty), Some(Key::Slot(u32::try_from(*slot).expect("slot too large"), *ty))),
             StoreSlot{ty,slot,src} =>

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -290,6 +290,9 @@ pub(crate) mod boilerplate {
                 f(dst.into(), Some(y.into()));
                 f(dst.into(), Some(z.into()));
             }
+            ToUpperAscii(dst, src) | ToLowerAscii(dst, src) => {
+                f(dst.into(), Some(src.into()));
+            }
             ReadErr(dst, _cmd, _) => f(dst.into(), None),
             NextLine(dst, _cmd, _) => f(dst.into(), None),
             ReadErrStdin(dst) => f(dst.into(), None),

--- a/src/display.rs
+++ b/src/display.rs
@@ -187,6 +187,7 @@ impl Display for Function {
             SetFI => write!(f, "set-FI"),
             ToLower => write!(f, "tolower"),
             ToUpper => write!(f, "toupper"),
+            IncMap => write!(f, "inc_map"),
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -185,6 +185,8 @@ impl Display for Function {
             System => write!(f, "system"),
             UpdateUsedFields => write!(f, "update_used_fields"),
             SetFI => write!(f, "set-FI"),
+            ToLower => write!(f, "tolower"),
+            ToUpper => write!(f, "toupper"),
         }
     }
 }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -836,6 +836,11 @@ it has one more line"#
 
     test_program!(single_stmt, r#"BEGIN {print "hello"}"#, "hello\n");
     test_program!(
+        to_lower_upper,
+        r#"BEGIN { print tolower("Hi1 there"), toupper("hI there"), tolower(tolower("hi there")); }"#,
+        "hi1 there HI THERE hi there\n"
+    );
+    test_program!(
         factorial,
         r#"BEGIN {
     fact=1

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1022,6 +1022,14 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                             self.line.join_cols(start, end, sep, nf, |s| s)?
                         };
                     }
+                    ToUpperAscii(dst, src) => {
+                        let res = index(&self.strs, src).to_upper_ascii();
+                        *index_mut(&mut self.strs, dst) = res;
+                    }
+                    ToLowerAscii(dst, src) => {
+                        let res = index(&self.strs, src).to_lower_ascii();
+                        *index_mut(&mut self.strs, dst) = res;
+                    }
                     SplitInt(flds, to_split, arr, pat) => {
                         // Index manually here to defeat the borrow checker.
                         let to_split = index(&self.strs, to_split);

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1142,6 +1142,20 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         key,
                         val,
                     } => self.store_map(*map_ty, *map, *key, *val),
+                    IncInt {
+                        map_ty,
+                        map,
+                        key,
+                        by,
+                        dst,
+                    } => self.inc_map_int(*map_ty, *map, *key, *by, *dst),
+                    IncFloat {
+                        map_ty,
+                        map,
+                        key,
+                        by,
+                        dst,
+                    } => self.inc_map_float(*map_ty, *map, *key, *by, *dst),
                     LoadVarStr(dst, var) => {
                         let s = self.core.vars.load_str(*var)?;
                         let dst = *dst;
@@ -1376,6 +1390,24 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
             let v = self.get(val).clone();
             self.get(map).insert(k, v);
         });
+    }
+    fn inc_map_int(&mut self, map_ty: Ty, map: NumTy, key: NumTy, by: Reg<Int>, dst: NumTy) {
+        map_regs!(map_ty, map, key, dst, {
+            let k = self.get(key);
+            let m = self.get(map);
+            let by = self.get(by).clone();
+            let res = m.inc_int(k, by);
+            *self.get_mut(dst) = res;
+        })
+    }
+    fn inc_map_float(&mut self, map_ty: Ty, map: NumTy, key: NumTy, by: Reg<Float>, dst: NumTy) {
+        map_regs!(map_ty, map, key, dst, {
+            let k = self.get(key);
+            let m = self.get(map);
+            let by = self.get(by).clone();
+            let res = m.inc_float(k, by);
+            *self.get_mut(dst) = res;
+        })
     }
     fn len(&mut self, map_ty: Ty, map: NumTy, dst: NumTy) {
         let len = map_regs!(map_ty, map, self.get(map).len() as Int);

--- a/src/types.rs
+++ b/src/types.rs
@@ -321,6 +321,15 @@ impl<T: Clone> TVar<T> {
     }
 }
 
+pub(crate) fn val_of(s: &State) -> Result<State> {
+    match s {
+        Some(TVar::Map { val, .. }) => Ok(Some(TVar::Scalar(val.clone()))),
+        None => Ok(None),
+        Some(TVar::Iter(_)) => err!("attempting to get value out of iterator state"),
+        Some(TVar::Scalar(_)) => err!("attempting to get value out of iterator scalar"),
+    }
+}
+
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) enum Constraint<T> {
     // TODO(ezr): Better names for Key/KeyIn etc.
@@ -930,7 +939,7 @@ impl<'b, 'c> TypeContext<'b, 'c> {
 
 impl<'b, 'c, 'd> View<'b, 'c, 'd> {
     fn add_builtin_call(&mut self, f: builtins::Function, args: SmallVec<NodeIx>, to: NodeIx) {
-        f.feedback(&args[..], self);
+        f.feedback(&args[..], to, self);
         for arg in args.iter() {
             self.nw
                 .call_deps

--- a/src/types.rs
+++ b/src/types.rs
@@ -397,12 +397,10 @@ impl Constraint<State> {
                 key: None,
                 val: None,
             })),
-            Constraint::ValIn(Some(TVar::Scalar(v))) => {
-                Ok(Some(TVar::Map {
-                    key: None,
-                    val: v.clone(),
-                }))
-            }
+            Constraint::ValIn(Some(TVar::Scalar(v))) => Ok(Some(TVar::Map {
+                key: None,
+                val: v.clone(),
+            })),
             Constraint::ValIn(op) => err!("Non-scalar ValIn constraint: {:?}", op),
 
             Constraint::Val(None) => Ok(None),

--- a/src/types.rs
+++ b/src/types.rs
@@ -397,10 +397,12 @@ impl Constraint<State> {
                 key: None,
                 val: None,
             })),
-            Constraint::ValIn(Some(TVar::Scalar(v))) => Ok(Some(TVar::Map {
-                key: None,
-                val: v.clone(),
-            })),
+            Constraint::ValIn(Some(TVar::Scalar(v))) => {
+                Ok(Some(TVar::Map {
+                    key: None,
+                    val: v.clone(),
+                }))
+            }
             Constraint::ValIn(op) => err!("Non-scalar ValIn constraint: {:?}", op),
 
             Constraint::Val(None) => Ok(None),
@@ -939,7 +941,12 @@ impl<'b, 'c> TypeContext<'b, 'c> {
 
 impl<'b, 'c, 'd> View<'b, 'c, 'd> {
     fn add_builtin_call(&mut self, f: builtins::Function, args: SmallVec<NodeIx>, to: NodeIx) {
-        f.feedback(&args[..], to, self);
+        // We want to give feedback the opportunity to influence function arguments based on the
+        // return value of the function (this is used in IncMap specifically), but since `to` may
+        // be used in other places, we set up an additional node to soak up "return-specific
+        // information" for the builtin call.
+        let tmp_res = self.nw.add_rule(Rule::Var);
+        f.feedback(&args[..], tmp_res, self);
         for arg in args.iter() {
             self.nw
                 .call_deps
@@ -948,7 +955,10 @@ impl<'b, 'c, 'd> View<'b, 'c, 'd> {
                 .push(to);
         }
         let from = self.nw.base_node;
-        self.nw.add_dep(from, to, Constraint::CallBuiltin(args, f));
+        self.nw
+            .add_dep(from, tmp_res, Constraint::CallBuiltin(args, f));
+        self.nw.add_dep(tmp_res, to, Constraint::Flows(()));
+        self.nw.wl.insert(tmp_res);
         self.nw.wl.insert(to);
     }
     fn add_udf_call(&mut self, f: NumTy, args: SmallVec<NodeIx>, to: NodeIx) {
@@ -972,7 +982,7 @@ impl<'b, 'c, 'd> View<'b, 'c, 'd> {
                 let arr_ix = self.ident_node(arr);
                 let ix_ix = self.val_node(ix);
                 self.constrain_as_map(arr_ix);
-                // TODO(ezr): set up caching for keys, values of maps and iterators?
+                // TODO: set up caching for keys, values of maps and iterators?
                 self.nw.add_dep(ix_ix, arr_ix, Constraint::KeyIn(()));
                 let val_ix = self.nw.add_rule(Rule::Var);
                 self.nw.add_dep(val_ix, arr_ix, Constraint::ValIn(()));


### PR DESCRIPTION
This PR also includes an optimization for increment operations on an array (`m[x] += y` or `m[x]++`). This seems to speed up the groupby module.

I'm not sure if I'm happy with the exact implementation here. I think it might be easier to express this pattern as a peephole-style optimization rather than a syntactic rewrite. I may experiment with that some in the future.

Also left to future work: SIMD implementations of toupper and tolower.