### PR TITLE
Replace custom arena with bumpalo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,9 @@ build = "build.rs"
 
 
 [dependencies]
-elsa = "1.3.2"
 petgraph = "0.4.13"
 smallvec = "1.6"
 hashbrown = "0.9"
-stable_deref_trait = "1.1.1"
 lazy_static = "1.4.0"
 regex = "1.3"
 regex-syntax = "0.6.22"
@@ -47,6 +45,7 @@ cranelift-frontend = "0.69.0"
 cranelift-module = "0.69.0"
 cranelift-jit = "0.69.0"
 fast-float = "0.2"
+bumpalo = { version = "3.6", features = ["collections"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.2"
@@ -57,8 +56,8 @@ tempfile = "3.1.0"
 default = ["use_jemalloc", "allow_avx2", "llvm_backend", "unstable"]
 use_jemalloc = ["jemallocator"]
 # Certain features leverage the AVX2 instruction set, but AVX2 can often make
-# the entire application slightly slower, even on chips that support it. As a
-# result, we default to SSE2 implementations unless this feature is enabled.
+# the entire application slightly slower, even on chips that support it. For
+# those cases, consider disabling allow_avx2.
 allow_avx2 = []
 llvm_backend = ["llvm-sys"]
 unstable = []

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -32,12 +32,8 @@ impl Arena {
             std::slice::from_raw_parts(res_p, bs.len())
         }
     }
-    pub fn alloc_v<T>(&self, t: T) -> &T {
-        self.alloc(move || t)
-    }
-
-    pub fn alloc<T>(&self, f: impl FnOnce() -> T) -> &T {
-        self.0.alloc_with(f)
+    pub fn alloc<T>(&self, t: T) -> &T {
+        self.0.alloc(t)
     }
 }
 
@@ -95,12 +91,12 @@ mod bench {
 
     fn build_2<'a>(a: &'a Arena, depth: usize) -> &'a Arith2<'a> {
         use Arith2::*;
-        let mut expr = a.alloc(|| N(1));
+        let mut expr = a.alloc(N(1));
         for i in 0..depth {
             if i % 2 == 0 {
-                expr = a.alloc(|| Add(expr, a.alloc(|| N(i as i64))));
+                expr = a.alloc(Add(expr, a.alloc(N(i as i64))));
             } else {
-                expr = a.alloc(|| Sub(expr, a.alloc(|| N(i as i64))));
+                expr = a.alloc(Sub(expr, a.alloc(N(i as i64))));
             }
         }
         expr
@@ -108,13 +104,13 @@ mod bench {
 
     fn build_2_cheat<'a>(a: &'a Arena, depth: usize) -> &'a Arith2<'a> {
         use Arith2::*;
-        let n1 = a.alloc(|| N(1));
+        let n1 = a.alloc(N(1));
         let mut expr = n1;
         for i in 0..depth {
             if i % 2 == 0 {
-                expr = a.alloc(|| Add(expr, n1));
+                expr = a.alloc(Add(expr, n1));
             } else {
-                expr = a.alloc(|| Sub(expr, n1));
+                expr = a.alloc(Sub(expr, n1));
             }
         }
         expr

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1,299 +1,43 @@
-//! Implement a simple arena-allocation mechanism around frozen vectors.
-use elsa::FrozenVec;
-use stable_deref_trait::StableDeref;
-
-use std::alloc::{alloc, dealloc, Layout};
-use std::cell::Cell;
-use std::marker::PhantomData;
-use std::mem;
+//! A basic arena allocator.
+//!
+//! This used to include a custom implementation based on frozen vectors that respected Drop calls
+//! automatically (without using a Box type).  It has since been moved to a solution based on the
+//! bumpalo crate, which is now the standard in the broader Rust ecosystem. We keep this as a
+//! wrapper for a couple reasons:
+//!
+//! 1. bumpalo returns a mutable reference by default, but all of the uses of arena-allocated data
+//!    in this proejct use immutable references.
+//! 2. For byte slices and strings, frawk's runtime has special runtime requirements, so we use the
+//!    extra wrapper to enforce those rather than passing them down to the user.
 use std::ptr;
 
-/// The size of arena chunks. Allocating objects larger than this will fall back to the heap.
-const CHUNK_SIZE: usize = 1024;
+#[derive(Default)]
+pub struct Arena(bumpalo::Bump);
 
-struct Chunk {
-    len: Cell<usize>,
-}
-
-impl Chunk {
-    fn layout() -> Layout {
-        Layout::from_size_align(CHUNK_SIZE, mem::align_of::<Chunk>()).unwrap()
-    }
-    unsafe fn new() -> *mut Chunk {
-        let chunk = alloc(Self::layout()) as *mut Chunk;
-        ptr::write(
-            chunk,
-            Chunk {
-                len: Cell::new(mem::size_of::<Chunk>()),
-            },
-        );
-        chunk
-    }
-    unsafe fn dealloc(chunk: *mut Chunk) {
-        dealloc(chunk as *mut u8, Self::layout());
-    }
-    unsafe fn get_raw(&self, off: usize) -> *mut u8 {
-        let p = self as *const Chunk as *mut Chunk as *mut u8;
-        p.offset(off as isize)
-    }
-    unsafe fn alloc_inner<T>(&self, n: usize) -> Option<*mut T> {
-        let size = mem::size_of::<T>() * n;
-        // We plan to do some pointer-tagging elsewhere in the stack. Malloc will hand us back
-        // 8-byte aligned addresses; let's make sure to do the same.
-        let align = std::cmp::max(8, mem::align_of::<T>());
-        let len = self.len.get();
-        let cap = CHUNK_SIZE;
-
-        let extra = self.get_raw(len).align_offset(align);
-        let start = len + extra;
-        let new_len = start + size;
-        if new_len > cap {
-            return None;
-        }
-        // must set len before calling f, as f may call alloc recursively.
-        self.len.set(new_len);
-        Some(self.get_raw(start) as *mut T)
-    }
-
-    fn alloc<T, F: FnOnce() -> T>(&self, f: F) -> Result<&T, F> {
-        unsafe {
-            match self.alloc_inner::<T>(1) {
-                Some(start) => {
-                    ptr::write(start, f());
-                    Ok(&*start)
-                }
-                None => Err(f),
-            }
-        }
-    }
-}
-
-struct ChunkPtr(*mut Chunk);
-
-impl Drop for ChunkPtr {
-    fn drop(&mut self) {
-        unsafe { Chunk::dealloc(self.0) };
-    }
-}
-
-impl Default for ChunkPtr {
-    fn default() -> ChunkPtr {
-        unsafe { ChunkPtr(Chunk::new()) }
-    }
-}
-
-impl std::ops::Deref for ChunkPtr {
-    type Target = Chunk;
-    fn deref(&self) -> &Chunk {
-        unsafe { &*self.0 }
-    }
-}
-
-unsafe impl StableDeref for ChunkPtr {}
-
-pub struct Arena<'outer> {
-    data: FrozenVec<ChunkPtr>,
-    drops: FrozenVec<Box<dyn Fn()>>,
-    _marker: PhantomData<*const &'outer ()>,
-}
-
-impl<'outer> Drop for Arena<'outer> {
-    fn drop(&mut self) {
-        for f in mem::replace(&mut self.drops, Default::default()).into_iter() {
-            f()
-        }
-    }
-}
-
-impl<'outer> Default for Arena<'outer> {
-    fn default() -> Arena<'outer> {
-        let res = Arena {
-            data: Default::default(),
-            drops: Default::default(),
-            _marker: PhantomData,
-        };
-        res.data.push(Default::default());
-        res
-    }
-}
-
-impl<'outer> Arena<'outer> {
-    fn head(&self) -> &Chunk {
-        &self.data[self.data.len() - 1]
-    }
-
+impl Arena {
     pub fn alloc_str<'a>(&'a self, s: &str) -> &'a str {
         let bs = self.alloc_bytes(s.as_bytes());
-        debug_assert_eq!(s.as_bytes(), bs);
         unsafe { std::str::from_utf8_unchecked(bs) }
     }
 
     pub fn alloc_bytes<'a>(&'a self, bs: &[u8]) -> &'a [u8] {
-        use std::slice;
-        if bs.len() == 0 {
-            return &[];
-        }
+        // We want all of these strings to be 8-byte aligned, due to how we represent string
+        // contents at runtime in frawk.
         unsafe {
-            match self.head().alloc_inner::<u8>(bs.len()) {
-                Some(r) => {
-                    ptr::copy_nonoverlapping(&bs[0], r, bs.len());
-                    slice::from_raw_parts_mut(r, bs.len())
-                }
-                None => {
-                    let len = bs.len();
-                    if len >= CHUNK_SIZE / 2 {
-                        let mut v = Vec::new();
-                        v.extend_from_slice(bs);
-                        let b = v.into_boxed_slice();
-                        let p = Box::into_raw(b);
-                        self.drops
-                            .push(Box::new(move || mem::drop(Box::from_raw(p))));
-                        &*p
-                    } else {
-                        self.data.push(ChunkPtr::default());
-                        self.alloc_bytes(bs)
-                    }
-                }
-            }
+            let res_p = self
+                .0
+                .alloc_layout(std::alloc::Layout::from_size_align(bs.len(), 8).unwrap())
+                .as_ptr();
+            ptr::copy_nonoverlapping(bs.as_ptr(), res_p, bs.len());
+            std::slice::from_raw_parts(res_p, bs.len())
         }
     }
-    pub fn alloc_v<T: 'outer>(&self, t: T) -> &T {
+    pub fn alloc_v<T>(&self, t: T) -> &T {
         self.alloc(move || t)
     }
 
-    pub fn alloc<T: 'outer>(&self, f: impl FnOnce() -> T) -> &T {
-        match self.head().alloc(f) {
-            Ok(r) => {
-                if mem::needs_drop::<T>() {
-                    // Close over a *mut u8 instead of a *mut T. Why? Without this the borrow checker
-                    // complains that we are moving a T (with lifetime : 'outer) into a Box (with
-                    // lifetime 'static). We ensure that the Box's contents will be dropped within
-                    // 'outer, so casting away this information is safe.
-                    let rr = r as *const _ as *mut u8;
-                    self.drops.push(Box::new(move || unsafe {
-                        ptr::drop_in_place(rr as *mut T)
-                    }));
-                }
-                return r;
-            }
-            Err(f) => {
-                if mem::size_of::<T>() >= CHUNK_SIZE / 2 {
-                    let b = Box::new(f());
-                    let p = Box::into_raw(b);
-                    let r = p as *mut u8;
-                    self.drops.push(Box::new(move || unsafe {
-                        mem::drop(Box::from_raw(r as *mut T))
-                    }));
-                    unsafe { &*(p as *const T) }
-                } else {
-                    self.data.push(ChunkPtr::default());
-                    self.alloc(f)
-                }
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn bytes(n: usize) -> String {
-        let mut res = Vec::with_capacity(n);
-        use rand::distributions::{Distribution, Uniform};
-        let ascii = Uniform::new_inclusive(0u8, 127u8);
-        let mut rng = rand::thread_rng();
-        for _ in 0..n {
-            res.push(ascii.sample(&mut rng))
-        }
-        String::from_utf8(res).unwrap()
-    }
-
-    #[test]
-    fn alloc_str() {
-        let a = Arena::default();
-        let s = a.alloc_str("test string");
-        assert_eq!(s, "test string");
-        let runs = CHUNK_SIZE / 2 + 2;
-        let mut origs = Vec::with_capacity(runs);
-        let mut arena = Vec::with_capacity(runs);
-        for i in 0..(CHUNK_SIZE / 2 + 2) {
-            let bs = bytes(i);
-            arena.push(a.alloc_str(bs.as_str()));
-            origs.push(bs);
-        }
-        for (orig, arena) in origs.into_iter().zip(arena.into_iter()) {
-            assert_eq!(orig.as_str(), arena);
-        }
-    }
-
-    #[test]
-    fn bumps_for_align() {
-        let a = Arena::default();
-        fn assert_aligned<T>(ptr: *const T) {
-            let align = std::mem::align_of::<T>();
-            let off = (ptr as usize) % align;
-            assert_eq!(off, 0);
-        }
-        let _s = a.alloc_str("a");
-        let i = a.alloc_v(0usize);
-        assert_aligned(i);
-    }
-
-    #[test]
-    fn basic_alloc() {
-        let mut v = Vec::new();
-        let a = Arena::default();
-        let mut sum: usize = 0;
-        for i in 0..1024 {
-            v.push(a.alloc(|| i));
-            sum += i;
-        }
-        let mut rsum = 0;
-        for i in v.iter() {
-            rsum += *i;
-        }
-        assert_eq!(sum, rsum);
-    }
-
-    #[test]
-    fn drop_small() {
-        static mut N_DROPS: usize = 0;
-        struct Dropper;
-        impl Drop for Dropper {
-            fn drop(&mut self) {
-                unsafe {
-                    N_DROPS += 1;
-                }
-            }
-        }
-        {
-            let a = Arena::default();
-            for _ in 0..CHUNK_SIZE {
-                a.alloc(|| Dropper);
-            }
-        }
-        assert_eq!(unsafe { N_DROPS }, CHUNK_SIZE);
-    }
-
-    #[test]
-    fn drop_big() {
-        static mut N_DROPS: usize = 0;
-        #[derive(Default)]
-        struct Dropper([[u64; 8]; 32]);
-        impl Drop for Dropper {
-            fn drop(&mut self) {
-                unsafe {
-                    N_DROPS += 1;
-                }
-            }
-        }
-        {
-            let a = Arena::default();
-            for _ in 0..128 {
-                a.alloc(Dropper::default);
-            }
-        }
+    pub fn alloc<T>(&self, f: impl FnOnce() -> T) -> &T {
+        self.0.alloc_with(f)
     }
 }
 
@@ -349,7 +93,7 @@ mod bench {
         expr
     }
 
-    fn build_2<'a, 'outer>(a: &'a Arena<'outer>, depth: usize) -> &'a Arith2<'a> {
+    fn build_2<'a>(a: &'a Arena, depth: usize) -> &'a Arith2<'a> {
         use Arith2::*;
         let mut expr = a.alloc(|| N(1));
         for i in 0..depth {
@@ -362,7 +106,7 @@ mod bench {
         expr
     }
 
-    fn build_2_cheat<'a, 'outer>(a: &'a Arena<'outer>, depth: usize) -> &'a Arith2<'a> {
+    fn build_2_cheat<'a>(a: &'a Arena, depth: usize) -> &'a Arith2<'a> {
         use Arith2::*;
         let n1 = a.alloc(|| N(1));
         let mut expr = n1;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -83,38 +83,36 @@ fn parse_header<'a, 'b, I: From<&'b str> + Clone>(
     //  update_used_fields()
     // }
 
-    let loop_var = arena.alloc_v(Var(LOOP_VAR.into()));
-    let init = arena.alloc_v(Expr(
-        arena.alloc_v(Assign(loop_var, arena.alloc_v(ILit(1)))),
-    ));
-    let cond = arena.alloc_v(Binop(
+    let loop_var = arena.alloc(Var(LOOP_VAR.into()));
+    let init = arena.alloc(Expr(arena.alloc(Assign(loop_var, arena.alloc(ILit(1))))));
+    let cond = arena.alloc(Binop(
         self::Binop::LTE,
         loop_var,
-        arena.alloc_v(Var("NF".into())),
+        arena.alloc(Var("NF".into())),
     ));
-    let update = arena.alloc_v(Expr(arena.alloc_v(Inc {
+    let update = arena.alloc(Expr(arena.alloc(Inc {
         is_inc: true,
         is_post: false,
         x: loop_var,
     })));
-    let body = arena.alloc_v(Expr(arena.alloc_v(Call(
+    let body = arena.alloc(Expr(arena.alloc(Call(
         Either::Right(Function::SetFI),
         vec![loop_var, loop_var],
     ))));
 
     let block = vec![
-        arena.alloc_v(For(Some(init), Some(cond), Some(update), body)),
-        arena.alloc_v(Expr(
-            arena.alloc_v(Call(Either::Right(Function::UpdateUsedFields), vec![])),
+        arena.alloc(For(Some(init), Some(cond), Some(update), body)),
+        arena.alloc(Expr(
+            arena.alloc(Call(Either::Right(Function::UpdateUsedFields), vec![])),
         )),
     ];
-    begin.push(arena.alloc_v(If(
-        arena.alloc_v(Binop(
+    begin.push(arena.alloc(If(
+        arena.alloc(Binop(
             self::Binop::GT,
-            arena.alloc_v(ReadStdin),
-            arena.alloc_v(ILit(0)),
+            arena.alloc(ReadStdin),
+            arena.alloc(ILit(0)),
         )),
-        arena.alloc_v(Block(block)),
+        arena.alloc(Block(block)),
         /*else*/ None,
     )));
 }
@@ -146,9 +144,9 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
 
         // Desugar -F flag
         if let Some(sep) = self.field_sep {
-            begin.push(arena.alloc_v(Expr(arena.alloc_v(Assign(
-                arena.alloc_v(Var("FS".into())),
-                arena.alloc_v(StrLit(sep)),
+            begin.push(arena.alloc(Expr(arena.alloc(Assign(
+                arena.alloc(Var("FS".into())),
+                arena.alloc(StrLit(sep)),
             )))));
         }
 
@@ -159,42 +157,42 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
 
         // Support "output csv/tsv" mode
         if let Some(sep) = self.output_sep {
-            begin.push(arena.alloc_v(Expr(arena.alloc_v(Assign(
-                arena.alloc_v(Var("OFS".into())),
-                arena.alloc_v(StrLit(sep)),
+            begin.push(arena.alloc(Expr(arena.alloc(Assign(
+                arena.alloc(Var("OFS".into())),
+                arena.alloc(StrLit(sep)),
             )))));
         }
         if let Some(sep) = self.output_record_sep {
-            begin.push(arena.alloc_v(Expr(arena.alloc_v(Assign(
-                arena.alloc_v(Var("ORS".into())),
-                arena.alloc_v(StrLit(sep)),
+            begin.push(arena.alloc(Expr(arena.alloc(Assign(
+                arena.alloc(Var("ORS".into())),
+                arena.alloc(StrLit(sep)),
             )))));
         }
 
         // Assign SUBSEP, which we treat as a normal variable
-        begin.push(arena.alloc_v(Expr(arena.alloc_v(Assign(
-            arena.alloc_v(Var("SUBSEP".into())),
-            arena.alloc_v(StrLit(&[0o034u8])),
+        begin.push(arena.alloc(Expr(arena.alloc(Assign(
+            arena.alloc(Var("SUBSEP".into())),
+            arena.alloc(StrLit(&[0o034u8])),
         )))));
         // Desugar -v flags
         for (ident, exp) in self.prelude_vardecs.iter() {
-            begin.push(arena.alloc_v(Expr(
-                arena.alloc_v(Assign(arena.alloc_v(Var(ident.clone())), exp)),
+            begin.push(arena.alloc(Expr(
+                arena.alloc(Assign(arena.alloc(Var(ident.clone())), exp)),
             )));
         }
 
         // Set argc, argv
         if self.argv.len() > 0 {
-            begin.push(arena.alloc_v(Expr(arena.alloc_v(Assign(
-                arena.alloc_v(Var("ARGC".into())),
-                arena.alloc_v(ILit(self.argv.len() as i64)),
+            begin.push(arena.alloc(Expr(arena.alloc(Assign(
+                arena.alloc(Var("ARGC".into())),
+                arena.alloc(ILit(self.argv.len() as i64)),
             )))));
-            let argv = arena.alloc_v(Var("ARGV".into()));
+            let argv = arena.alloc(Var("ARGV".into()));
             for (ix, arg) in self.argv.iter().enumerate() {
-                let arg = arena.alloc_v(StrLit(arg.as_bytes()));
-                let ix = arena.alloc_v(ILit(ix as i64));
-                let arr_exp = arena.alloc_v(Index(argv, ix));
-                begin.push(arena.alloc_v(Expr(arena.alloc_v(Assign(arr_exp, arg)))));
+                let arg = arena.alloc(StrLit(arg.as_bytes()));
+                let ix = arena.alloc(ILit(ix as i64));
+                let arr_exp = arena.alloc(Index(argv, ix));
+                begin.push(arena.alloc(Expr(arena.alloc(Assign(arr_exp, arg)))));
             }
         }
 
@@ -202,15 +200,15 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
 
         // Desugar patterns into if statements, with the usual desugaring for an empty action.
         let mut inner = vec![
-            arena.alloc_v(Expr(arena.alloc_v(Inc {
+            arena.alloc(Expr(arena.alloc(Inc {
                 is_inc: true,
                 is_post: false,
-                x: arena.alloc_v(Var("NR".into())),
+                x: arena.alloc(Var("NR".into())),
             }))),
-            arena.alloc_v(Expr(arena.alloc_v(Inc {
+            arena.alloc(Expr(arena.alloc(Inc {
                 is_inc: true,
                 is_post: false,
-                x: arena.alloc_v(Var("FNR".into())),
+                x: arena.alloc(Var("FNR".into())),
             }))),
         ];
         let init_len = inner.len();
@@ -218,11 +216,11 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
             let body = if let Some(body) = body {
                 body
             } else {
-                arena.alloc_v(Print(vec![], None))
+                arena.alloc(Print(vec![], None))
             };
             match pat {
                 Pattern::Null => inner.push(body),
-                Pattern::Bool(pat) => inner.push(arena.alloc_v(If(pat, body, None))),
+                Pattern::Bool(pat) => inner.push(arena.alloc(If(pat, body, None))),
                 Pattern::Comma(l, r) => {
                     // Comma patterns run the corresponding action between pairs of lines matching
                     // patterns `l` and `r`, inclusive. One common example is the patterh
@@ -263,23 +261,19 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
                     //      if (Cond(0) == 2) EndCond(0); # _cond_0 = 0;
                     //      next;
                     //  }
-                    inner.push(arena.alloc_v(If(l, arena.alloc_v(StartCond(conds)), None)));
-                    inner.push(arena.alloc_v(If(r, arena.alloc_v(LastCond(conds)), None)));
+                    inner.push(arena.alloc(If(l, arena.alloc(StartCond(conds)), None)));
+                    inner.push(arena.alloc(If(r, arena.alloc(LastCond(conds)), None)));
                     let block = vec![
-                        arena.alloc_v(If(
-                            arena.alloc_v(Binop(
-                                EQ,
-                                arena.alloc_v(Cond(conds)),
-                                arena.alloc_v(ILit(2)),
-                            )),
-                            arena.alloc_v(EndCond(conds)),
+                        arena.alloc(If(
+                            arena.alloc(Binop(EQ, arena.alloc(Cond(conds)), arena.alloc(ILit(2)))),
+                            arena.alloc(EndCond(conds)),
                             None,
                         )),
                         body,
                     ];
-                    inner.push(arena.alloc_v(If(
-                        arena.alloc_v(Cond(conds)),
-                        arena.alloc_v(Block(block)),
+                    inner.push(arena.alloc(If(
+                        arena.alloc(Cond(conds)),
+                        arena.alloc(Block(block)),
                         None,
                     )));
                     conds += 1;
@@ -289,31 +283,31 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
 
         if self.end.len() > 0 || self.prepare.len() > 0 || inner.len() > init_len {
             // Wrap the whole thing in a while((getline) > 0) { } statement.
-            let main_portion = arena.alloc_v(While(
+            let main_portion = arena.alloc(While(
                 /*is_toplevel=*/ true,
-                arena.alloc(|| Binop(GT, arena.alloc(|| ReadStdin), arena.alloc(|| ILit(0)))),
-                arena.alloc(move || Block(inner)),
+                arena.alloc(Binop(GT, arena.alloc(ReadStdin), arena.alloc(ILit(0)))),
+                arena.alloc(Block(inner)),
             ));
             main_loop = Some(if self.prepare.len() > 0 {
                 let mut block = Vec::with_capacity(self.prepare.len() + 1);
                 block.push(main_portion);
                 block.extend(self.prepare.iter().cloned());
-                arena.alloc_v(Stmt::Block(block))
+                arena.alloc(Stmt::Block(block))
             } else {
                 main_portion
             });
         }
         if self.end.len() > 0 {
-            end = Some(arena.alloc_v(Stmt::Block(self.end.clone())));
+            end = Some(arena.alloc(Stmt::Block(self.end.clone())));
         }
         match self.stage {
             Stage::Main(_) => {
                 begin.extend(main_loop.into_iter().chain(end));
-                Stage::Main(arena.alloc_v(Stmt::Block(begin)))
+                Stage::Main(arena.alloc(Stmt::Block(begin)))
             }
             Stage::Par { .. } => Stage::Par {
                 begin: if begin.len() > 0 {
-                    Some(arena.alloc_v(Stmt::Block(begin)))
+                    Some(arena.alloc(Stmt::Block(begin)))
                 } else {
                     None
                 },

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -136,10 +136,7 @@ impl<'a, 'b, I: From<&'b str> + Clone> Prog<'a, 'b, I> {
             stage,
         }
     }
-    pub(crate) fn desugar_stage<'outer>(
-        &self,
-        arena: &'a Arena<'outer>,
-    ) -> Stage<&'a Stmt<'a, 'b, I>> {
+    pub(crate) fn desugar_stage(&self, arena: &'a Arena) -> Stage<&'a Stmt<'a, 'b, I>> {
         use {self::Binop::*, self::Expr::*, Stmt::*};
         let mut conds = 0;
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -538,7 +538,9 @@ where
                 begin: None,
                 main_loop: None,
                 end: None,
-            } => Stage::Main(fill!(Some(&Stmt::Block(vec![])), FunctionName::Begin).unwrap()),
+            } => Stage::Main(
+                fill!(Some(&Stmt::Block(arena.new_vec())), FunctionName::Begin).unwrap(),
+            ),
             Stage::Par {
                 begin,
                 main_loop,
@@ -801,7 +803,7 @@ where
             Printf(fmt, args, out) => {
                 let (mut current_open, fmt_v) = self.convert_val(fmt, current_open)?;
                 let mut arg_vs = SmallVec::with_capacity(args.len());
-                for a in args {
+                for a in args.iter() {
                     let (next, arg_v) = self.convert_val(a, current_open)?;
                     arg_vs.push(arg_v);
                     current_open = next;
@@ -1126,7 +1128,7 @@ where
                     // We don't need in_cond here, it would seem, because there aren't
                     // subexpressions which should be considered patterns.
                     return self.convert_expr(
-                        &Expr::Call(Either::Right(builtins::Function::IncMap), vec![arr, ix, to]),
+                        &Expr::Call(Either::Right(builtins::Function::IncMap), &[arr, ix, to]),
                         current_open,
                     );
                 }
@@ -1214,7 +1216,7 @@ where
                     ),
                 )?;
                 return self.convert_expr(
-                    &ast::Expr::Call(Either::Right(ReadErrStdin), vec![]),
+                    &ast::Expr::Call(Either::Right(ReadErrStdin), &[]),
                     current_open,
                 );
             }
@@ -1272,12 +1274,12 @@ where
                         let (next, _) = self.convert_expr(
                             &ast::Expr::Assign(
                                 into,
-                                &ast::Expr::Call(Either::Right(next_line), vec![from]),
+                                &ast::Expr::Call(Either::Right(next_line), &[from]),
                             ),
                             current_open,
                         )?;
                         return self.convert_expr(
-                            &ast::Expr::Call(Either::Right(read_err), vec![from]),
+                            &ast::Expr::Call(Either::Right(read_err), &[from]),
                             next,
                         );
                     }
@@ -1285,12 +1287,12 @@ where
                         let (next, _) = self.convert_expr(
                             &ast::Expr::Assign(
                                 into,
-                                &ast::Expr::Call(Either::Right(NextlineStdin), vec![]),
+                                &ast::Expr::Call(Either::Right(NextlineStdin), &[]),
                             ),
                             current_open,
                         )?;
                         return self.convert_expr(
-                            &ast::Expr::Call(Either::Right(ReadErrStdin), vec![]),
+                            &ast::Expr::Call(Either::Right(ReadErrStdin), &[]),
                             next,
                         );
                     }
@@ -1309,7 +1311,7 @@ where
 
     fn do_sprintf<'c>(
         &mut self,
-        args: &Vec<&'c Expr<'c, 'b, I>>,
+        args: &'c [&'c Expr<'c, 'b, I>],
         mut current_open: NodeIx,
     ) -> Result<(NodeIx, PrimExpr<'b>)> {
         if args.len() == 0 {
@@ -1591,7 +1593,7 @@ where
         &mut self,
         current_open: NodeIx,
         fname: &Either<I, builtins::Function>,
-        args: &Vec<&'c Expr<'c, 'b, I>>,
+        args: &'c [&'c Expr<'c, 'b, I>],
     ) -> Result<(NodeIx, PrimExpr<'b>)> {
         // Handle call expressions. This is pretty complicated because AWK has several rules that
         // "fill in missing arguments".

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -438,8 +438,8 @@ where
             .collect()
     }
 
-    pub(crate) fn from_prog<'b, 'outer>(
-        arena: &'a arena::Arena<'outer>,
+    pub(crate) fn from_prog<'b>(
+        arena: &'a arena::Arena,
         p: &ast::Prog<'a, 'b, I>,
         esc: Escaper,
     ) -> Result<Self> {

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -317,7 +317,7 @@ pub(crate) fn parse_program<'a, 'inp>(
                 Escaper::TSV => program.output_sep = Some(b"\t"),
                 Escaper::Identity => {}
             };
-            Ok(a.alloc_v(program))
+            Ok(a.alloc(program))
         }
         Err(e) => {
             let mut ix = 0;
@@ -1062,7 +1062,8 @@ print w,z;
     );
 
     test_program!(
-        division_parse, r#"BEGIN { a[0] = 4; t = 2; print "test/test\t" (a[0] / t)}"#,
+        division_parse,
+        r#"BEGIN { a[0] = 4; t = 2; print "test/test\t" (a[0] / t)}"#,
         "test/test\t2\n"
     );
 

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -308,7 +308,7 @@ pub(crate) fn parse_program<'a, 'inp>(
     let prog = a.alloc_str(prog);
     let lexer = lexer::Tokenizer::new(prog);
     let mut buf = Vec::new();
-    let mut program = ast::Prog::from_stage(strat.stage());
+    let mut program = ast::Prog::from_stage(a, strat.stage());
     let parser = syntax::ProgParser::new();
     match parser.parse(a, &mut buf, &mut program, lexer) {
         Ok(()) => {

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -299,9 +299,9 @@ pub(crate) fn used_fields(prog: &str) -> Result<FieldSet> {
     compile::used_fields(&mut ctx)
 }
 
-pub(crate) fn parse_program<'a, 'inp, 'outer>(
+pub(crate) fn parse_program<'a, 'inp>(
     prog: &'inp str,
-    a: &'a Arena<'outer>,
+    a: &'a Arena,
     esc: Escaper,
     strat: ExecutionStrategy,
 ) -> Result<Prog<'a>> {
@@ -332,8 +332,8 @@ pub(crate) fn parse_program<'a, 'inp, 'outer>(
 }
 
 #[cfg(feature = "unstable")]
-fn compile_program<'a, 'inp, 'outer>(
-    a: &'a Arena<'outer>,
+fn compile_program<'a, 'inp>(
+    a: &'a Arena,
     prog: Prog<'a>,
     stdin: impl Into<String>,
     esc: Escaper,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -247,11 +247,7 @@ fn push_char(buf: &mut Vec<u8>, c: char) {
     c.encode_utf8(&mut buf[start..]);
 }
 
-pub(crate) fn parse_string_literal<'a, 'outer>(
-    lit: &str,
-    arena: &'a Arena<'outer>,
-    buf: &mut Vec<u8>,
-) -> &'a [u8] {
+pub(crate) fn parse_string_literal<'a>(lit: &str, arena: &'a Arena, buf: &mut Vec<u8>) -> &'a [u8] {
     fn hex_digit(c: char) -> Option<u8> {
         match c {
             '0'..='9' => Some((c as u8) - b'0'),
@@ -352,11 +348,7 @@ pub(crate) fn parse_string_literal<'a, 'outer>(
     arena.alloc_bytes(&buf[..])
 }
 
-pub(crate) fn parse_regex_literal<'a, 'outer>(
-    lit: &str,
-    arena: &'a Arena<'outer>,
-    buf: &mut Vec<u8>,
-) -> &'a [u8] {
+pub(crate) fn parse_regex_literal<'a>(lit: &str, arena: &'a Arena, buf: &mut Vec<u8>) -> &'a [u8] {
     // Regexes have their own escaping rules, let them apply them. The only think we look to do is
     // replace "\/" with "/".
     // NB: Awk escaping rules are a subset of Rust's regex escape rule syntax, but if we applied

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ use runtime::{
 use std::fs::File;
 use std::io::{self, BufReader, Write};
 use std::iter::once;
+use std::mem;
 
 #[cfg(feature = "use_jemalloc")]
 #[global_allocator]
@@ -184,8 +185,8 @@ fn get_context<'a>(
     let lexer = lexer::Tokenizer::new(prog);
     let mut buf = Vec::new();
     let parser = parsing::syntax::ProgParser::new();
-    let mut prog = ast::Prog::from_stage(prelude.scalars.stage.clone());
-    prog.argv = std::mem::replace(&mut prelude.argv, Default::default());
+    let mut prog = ast::Prog::from_stage(a, prelude.scalars.stage.clone());
+    prog.argv = mem::take(&mut prelude.argv);
     let stmt = match parser.parse(a, &mut buf, &mut prog, lexer) {
         Ok(()) => {
             prog.field_sep = prelude.field_sep;

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ fn get_vars<'a, 'b>(
             );
         }
         let str_lit = lexer::parse_string_literal(split_buf[1], a, buf);
-        res.push((ident, a.alloc_v(ast::Expr::StrLit(str_lit))))
+        res.push((ident, a.alloc(ast::Expr::StrLit(str_lit))))
     }
     res
 }
@@ -193,7 +193,7 @@ fn get_context<'a>(
             prog.output_sep = prelude.output_sep;
             prog.output_record_sep = prelude.output_record_sep;
             prog.parse_header = prelude.scalars.parse_header;
-            a.alloc_v(prog)
+            a.alloc(prog)
         }
         Err(e) => {
             fail!("{}", e);

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -89,45 +89,44 @@ Stmt: &'a Stmt<'a, 'a, &'a str> = {
 }
 
 OpenStmt: &'a Stmt<'a,'a,&'a str> = {
-    "if" "(" <cond:Expr> Rparen <s1:ClosedStmt> Else <s2:OpenStmt> => arena.alloc_v(Stmt::If(cond, s1, Some(s2))),
-    "if" "(" <cond:Expr> Rparen <s1:Stmt> => arena.alloc_v(Stmt::If(cond, s1, None)),
-    "while" "(" <cond:Expr> Rparen <body:OpenStmt> => arena.alloc_v(Stmt::While(false, cond, body)),
+    "if" "(" <cond:Expr> Rparen <s1:ClosedStmt> Else <s2:OpenStmt> => arena.alloc(Stmt::If(cond, s1, Some(s2))),
+    "if" "(" <cond:Expr> Rparen <s1:Stmt> => arena.alloc(Stmt::If(cond, s1, None)),
+    "while" "(" <cond:Expr> Rparen <body:OpenStmt> => arena.alloc(Stmt::While(false, cond, body)),
     "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> Rparen <body:OpenStmt> =>
-        arena.alloc_v(Stmt::For(
-                init.map(|x| arena.alloc_v(Stmt::Expr(x))),
+        arena.alloc(Stmt::For(
+                init.map(|x| arena.alloc(Stmt::Expr(x))),
                 cond,
-                update.map(|x| arena.alloc_v(Stmt::Expr(x))),
+                update.map(|x| arena.alloc(Stmt::Expr(x))),
                 body
         )),
-    // TODO: for ((i, j) in arr)
     "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:OpenStmt> =>
-        arena.alloc_v(Stmt::ForEach(id, arr, body)),
+        arena.alloc(Stmt::ForEach(id, arr, body)),
 }
 
 ClosedStmt: &'a Stmt<'a,'a,&'a str> = {
     BaseStmt,
     "if" "(" <cond:Expr> Rparen <s1:ClosedStmt> Else <s2:ClosedStmt> =>
-           arena.alloc_v(Stmt::If(cond, s1, Some(s2))),
-    "while" "(" <cond:Expr> Rparen <body:ClosedStmt> => arena.alloc_v(Stmt::While(false, cond, body)),
+           arena.alloc(Stmt::If(cond, s1, Some(s2))),
+    "while" "(" <cond:Expr> Rparen <body:ClosedStmt> => arena.alloc(Stmt::While(false, cond, body)),
     "for" "(" <init: ExprNoIn?> ";" <cond:Expr?> ";" <update:Expr?> Rparen <body:ClosedLoopBody> =>
-        arena.alloc_v(Stmt::For(
-                init.map(|x| arena.alloc_v(Stmt::Expr(x))),
+        arena.alloc(Stmt::For(
+                init.map(|x| arena.alloc(Stmt::Expr(x))),
                 cond,
-                update.map(|x| arena.alloc_v(Stmt::Expr(x))),
+                update.map(|x| arena.alloc(Stmt::Expr(x))),
                 body
         )),
     "for" "(" <id:"IDENT"> "in" <arr:Expr> Rparen <body:ClosedLoopBody> =>
-        arena.alloc_v(Stmt::ForEach(id, arr, body)),
+        arena.alloc(Stmt::ForEach(id, arr, body)),
 
 
-    Do <body:BaseStmt> "while" "(" <cond:Expr> ")" Sep => arena.alloc_v(Stmt::DoWhile(cond, body)),
+    Do <body:BaseStmt> "while" "(" <cond:Expr> ")" Sep => arena.alloc(Stmt::DoWhile(cond, body)),
 }
 
 Getline : &'a Expr<'a, 'a, &'a str> = {
     "getline" <into:BaseTerm?> <from:("<" <Expr>)?> =>
-      arena.alloc_v(Expr::Getline{into, from, is_file: true}),
+      arena.alloc(Expr::Getline{into, from, is_file: true}),
     <from:PrecFieldRef> "|" "getline" <into:BaseTerm?> =>
-      arena.alloc_v(Expr::Getline{into, from: Some(from), is_file: false}),
+      arena.alloc(Expr::Getline{into, from: Some(from), is_file: false}),
 }
 
 Redirect: (&'a Expr<'a, 'a, &'a str>, FileSpec) = {
@@ -137,7 +136,7 @@ Redirect: (&'a Expr<'a, 'a, &'a str>, FileSpec) = {
 }
 
 ClosedLoopBody: &'a Stmt<'a, 'a, &'a str> = {
-    SemiSep => arena.alloc_v(Stmt::Block(vec![])),
+    SemiSep => arena.alloc(Stmt::Block(vec![])),
     ClosedStmt,
 }
 
@@ -147,30 +146,30 @@ BaseStmt: &'a Stmt<'a, 'a, &'a str> = {
 }
 
 LeafStmt: &'a Stmt<'a, 'a, &'a str> = {
-    <e: Expr> => arena.alloc_v(Stmt::Expr(e)),
+    <e: Expr> => arena.alloc(Stmt::Expr(e)),
     "delete" <i: IndexBase> =>
-        arena.alloc_v(Stmt::Expr(arena.alloc_v(Expr::Call(Either::Right(Function::Delete), vec![i.0, i.1])))),
+        arena.alloc(Stmt::Expr(arena.alloc(Expr::Call(Either::Right(Function::Delete), vec![i.0, i.1])))),
     "delete" <b: LeafTerm> =>
-        arena.alloc_v(Stmt::Expr(arena.alloc_v(Expr::Call(Either::Right(Function::Clear), vec![b])))),
+        arena.alloc(Stmt::Expr(arena.alloc(Expr::Call(Either::Right(Function::Clear), vec![b])))),
     "print" <pa:PrintArgs?> <re:Redirect?> =>
-        arena.alloc_v(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
     "print(" "\n"* <pa:(<Args?>)> ")" <re:Redirect?> =>
-        arena.alloc_v(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
     "printf" <spec:PrecAdd> <pa: ("," "\n"* <PrintArgs>)?> <re:Redirect?> =>
-        arena.alloc_v(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
     "printf(" "\n"* <spec:(<Expr> "\n"*)> <pa: ("," "\n"* <Args>)?> ")" <re:Redirect?> =>
-        arena.alloc_v(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
-    "break" => arena.alloc_v(Stmt::Break),
-    "continue" => arena.alloc_v(Stmt::Continue),
-    "next" => arena.alloc_v(Stmt::Next),
-    "nextfile" => arena.alloc_v(Stmt::NextFile),
-    "return" <Expr?> => arena.alloc_v(Stmt::Return(<>)),
+        arena.alloc(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
+    "break" => arena.alloc(Stmt::Break),
+    "continue" => arena.alloc(Stmt::Continue),
+    "next" => arena.alloc(Stmt::Next),
+    "nextfile" => arena.alloc(Stmt::NextFile),
+    "return" <Expr?> => arena.alloc(Stmt::Return(<>)),
 }
 
 Block: &'a Stmt<'a,'a,&'a str> = {
-    Lbrace Rbrace SemiSep? => arena.alloc_v(Stmt::Block(vec![])),
+    Lbrace Rbrace SemiSep? => arena.alloc(Stmt::Block(vec![])),
     Lbrace <LeafStmt> Rbrace SemiSep? => <>,
-    Lbrace <BlockInner> Rbrace SemiSep? => arena.alloc_v(Stmt::Block(<>)),
+    Lbrace <BlockInner> Rbrace SemiSep? => arena.alloc(Stmt::Block(<>)),
 }
 
 BlockInner: Vec<&'a Stmt<'a,'a,&'a str>> = {
@@ -211,56 +210,56 @@ Expr: &'a Expr<'a,'a,&'a str> = {
 };
 
 PrecAsgn: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecIn> "=" <r: PrecAsgn> => arena.alloc_v(Expr::Assign(l, r)),
-    <l: PrecIn> "+=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Plus, r)),
-    <l: PrecIn> "-=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Minus, r)),
-    <l: PrecIn> "*=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Mult, r)),
-    <l: PrecIn> "/=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Div, r)),
-    <l: PrecIn> "^=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Pow, r)),
-    <l: PrecIn> "%=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Mod, r)),
+    <l: PrecIn> "=" <r: PrecAsgn> => arena.alloc(Expr::Assign(l, r)),
+    <l: PrecIn> "+=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Plus, r)),
+    <l: PrecIn> "-=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Minus, r)),
+    <l: PrecIn> "*=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Mult, r)),
+    <l: PrecIn> "/=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Div, r)),
+    <l: PrecIn> "^=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Pow, r)),
+    <l: PrecIn> "%=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Mod, r)),
     PrecTern,
 }
 
 LookupList: &'a Expr<'a, 'a, &'a str> = {
     <first:PrecMatch> <rest:("," <PrecMatch>)+> => {
       let mut res = first;
-      let subsep = arena.alloc_v(Expr::Var("SUBSEP"));
+      let subsep = arena.alloc(Expr::Var("SUBSEP"));
       for dim in rest.into_iter() {
-        res = arena.alloc_v(Expr::Binop(Binop::Concat, res, subsep));
-        res = arena.alloc_v(Expr::Binop(Binop::Concat, res, dim));
+        res = arena.alloc(Expr::Binop(Binop::Concat, res, subsep));
+        res = arena.alloc(Expr::Binop(Binop::Concat, res, dim));
       }
       res
    }
 }
 
 PrecTern: &'a Expr<'a, 'a, &'a str> = {
-   <c: PrecOr> "?" <t: PrecTern> ":" <f: PrecTern> => arena.alloc_v(Expr::ITE(c, t, f)),
+   <c: PrecOr> "?" <t: PrecTern> ":" <f: PrecTern> => arena.alloc(Expr::ITE(c, t, f)),
    PrecOr,
 }
 
 PrecOr: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecAnd> Or <r: PrecOr> => arena.alloc_v(Expr::Or(l, r)),
+    <l: PrecAnd> Or <r: PrecOr> => arena.alloc(Expr::Or(l, r)),
     PrecAnd,
 }
 
 PrecAnd: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecIn> And <r: PrecAnd> => arena.alloc_v(Expr::And(l, r)),
+    <l: PrecIn> And <r: PrecAnd> => arena.alloc(Expr::And(l, r)),
     PrecIn,
 }
 
 PrecIn: &'a Expr<'a,'a,&'a str> = {
     <l: PrecMatch> "in" <r: PrecMatch> =>
-        arena.alloc_v(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
+        arena.alloc(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
     "(" <l: LookupList> Rparen "in" <r: PrecMatch> =>
-        arena.alloc_v(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
+        arena.alloc(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
     PrecMatch,
 }
 
 PrecMatch: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecMatch> "~" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::IsMatch, l, r)),
-    <l: PrecMatch> "!~" <r: PrecCmp> => arena.alloc_v(Expr::Unop(
+    <l: PrecMatch> "~" <r: PrecCmp> => arena.alloc(Expr::Binop(Binop::IsMatch, l, r)),
+    <l: PrecMatch> "!~" <r: PrecCmp> => arena.alloc(Expr::Unop(
             Unop::Not,
-            arena.alloc_v(Expr::Binop(Binop::IsMatch, l, r)))),
+            arena.alloc(Expr::Binop(Binop::IsMatch, l, r)))),
     PrecCmp,
 }
 
@@ -273,77 +272,77 @@ ExprNoIn: &'a Expr<'a,'a,&'a str> = {
 };
 
 PrecAsgnNoIn: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecTernNoIn> "=" <r: PrecAsgn> => arena.alloc_v(Expr::Assign(l, r)),
-    <l: PrecTernNoIn> "+=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Plus, r)),
-    <l: PrecTernNoIn> "-=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Minus, r)),
-    <l: PrecTernNoIn> "*=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Mult, r)),
-    <l: PrecTernNoIn> "/=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Div, r)),
-    <l: PrecTernNoIn> "^=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Pow, r)),
-    <l: PrecTernNoIn> "%=" <r: PrecAsgn> => arena.alloc_v(Expr::AssignOp(l, Binop::Mod, r)),
+    <l: PrecTernNoIn> "=" <r: PrecAsgn> => arena.alloc(Expr::Assign(l, r)),
+    <l: PrecTernNoIn> "+=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Plus, r)),
+    <l: PrecTernNoIn> "-=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Minus, r)),
+    <l: PrecTernNoIn> "*=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Mult, r)),
+    <l: PrecTernNoIn> "/=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Div, r)),
+    <l: PrecTernNoIn> "^=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Pow, r)),
+    <l: PrecTernNoIn> "%=" <r: PrecAsgn> => arena.alloc(Expr::AssignOp(l, Binop::Mod, r)),
     PrecTernNoIn,
 }
 
 PrecTernNoIn: &'a Expr<'a, 'a, &'a str> = {
-   <c: PrecOrNoIn> "?" <t: PrecTernNoIn> ":" <f: PrecTern> => arena.alloc_v(Expr::ITE(c, t, f)),
+   <c: PrecOrNoIn> "?" <t: PrecTernNoIn> ":" <f: PrecTern> => arena.alloc(Expr::ITE(c, t, f)),
    PrecOrNoIn,
 }
 
 PrecOrNoIn: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecAndNoIn> Or <r: PrecOrNoIn> => arena.alloc_v(Expr::Or(l, r)),
+    <l: PrecAndNoIn> Or <r: PrecOrNoIn> => arena.alloc(Expr::Or(l, r)),
     PrecAndNoIn,
 }
 
 PrecAndNoIn: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecMatch> And <r: PrecAndNoIn> => arena.alloc_v(Expr::And(l, r)),
+    <l: PrecMatch> And <r: PrecAndNoIn> => arena.alloc(Expr::And(l, r)),
     PrecMatch,
 }
 
 
 PrecCmp: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecAdd> "<" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::LT, l, r)),
-    <l: PrecAdd> "<=" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::LTE, l, r)),
-    <l: PrecAdd> ">" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::GT, l, r)),
-    <l: PrecAdd> ">=" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::GTE, l, r)),
-    <l: PrecAdd> "==" <r: PrecCmp> => arena.alloc_v(Expr::Binop(Binop::EQ, l, r)),
-    <l: PrecAdd> "!=" <r: PrecCmp> => arena.alloc_v(Expr::Unop(Unop::Not, arena.alloc_v(Expr::Binop(Binop::EQ, l, r)))),
+    <l: PrecAdd> "<" <r: PrecCmp> => arena.alloc(Expr::Binop(Binop::LT, l, r)),
+    <l: PrecAdd> "<=" <r: PrecCmp> => arena.alloc(Expr::Binop(Binop::LTE, l, r)),
+    <l: PrecAdd> ">" <r: PrecCmp> => arena.alloc(Expr::Binop(Binop::GT, l, r)),
+    <l: PrecAdd> ">=" <r: PrecCmp> => arena.alloc(Expr::Binop(Binop::GTE, l, r)),
+    <l: PrecAdd> "==" <r: PrecCmp> => arena.alloc(Expr::Binop(Binop::EQ, l, r)),
+    <l: PrecAdd> "!=" <r: PrecCmp> => arena.alloc(Expr::Unop(Unop::Not, arena.alloc(Expr::Binop(Binop::EQ, l, r)))),
     PrecAdd
 }
 
 PrecAdd: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecAdd> "+" <r:PrecMul>  => arena.alloc_v(Expr::Binop(Binop::Plus, l, r)),
-    <l: PrecAdd> "-" <r:PrecMul>  => arena.alloc_v(Expr::Binop(Binop::Minus, l, r)),
+    <l: PrecAdd> "+" <r:PrecMul>  => arena.alloc(Expr::Binop(Binop::Plus, l, r)),
+    <l: PrecAdd> "-" <r:PrecMul>  => arena.alloc(Expr::Binop(Binop::Minus, l, r)),
     PrecMul,
 }
 
 PrecMul: &'a Expr<'a,'a,&'a str> = {
-    <l: PrecMul> "*" <r:PrecPow> => arena.alloc_v(Expr::Binop(Binop::Mult, l, r)),
-    <l: PrecMul> "/" <r:PrecPow> => arena.alloc_v(Expr::Binop(Binop::Div, l, r)),
-    <l: PrecMul> "%" <r:PrecPow> => arena.alloc_v(Expr::Binop(Binop::Mod, l, r)),
+    <l: PrecMul> "*" <r:PrecPow> => arena.alloc(Expr::Binop(Binop::Mult, l, r)),
+    <l: PrecMul> "/" <r:PrecPow> => arena.alloc(Expr::Binop(Binop::Div, l, r)),
+    <l: PrecMul> "%" <r:PrecPow> => arena.alloc(Expr::Binop(Binop::Mod, l, r)),
     PrecPow,
 }
 
 PrecPow: &'a Expr<'a, 'a, &'a str> = {
-    <l: PrecUnop> "^" <r: PrecPow> => arena.alloc_v(Expr::Binop(Binop::Pow, l, r)),
+    <l: PrecUnop> "^" <r: PrecPow> => arena.alloc(Expr::Binop(Binop::Pow, l, r)),
     PrecUnop
 }
 
 PrecUnop: &'a Expr<'a,'a,&'a str> = {
-    "-" <e: PrecInc> => arena.alloc_v(Expr::Unop(Unop::Neg, e)),
-    "+" <e: PrecInc> => arena.alloc_v(Expr::Unop(Unop::Pos, e)),
-    "!" <e: PrecInc> => arena.alloc_v(Expr::Unop(Unop::Not, e)),
+    "-" <e: PrecInc> => arena.alloc(Expr::Unop(Unop::Neg, e)),
+    "+" <e: PrecInc> => arena.alloc(Expr::Unop(Unop::Pos, e)),
+    "!" <e: PrecInc> => arena.alloc(Expr::Unop(Unop::Not, e)),
     PrecInc
 }
 
 PrecInc: &'a Expr<'a,'a,&'a str> = {
-    <e:CatBaseTerm>"++" => arena.alloc_v(Expr::Inc { is_inc: true, is_post: true, x: e }),
-    <e:CatBaseTerm>"--"=> arena.alloc_v(Expr::Inc { is_inc: false, is_post: true, x: e }),
-    "++" <e:CatBaseTerm> => arena.alloc_v(Expr::Inc { is_inc: true, is_post: false, x: e }),
-    "--" <e:CatBaseTerm> => arena.alloc_v(Expr::Inc { is_inc: false, is_post: false, x: e }),
+    <e:CatBaseTerm>"++" => arena.alloc(Expr::Inc { is_inc: true, is_post: true, x: e }),
+    <e:CatBaseTerm>"--"=> arena.alloc(Expr::Inc { is_inc: false, is_post: true, x: e }),
+    "++" <e:CatBaseTerm> => arena.alloc(Expr::Inc { is_inc: true, is_post: false, x: e }),
+    "--" <e:CatBaseTerm> => arena.alloc(Expr::Inc { is_inc: false, is_post: false, x: e }),
     CatBaseTerm,
 }
 
 CatBaseTerm: &'a Expr<'a,'a, &'a str> = {
-    <l: CatBaseTerm> <r: PrecFieldRef> => arena.alloc_v(Expr::Binop(Binop::Concat, l, r)),
+    <l: CatBaseTerm> <r: PrecFieldRef> => arena.alloc(Expr::Binop(Binop::Concat, l, r)),
     PrecFieldRef
 }
 
@@ -353,19 +352,19 @@ PrecFieldRef: &'a Expr<'a,'a,&'a str> = {
 }
 
 Col: &'a Expr<'a,'a,&'a str> = {
-    "$" <e:BaseTerm> => arena.alloc_v(Expr::Unop(Unop::Column, e)),
+    "$" <e:BaseTerm> => arena.alloc(Expr::Unop(Unop::Column, e)),
 }
 
 Ident: &'a Expr<'a,'a,&'a str> = {
-  "IDENT" => arena.alloc_v(Expr::Var(arena.alloc_str(<>))),
+  "IDENT" => arena.alloc(Expr::Var(arena.alloc_str(<>))),
 }
 
 StrLit: &'a Expr<'a,'a,&'a str> = {
-  "STRLIT" => arena.alloc_v(Expr::StrLit(lexer::parse_string_literal(<>, &arena, buf))),
+  "STRLIT" => arena.alloc(Expr::StrLit(lexer::parse_string_literal(<>, &arena, buf))),
 }
 
 Index: &'a Expr<'a,'a,&'a str> = {
-    <i:IndexBase> => arena.alloc_v(Expr::Index(i.0, i.1)),
+    <i:IndexBase> => arena.alloc(Expr::Index(i.0, i.1)),
 }
 
 IndexBase: (&'a Expr<'a,'a,&'a str>, &'a Expr<'a,'a,&'a str>) = {
@@ -382,13 +381,13 @@ BaseTerm: &'a Expr<'a,'a, &'a str> = {
 LeafTerm: &'a Expr<'a,'a, &'a str> = {
   Ident,
   StrLit,
-  "INT" => arena.alloc_v(Expr::ILit(strtoi(<>.as_bytes()))),
-  "HEX" => arena.alloc_v(Expr::ILit(hextoi(<>.as_bytes()))),
-  "FLOAT" => arena.alloc_v(Expr::FLit(strtod(<>.as_bytes()))),
-  "PATLIT" => arena.alloc_v(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf))),
+  "INT" => arena.alloc(Expr::ILit(strtoi(<>.as_bytes()))),
+  "HEX" => arena.alloc(Expr::ILit(hextoi(<>.as_bytes()))),
+  "FLOAT" => arena.alloc(Expr::FLit(strtod(<>.as_bytes()))),
+  "PATLIT" => arena.alloc(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf))),
   // TODO: not Rparen for these next two?
   <i:CallStart> <args:Args?> ")" =>
-        arena.alloc_v(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),
+        arena.alloc(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),
 }
 
 And: () = { "&&" "\n"* }

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -136,7 +136,7 @@ Redirect: (&'a Expr<'a, 'a, &'a str>, FileSpec) = {
 }
 
 ClosedLoopBody: &'a Stmt<'a, 'a, &'a str> = {
-    SemiSep => arena.alloc(Stmt::Block(vec![])),
+    SemiSep => arena.alloc(Stmt::Block(arena.new_vec())),
     ClosedStmt,
 }
 
@@ -148,17 +148,17 @@ BaseStmt: &'a Stmt<'a, 'a, &'a str> = {
 LeafStmt: &'a Stmt<'a, 'a, &'a str> = {
     <e: Expr> => arena.alloc(Stmt::Expr(e)),
     "delete" <i: IndexBase> =>
-        arena.alloc(Stmt::Expr(arena.alloc(Expr::Call(Either::Right(Function::Delete), vec![i.0, i.1])))),
+        arena.alloc(Stmt::Expr(arena.alloc(Expr::Call(Either::Right(Function::Delete), arena.alloc_slice(&[i.0, i.1]))))),
     "delete" <b: LeafTerm> =>
-        arena.alloc(Stmt::Expr(arena.alloc(Expr::Call(Either::Right(Function::Clear), vec![b])))),
+        arena.alloc(Stmt::Expr(arena.alloc(Expr::Call(Either::Right(Function::Clear), arena.alloc_slice(&[b]))))),
     "print" <pa:PrintArgs?> <re:Redirect?> =>
-        arena.alloc(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Print(arena.alloc_slice(pa.unwrap_or_else(Vec::new).as_slice()), re)),
     "print(" "\n"* <pa:(<Args?>)> ")" <re:Redirect?> =>
-        arena.alloc(Stmt::Print(pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Print(arena.alloc_slice(pa.unwrap_or_else(Vec::new).as_slice()), re)),
     "printf" <spec:PrecAdd> <pa: ("," "\n"* <PrintArgs>)?> <re:Redirect?> =>
-        arena.alloc(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Printf(spec, arena.alloc_slice(pa.unwrap_or_else(Vec::new).as_slice()), re)),
     "printf(" "\n"* <spec:(<Expr> "\n"*)> <pa: ("," "\n"* <Args>)?> ")" <re:Redirect?> =>
-        arena.alloc(Stmt::Printf(spec, pa.unwrap_or(Vec::new()), re)),
+        arena.alloc(Stmt::Printf(spec, arena.alloc_slice(pa.unwrap_or_else(Vec::new).as_slice()), re)),
     "break" => arena.alloc(Stmt::Break),
     "continue" => arena.alloc(Stmt::Continue),
     "next" => arena.alloc(Stmt::Next),
@@ -167,9 +167,9 @@ LeafStmt: &'a Stmt<'a, 'a, &'a str> = {
 }
 
 Block: &'a Stmt<'a,'a,&'a str> = {
-    Lbrace Rbrace SemiSep? => arena.alloc(Stmt::Block(vec![])),
+    Lbrace Rbrace SemiSep? => arena.alloc(Stmt::Block(arena.new_vec())),
     Lbrace <LeafStmt> Rbrace SemiSep? => <>,
-    Lbrace <BlockInner> Rbrace SemiSep? => arena.alloc(Stmt::Block(<>)),
+    Lbrace <BlockInner> Rbrace SemiSep? => arena.alloc(Stmt::Block(arena.new_vec_from_slice(&<>[..]))),
 }
 
 BlockInner: Vec<&'a Stmt<'a,'a,&'a str>> = {
@@ -249,9 +249,9 @@ PrecAnd: &'a Expr<'a, 'a, &'a str> = {
 
 PrecIn: &'a Expr<'a,'a,&'a str> = {
     <l: PrecMatch> "in" <r: PrecMatch> =>
-        arena.alloc(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
+        arena.alloc(Expr::Call(Either::Right(Function::Contains), arena.alloc_slice(&[r, l]))),
     "(" <l: LookupList> Rparen "in" <r: PrecMatch> =>
-        arena.alloc(Expr::Call(Either::Right(Function::Contains), vec![r, l])),
+        arena.alloc(Expr::Call(Either::Right(Function::Contains), arena.alloc_slice(&[r, l]))),
     PrecMatch,
 }
 
@@ -387,7 +387,7 @@ LeafTerm: &'a Expr<'a,'a, &'a str> = {
   "PATLIT" => arena.alloc(Expr::PatLit(lexer::parse_regex_literal(<>, &arena, buf))),
   // TODO: not Rparen for these next two?
   <i:CallStart> <args:Args?> ")" =>
-        arena.alloc(Expr::Call(Either::Left(i), args.unwrap_or(vec![]))),
+        arena.alloc(Expr::Call(Either::Left(i), arena.alloc_slice(args.unwrap_or_else(Vec::new).as_slice()))),
 }
 
 And: () = { "&&" "\n"* }

--- a/src/parsing/syntax.lalrpop
+++ b/src/parsing/syntax.lalrpop
@@ -10,8 +10,8 @@ use crate::{
   lexer::{self, Tok},
 };
 
-grammar<'a, 'outer>(
-  arena: &'a Arena<'outer>,
+grammar<'a>(
+  arena: &'a Arena,
   buf: &mut Vec<u8>,
   prog: &mut Prog<'a, 'a, &'a str>,
 );


### PR DESCRIPTION
I don't think I knew about bumpalo when I started this project, but there's basically no reason to use the old custom arena instead of this one.

This PR migrates the arena module from a custom implementation based on frozen vectors to a thin wrapper around bumpalo. It also changes the vectors to use bumpalo's custom Vec type, to move even more of the frontend data structures into the arena. Various cleanups along the way too.