### PR TITLE
Disallow literal regex parsing with last token ]

### DIFF
--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1062,6 +1062,11 @@ print w,z;
     );
 
     test_program!(
+        division_parse, r#"BEGIN { a[0] = 4; t = 2; print "test/test\t" (a[0] / t)}"#,
+        "test/test\t2\n"
+    );
+
+    test_program!(
         identity_function,
         r#"function id(x) { return x; }
         BEGIN { print 1, id(1) }"#,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -552,7 +552,9 @@ impl<'a> Tokenizer<'a> {
     fn potential_re(&self) -> bool {
         match &self.prev_tok {
             Some(Tok::Ident(_)) | Some(Tok::StrLit(_)) | Some(Tok::PatLit(_))
-            | Some(Tok::ILit(_)) | Some(Tok::FLit(_)) | Some(Tok::RParen) => false,
+            | Some(Tok::ILit(_)) | Some(Tok::FLit(_)) | Some(Tok::RParen) | Some(Tok::RBrack) => {
+                false
+            }
             _ => true,
         }
     }


### PR DESCRIPTION
This fixes one of the examples brought up in #54 
For the first example, I think I'll need to do a larger refactor for the parser. Spent some time trying to permute the rules in syntax.lalrpop but I don't think local/tactical changes are going to get us there.