### PR TITLE
Update to LLVM version 12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ jemallocator = { version = "0.3", optional = true }
 rand = "0.8.3"
 lalrpop-util = "0.19.6"
 unicode-xid = "0.2.0"
-llvm-sys = {version = "100", optional = true }
+llvm-sys = {version = "120", optional = true }
 clap = "3.0.0-beta.4"
 crossbeam-channel = "0.4"
 crossbeam = "0.7.3"

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ the LLVM backend, you will need an installation of LLVM 10.0 on your machine:
 
 * See [this site](https://apt.llvm.org/) for installation instructions on some debian-based Linux distros.
 * On Arch `pacman -Sy llvm llvm-libs` and a C compiler (e.g. `clang`) are sufficient as of September 2020.
-* `brew install llvm@10` or similar seem to work on Mac OS.
+* `brew install llvm@12` or similar seem to work on Mac OS.
 
 Depending on where your package manager puts these libraries, you may need to
-point `LLVM_SYS_100_PREFIX` at the llvm library installation (e.g.
-`/usr/lib/llvm-10`).
+point `LLVM_SYS_120_PREFIX` at the llvm library installation (e.g.
+`/usr/lib/llvm-12`).
 
 ### Building Without LLVM
 


### PR DESCRIPTION
This was pointed out in #67 as LLVM 10 is a couple releases back now, and some distros will make it easier to use a newer version. 

Small diff as everything built cleanly.