### PR TITLE
Fix non avx2

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [build]
-rustflags = ["-C", "target-cpu=native", "-A" , "unused_attributes"]
+# rustflags = ["-C", "target-cpu=native", "-A" , "unused_attributes"]
+rustflags = ["-A" , "unused_attributes"]
 
 [profile.dev]
 split-debuginfo = 'unpacked'

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,5 @@
 [build]
-# rustflags = ["-C", "target-cpu=native", "-A" , "unused_attributes"]
-rustflags = ["-A" , "unused_attributes"]
+rustflags = ["-C", "target-cpu=native", "-A" , "unused_attributes"]
 
 [profile.dev]
 split-debuginfo = 'unpacked'

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -1189,7 +1189,7 @@ mod sse2 {
 
     impl Vector for Impl {
         const VEC_BYTES: usize = 16;
-        #[inline(always)]
+        #[target_feature(enable = "sse2")]
         unsafe fn fill_input(bptr: *const u8) -> Self {
             Impl {
                 lo: _mm_loadu_si128(bptr as *const _),
@@ -1197,28 +1197,28 @@ mod sse2 {
             }
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "sse2")]
         unsafe fn mask(self) -> u64 {
             let lo = _mm_movemask_epi8(self.lo) as u32 as u64;
             let hi = _mm_movemask_epi8(self.hi) as u32 as u64;
             lo | hi << Self::VEC_BYTES
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "sse2")]
         unsafe fn or(self, rhs: Self) -> Self {
             let lo = _mm_or_si128(self.lo, rhs.lo);
             let hi = _mm_or_si128(self.hi, rhs.hi);
             Impl { lo, hi }
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "sse2")]
         unsafe fn and(self, rhs: Self) -> Self {
             let lo = _mm_and_si128(self.lo, rhs.lo);
             let hi = _mm_and_si128(self.hi, rhs.hi);
             Impl { lo, hi }
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "sse2")]
         unsafe fn cmp_against_input(self, m: u8) -> Self {
             // Load the mask into all lanes.
             let mask = _mm_set1_epi8(m as i8);
@@ -1227,6 +1227,7 @@ mod sse2 {
             Impl { lo, hi }
         }
 
+        #[target_feature(enable = "sse2")]
         unsafe fn find_quote_mask(
             self,
             prev_iter_inside_quote: &mut u64,
@@ -1250,7 +1251,7 @@ mod avx2 {
 
     impl Vector for Impl {
         const VEC_BYTES: usize = 32;
-        #[inline(always)]
+        #[target_feature(enable = "avx2")]
         unsafe fn fill_input(bptr: *const u8) -> Self {
             Impl {
                 lo: _mm256_loadu_si256(bptr as *const _),
@@ -1258,28 +1259,28 @@ mod avx2 {
             }
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "avx2")]
         unsafe fn mask(self) -> u64 {
             let lo = _mm256_movemask_epi8(self.lo) as u32 as u64;
             let hi = _mm256_movemask_epi8(self.hi) as u32 as u64;
             lo | hi << Self::VEC_BYTES
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "avx2")]
         unsafe fn or(self, rhs: Self) -> Self {
             let lo = _mm256_or_si256(self.lo, rhs.lo);
             let hi = _mm256_or_si256(self.hi, rhs.hi);
             Impl { lo, hi }
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "avx2")]
         unsafe fn and(self, rhs: Self) -> Self {
             let lo = _mm256_and_si256(self.lo, rhs.lo);
             let hi = _mm256_and_si256(self.hi, rhs.hi);
             Impl { lo, hi }
         }
 
-        #[inline(always)]
+        #[target_feature(enable = "avx2")]
         unsafe fn cmp_against_input(self, m: u8) -> Self {
             // Load the mask into all lanes.
             let mask = _mm256_set1_epi8(m as i8);
@@ -1288,6 +1289,7 @@ mod avx2 {
             Impl { lo, hi }
         }
 
+        #[target_feature(enable = "avx2")]
         unsafe fn find_quote_mask(
             self,
             prev_iter_inside_quote: &mut u64,

--- a/src/runtime/splitter/chunk.rs
+++ b/src/runtime/splitter/chunk.rs
@@ -9,7 +9,7 @@ use crate::common::Result;
 use crate::runtime::{
     splitter::{
         batch::{
-            get_find_indexes, get_find_indexes_bytes, InputFormat, Offsets, WhitespaceIndexKernel,
+            get_find_indexes, BytesIndexKernel, InputFormat, Offsets, WhitespaceIndexKernel,
             WhitespaceOffsets,
         },
         Reader,
@@ -94,8 +94,8 @@ pub fn new_offset_chunk_producer_bytes<R: Read>(
     record_sep: u8,
     start_version: u32,
     check_utf8: bool,
+    find_indexes: BytesIndexKernel,
 ) -> OffsetChunkProducer<R, impl FnMut(&[u8], &mut Offsets)> {
-    let find_indexes = get_find_indexes_bytes();
     OffsetChunkProducer {
         name: name.into(),
         inner: Reader::new(r, chunk_size, /*padding=*/ 128, check_utf8),
@@ -168,6 +168,7 @@ pub fn new_chained_offset_chunk_producer_bytes<
     field_sep: u8,
     record_sep: u8,
     check_utf8: bool,
+    kernel: BytesIndexKernel,
 ) -> ChainedChunkProducer<OffsetChunkProducer<R, impl FnMut(&[u8], &mut Offsets)>> {
     ChainedChunkProducer::new(
         r.enumerate()
@@ -180,6 +181,7 @@ pub fn new_chained_offset_chunk_producer_bytes<
                     record_sep,
                     /*start_version=*/ (i as u32).wrapping_add(1),
                     check_utf8,
+                    kernel,
                 )
             })
             .collect(),

--- a/src/runtime/splitter/chunk.rs
+++ b/src/runtime/splitter/chunk.rs
@@ -9,8 +9,8 @@ use crate::common::Result;
 use crate::runtime::{
     splitter::{
         batch::{
-            get_find_indexes, get_find_indexes_ascii_whitespace, get_find_indexes_bytes,
-            InputFormat, Offsets, WhitespaceOffsets,
+            get_find_indexes, get_find_indexes_bytes, InputFormat, Offsets, WhitespaceIndexKernel,
+            WhitespaceOffsets,
         },
         Reader,
     },
@@ -114,8 +114,8 @@ pub fn new_offset_chunk_producer_ascii_whitespace<R: Read>(
     name: &str,
     start_version: u32,
     check_utf8: bool,
+    find_indexes: WhitespaceIndexKernel,
 ) -> WhitespaceChunkProducer<R, impl FnMut(&[u8], &mut WhitespaceOffsets, u64) -> u64> {
-    let find_indexes = get_find_indexes_ascii_whitespace();
     WhitespaceChunkProducer(
         OffsetChunkProducer {
             name: name.into(),
@@ -194,6 +194,7 @@ pub fn new_chained_offset_chunk_producer_ascii_whitespace<
     r: I,
     chunk_size: usize,
     check_utf8: bool,
+    find_indexes: WhitespaceIndexKernel,
 ) -> ChainedChunkProducer<
     WhitespaceChunkProducer<R, impl FnMut(&[u8], &mut WhitespaceOffsets, u64) -> u64>,
 > {
@@ -206,6 +207,7 @@ pub fn new_chained_offset_chunk_producer_ascii_whitespace<
                     name.borrow(),
                     /*start_version=*/ (i as u32).wrapping_add(1),
                     check_utf8,
+                    find_indexes,
                 )
             })
             .collect(),

--- a/src/runtime/utf8.rs
+++ b/src/runtime/utf8.rs
@@ -327,6 +327,8 @@ mod x86 {
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
 
+    // TODO: use target_feature = "sse2" here?
+
     #[inline]
     unsafe fn check_smaller_than_0xf4(current_bytes: __m128i, has_error: &mut __m128i) {
         // Intel doesn't define a byte-wise comparison instruction. We could load these byte values


### PR DESCRIPTION
This change fixes the core bug pointed out in #60, though part of the ensuing discussion on that issue has pointed out to me that frawk does not have great support for people with CPUs that do not support AVX. This change will fix bugs that show up when those folks build from source on such a machine, but there's more work to do before we can reliably ship binary releases that will work on any (say, post-SSE2) x86-64 machine.