### PR TITLE
Add basic support for gensub function

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -35,6 +35,7 @@ pub enum Function {
     SubstrIndex,
     Sub,
     GSub,
+    GenSub,
     EscapeCSV,
     EscapeTSV,
     JoinCols,
@@ -203,6 +204,7 @@ static_map!(
     ["match", Function::Match],
     ["sub", Function::Sub],
     ["gsub", Function::GSub],
+    ["gensub", Function::GenSub],
     ["substr", Function::Substr],
     ["int", Function::ToInt],
     ["hex", Function::HexToInt],
@@ -298,6 +300,7 @@ impl Function {
                 ctx.nw.add_dep(v, arr, Constraint::ValIn(()));
                 ctx.nw.add_dep(arr, v, Constraint::Val(()));
             }
+            // TODO: GenSub?
             Function::Sub | Function::GSub => {
                 let out_str = args[2];
                 let str_const = ctx.constant(Scalar(BaseTy::Str).abs());
@@ -425,6 +428,7 @@ impl Function {
             Length => (smallvec![incoming[0]], Int),
             Close => (smallvec![Str], Str),
             Sub | GSub => (smallvec![Str, Str, Str], Int),
+            GenSub => (smallvec![Str, Str, Str, Str], Str),
             ToUpper | ToLower | EscapeCSV | EscapeTSV => (smallvec![Str], Str),
             Substr => (smallvec![Str, Int, Int], Str),
             Match => (smallvec![Str, Str], Int),
@@ -456,6 +460,7 @@ impl Function {
             SetFI | SubstrIndex | Match | Setcol | Binop(_) => 2,
             JoinCSV | JoinTSV | Delete | Contains => 2,
             IncMap | JoinCols | Substr | Sub | GSub | Split => 3,
+            GenSub => 4,
         })
     }
 
@@ -493,7 +498,7 @@ impl Function {
             | ReadErrCmd | ReadErrStdin | Contains | Delete | Match | Sub | GSub | ToInt
             | System | HexToInt => Ok(Scalar(BaseTy::Int).abs()),
             ToUpper | ToLower | JoinCSV | JoinTSV | JoinCols | EscapeCSV | EscapeTSV | Substr
-            | Unop(Column) | Binop(Concat) | Nextline | NextlineCmd | NextlineStdin => {
+            | Unop(Column) | Binop(Concat) | Nextline | NextlineCmd | NextlineStdin | GenSub => {
                 Ok(Scalar(BaseTy::Str).abs())
             }
             IncMap => Ok(step_arith(&types::val_of(&args[0])?, &args[2])),

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -133,6 +133,13 @@ pub(crate) enum Instr<'a> {
         /*for*/ Reg<Str<'a>>,
         /*in*/ Reg<Str<'a>>,
     ),
+    GenSubDynamic(
+        Reg<Str<'a>>,
+        /*pat*/ Reg<Str<'a>>,
+        /*for*/ Reg<Str<'a>>,
+        /*how*/ Reg<Str<'a>>,
+        /*in*/ Reg<Str<'a>>,
+    ),
     EscapeCSV(Reg<Str<'a>>, Reg<Str<'a>>),
     EscapeTSV(Reg<Str<'a>>, Reg<Str<'a>>),
     Substr(Reg<Str<'a>>, Reg<Str<'a>>, Reg<Int>, Reg<Int>),
@@ -556,6 +563,13 @@ impl<'a> Instr<'a> {
                 res.accum(&mut f);
                 pat.accum(&mut f);
                 s.accum(&mut f);
+                in_s.accum(&mut f);
+            }
+            GenSubDynamic(res, pat, s, how, in_s) => {
+                res.accum(&mut f);
+                pat.accum(&mut f);
+                s.accum(&mut f);
+                how.accum(&mut f);
                 in_s.accum(&mut f);
             }
             EscapeCSV(res, s) | EscapeTSV(res, s) => {

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1737,6 +1737,14 @@ where
                     }?;
                     return Ok((next, PrimExpr::Val(PrimVal::Var(res))));
                 }
+
+                if builtins::Function::GenSub == bi && args.len() == 3 {
+                    // If a third argument isn't provided, we assume you mean $0.
+                    let e = &Expr::Unop(ast::Unop::Column, &Expr::ILit(0));
+                    let (next, v) = self.convert_val(e, open)?;
+                    open = next;
+                    prim_args.push(v);
+                }
                 return Ok((open, PrimExpr::CallBuiltin(bi, prim_args)));
             }
         }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1739,7 +1739,7 @@ where
                 }
 
                 if builtins::Function::GenSub == bi && args.len() == 3 {
-                    // If a third argument isn't provided, we assume you mean $0.
+                    // If a fourth argument isn't provided, we assume you mean $0.
                     let e = &Expr::Unop(ast::Unop::Column, &Expr::ILit(0));
                     let (next, v) = self.convert_val(e, open)?;
                     open = next;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -729,6 +729,16 @@ pub(crate) trait CodeGenerator: Backend {
                     self.call_intrinsic(intrinsic!(subst_all), &mut [rt, patv, sv, in_sv])?;
                 self.bind_val(res.reflect(), resv)
             }
+            GenSubDynamic(res, pat, s, how, in_s) => {
+                let rt = self.runtime_val();
+                let patv = self.get_val(pat.reflect())?;
+                let sv = self.get_val(s.reflect())?;
+                let howv = self.get_val(how.reflect())?;
+                let in_sv = self.get_val(in_s.reflect())?;
+                let resv =
+                    self.call_intrinsic(intrinsic!(gen_subst), &mut [rt, patv, sv, howv, in_sv])?;
+                self.bind_val(res.reflect(), resv)
+            }
             EscapeCSV(dst, s) => self.unop(intrinsic!(escape_csv), dst, s),
             EscapeTSV(dst, s) => self.unop(intrinsic!(escape_tsv), dst, s),
             Substr(res, base, l, r) => {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1505,6 +1505,18 @@ impl<'a, 'b> View<'a, 'b> {
                     conv_regs[2].into(),
                 ))
             }
+            GenSub => {
+                if res_reg != UNUSED {
+                    // TODO: emit specialized versions of GenSub (how to inspect constants?)
+                    self.pushl(LL::GenSubDynamic(
+                        res_reg.into(),
+                        conv_regs[0].into(),
+                        conv_regs[1].into(),
+                        conv_regs[2].into(),
+                        conv_regs[3].into(),
+                    ));
+                }
+            }
             EscapeCSV => {
                 if res_reg != UNUSED {
                     self.pushl(LL::EscapeCSV(res_reg.into(), conv_regs[0].into()))

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -254,6 +254,12 @@ pub(crate) mod boilerplate {
                 f(dstin.into(), Some(x.into()));
                 f(dstin.into(), Some(y.into()));
             }
+            GenSubDynamic(dst, pat, s, how, in_s) => {
+                f(dst.into(), Some(pat.into()));
+                f(dst.into(), Some(s.into()));
+                f(dst.into(), Some(how.into()));
+                f(dst.into(), Some(in_s.into()));
+            }
             EscapeTSV(dst, src) | EscapeCSV(dst, src) => f(dst.into(), Some(src.into())),
             Substr(dst, x, y, z) => {
                 f(dst.into(), Some(x.into()));

--- a/src/display.rs
+++ b/src/display.rs
@@ -171,6 +171,7 @@ impl Display for Function {
             SubstrIndex => write!(f, "index"),
             Sub => write!(f, "sub"),
             GSub => write!(f, "gsub"),
+            GenSub => write!(f, "gensub"),
             EscapeCSV => write!(f, "escape_csv"),
             EscapeTSV => write!(f, "escape_tsv"),
             JoinCSV => write!(f, "join_csv"),

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1399,6 +1399,38 @@ this as well"#
         @input "6.18163e-27\n1.80782e-40\n2.38296e-05\n1.92843e-09\n7.37465e-39\n"
     );
 
+    test_program!(
+        gensub_basic,
+        r#"{$0 = gensub("(Hello), ([a-zA-Z]+)", "\\2", "g", $0)}; {print}"#,
+        "Joe\nNick\nBye, Joe\nRick\nBye, Rich\n",
+        @input "Hello, Joe\nHello, Nick\nBye, Joe\nHello, Rick\nBye, Rich\n"
+    );
+
+    test_program!(
+        gensub_first,
+        r#"BEGIN { v = "1234"; v = gensub("([0-9])([0-9])", "\\2", "1", v); print v}"#,
+        "234\n"
+    );
+
+    test_program!(
+        gensub_second,
+        r#"BEGIN { v = "1234"; v = gensub("([0-9])([0-9])", "\\2", "2", v); print v}"#,
+        "124\n"
+    );
+
+    test_program!(
+        gensub_third, // this matches nothing
+        r#"BEGIN { v = "1234"; v = gensub("([0-9])([0-9])", "\\2", "3", v); print v}"#,
+        "1234\n"
+    );
+
+    test_program!(
+        gensub_on_input, // this matches nothing
+        r#"{print gensub("a", "b", "g")}"#,
+        "bbobb\n",
+        @input "aboba\n"
+    );
+
     // TODO test more operators, consider more edge cases around functions
 }
 

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -883,6 +883,18 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
                         *index_mut(&mut self.strs, in_s) = subbed;
                         *index_mut(&mut self.ints, res) = subs_made;
                     }
+                    GenSubDynamic(res, pat, s, how, in_s) => {
+                        let subbed = {
+                            let pat = index(&self.strs, pat);
+                            let s = index(&self.strs, s);
+                            let how = index(&self.strs, how);
+                            let in_s = index(&self.strs, in_s);
+                            self.core
+                                .regexes
+                                .with_regex(pat, |re| in_s.gen_subst_dynamic(re, s, how))?
+                        };
+                        *index_mut(&mut self.strs, res) = subbed;
+                    }
                     EscapeCSV(res, s) => {
                         *index_mut(&mut self.strs, res) = {
                             let s = index(&self.strs, s);

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -566,7 +566,7 @@ impl<'a> Str<'a> {
 
     pub fn gen_subst_dynamic(&self, pat: &Regex, subst: &Str<'a>, how: &Str<'a>) -> Str<'a> {
         how.with_bytes(|how| {
-            if !how.is_empty() && (how[0] == b'g' || how[0] == b'G') {
+            if !how.is_empty() && matches!(how[0], b'g' | b'G') {
                 self.gen_subst_all(pat, subst)
             } else {
                 // this silently ignores strings that cannot be parsed and treats them as "1"

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -7,7 +7,7 @@
 ///
 /// TODO explain more about what is going on here.
 use crate::pushdown::FieldSet;
-use crate::runtime::{Float, Int};
+use crate::runtime::{strtoi, Float, Int};
 
 use regex::bytes::{Captures, Regex};
 use smallvec::SmallVec;
@@ -569,14 +569,8 @@ impl<'a> Str<'a> {
             if !how.is_empty() && (how[0] == b'g' || how[0] == b'G') {
                 self.gen_subst_all(pat, subst)
             } else {
-                fn parse_int(bytes: &[u8]) -> Option<Int> {
-                    Some(std::str::from_utf8(bytes).ok()?.parse().ok()?)
-                }
-
-                let which = parse_int(how).unwrap_or_else(|| {
-                    eprintln_ignore!("gensub warning: Could not parse \"how\" argument as either 'g'/'G' or a number; Treating as '1'");
-                    1
-                });
+                // this silently ignores strings that cannot be parsed and treats them as "1"
+                let which = strtoi(how);
                 let which = std::cmp::max(1, which);
                 self.gen_subst_n(pat, subst, which)
             }

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -9,7 +9,7 @@
 use crate::pushdown::FieldSet;
 use crate::runtime::{Float, Int};
 
-use regex::bytes::Regex;
+use regex::bytes::{Captures, Regex};
 use smallvec::SmallVec;
 
 use std::alloc::{alloc_zeroed, dealloc, realloc, Layout};
@@ -559,6 +559,85 @@ impl<'a> Str<'a> {
                 } else {
                     buf.write_all(&s[prev..s.len()]).unwrap();
                     (unsafe { buf.into_str() }, count)
+                }
+            })
+        })
+    }
+
+    pub fn gen_subst_dynamic(&self, pat: &Regex, subst: &Str<'a>, how: &Str<'a>) -> Str<'a> {
+        how.with_bytes(|how| {
+            if !how.is_empty() && (how[0] == b'g' || how[0] == b'G') {
+                self.gen_subst_all(pat, subst)
+            } else {
+                // TODO: handle the case with empty "how" and case with gen_subst_n (need to parse)
+                // is there a consistent way to handle errors? or we just abort?
+                let which: Int = std::str::from_utf8(how).unwrap().parse().unwrap();
+                let which = std::cmp::max(1, which);
+                self.gen_subst_n(pat, subst, which)
+            }
+        })
+    }
+
+    pub fn gen_subst_all(&self, pat: &Regex, subst: &Str<'a>) -> Str<'a> {
+        self.with_bytes(|s| {
+            subst.with_bytes(|subst| {
+                let mut buf = DynamicBuf::new(0);
+                let mut prev = 0;
+                let mut count = 0;
+                for c in pat.captures_iter(s) {
+                    let m = c.get(0).unwrap();
+                    buf.write_all(&s[prev..m.start()]).unwrap();
+                    process_match_gen(c, subst, &mut buf).unwrap();
+                    prev = m.end();
+                    count += 1;
+                }
+                if count == 0 {
+                    self.clone()
+                } else {
+                    buf.write_all(&s[prev..s.len()]).unwrap();
+                    unsafe { buf.into_str() }
+                }
+            })
+        })
+    }
+
+    /// Handle the general substitution for a case of integer value in "how"
+    /// Will replace match number `which` (indexed from 1)
+    pub fn gen_subst_n(&self, pat: &Regex, subst: &Str<'a>, which: Int) -> Str<'a> {
+        self.with_bytes(|s| {
+            subst.with_bytes(|subst| {
+                // skip first
+                let start = if which > 1 {
+                    let start = pat
+                        .find_iter(s)
+                        .skip(
+                            which as usize - 2, // 1 to convert from 1-based to 0-based
+                                                // 1 to take the last "next" into account
+                        )
+                        .next();
+                    if let Some(start) = start {
+                        start.end()
+                    } else {
+                        // not enough matches, so return the string verbatim
+                        return self.clone();
+                    }
+                } else {
+                    // no need to skip anything
+                    0
+                };
+
+                if let Some(c) = pat.captures(&s[start..]) {
+                    let m = c.get(0).unwrap();
+                    let end = start + m.end();
+                    let start = start + m.start();
+
+                    let mut buf = DynamicBuf::new(s.len());
+                    buf.write_all(&s[0..start]).unwrap();
+                    process_match_gen(c, subst, &mut buf).unwrap();
+                    buf.write_all(&s[end..]).unwrap();
+                    unsafe { buf.into_str() }
+                } else {
+                    self.clone()
                 }
             })
         })
@@ -1319,6 +1398,50 @@ fn process_match(matched: &[u8], subst: &[u8], w: &mut impl Write) -> io::Result
     Ok(())
 }
 
+/// Helper function for `subst_gen` function; handles the
+fn process_match_gen(matched: Captures, subst: &[u8], w: &mut impl Write) -> io::Result<()> {
+    let mut start = 0;
+    let mut escaped = false;
+    for (i, b) in subst.iter().cloned().enumerate() {
+        match b {
+            b'0'..=b'9' => {
+                if escaped {
+                    w.write_all(&subst[start..i - 1])?;
+                    let n = b - b'0';
+                    let match_ = matched.get(n as usize).unwrap(); // TODO: how to handle errors here?
+                    w.write_all(match_.as_bytes())?;
+                } else {
+                    w.write_all(&subst[start..i])?;
+                    w.write_all(&[b])?;
+                }
+                start = i + 1;
+            }
+            b'&' => {
+                if escaped {
+                    w.write_all(&subst[start..i - 1])?;
+                    w.write_all(&[b'&'])?;
+                } else {
+                    w.write_all(&subst[start..i])?;
+                    w.write_all(matched.get(0).unwrap().as_bytes())?;
+                }
+                start = i + 1;
+            }
+            b'\\' => {
+                if !escaped {
+                    escaped = true;
+                    continue;
+                }
+                w.write_all(&subst[start..i])?;
+                start = i + 1;
+            }
+            _ => {}
+        }
+        escaped = false;
+    }
+    w.write_all(&subst[start..])?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1473,6 +1596,36 @@ And this is the second part"#
         let (s6, subbed) = s1.subst_first(&re1, &s5);
         s6.with_bytes(|bs| assert_eq!(bs, b"hz&hbhc"));
         assert!(subbed);
+    }
+
+    #[test]
+    fn gen_subst_basic() {
+        let s1: Str = "String number one".into();
+        let s2: Str = "m".into();
+        let re1 = Regex::new("n").unwrap();
+        let s3 = s1.gen_subst_dynamic(&re1, &s2, &"g".into());
+        s3.with_bytes(|bs| assert_eq!(bs, b"Strimg mumber ome"));
+
+        let re2 = Regex::new("xxyz").unwrap();
+        let s4 = s3.gen_subst_dynamic(&re2, &s2, &"g".into());
+        assert_eq!(s3, s4);
+
+        let empty = Str::default();
+        let s5 = empty.gen_subst_dynamic(&re1, &s2, &"g".into());
+        assert_eq!(empty, s5);
+
+        let s6: Str = "xxyz substituted into another xxyz".into();
+        let s7 = s6.gen_subst_dynamic(&re2, &s1, &"1".into());
+        s7.with_bytes(|bs| assert_eq!(bs, b"String number one substituted into another xxyz"));
+    }
+
+    #[test]
+    fn gen_subst() {
+        let s1: Str = "abc def".into();
+        let s2: Str = "\\2 \\1 \\0".into();
+        let re1 = Regex::new("(.+) (.+)").unwrap();
+        let s3 = s1.gen_subst_dynamic(&re1, &s2, &"g".into());
+        s3.with_bytes(|bs| assert_eq!(bs, b"def abc abc def"));
     }
 }
 


### PR DESCRIPTION
This adds support for [gensub](https://www.gnu.org/software/gawk/manual/html_node/String-Functions.html#index-gensub_0028_0029-function-_0028gawk_0029-1) function, which is a common GNU extension.

This is accomplished by defining it as a built-in function, adding a bytecode instruction for it and finally implementing it as a method on a `Str`.

I am a bit unsure how to handle runtime errors: should I do something smart or just ad hoc `.unwrap()`s are fine?

Another thing: not sure whether (and how) I should handle `GenSub` in `feedback` function for type propagation

Performance can be improved by handling the very common case of using a constant for "how" parameter and introducing specialized instructions for handling `g` case (replace all) and number case (replace only n-th match)
