### PR TITLE
docs: add mac os specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the LLVM backend, you will need an installation of LLVM 12 on your machine:
 
 Depending on where your package manager puts these libraries, you may need to
 point `LLVM_SYS_120_PREFIX` at the llvm library installation (e.g.
-`/usr/lib/llvm-12`).
+`/usr/lib/llvm-12` on Linux or `/usr/local/opt/llvm@12` on Mac OS when installing llvm@12 via Homebrew).
 
 ### Building Without LLVM
 


### PR DESCRIPTION
also needed to add `#![feature(extended_key_value_attributes)]` to `.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/lib.rs` to get around a build failure on Mac OS
```
   Compiling clap v3.0.0-beta.4
error[E0658]: arbitrary expressions in key-value attributes are unstable
 --> /Users/smichael1/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/lib.rs:8:10
  |
8 | #![doc = include_str!("../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #78835 <https://github.com/rust-lang/rust/issues/78835> for more information
  = help: add `#![feature(extended_key_value_attributes)]` to the crate attributes to enable
```

built via `cargo +nightly install --path .`

Thanks again for this project @ezrosent !