### PR TITLE
Fix typos

### DIFF
--- a/info/overview.md
+++ b/info/overview.md
@@ -252,7 +252,7 @@ surprised to discover there were bugs in frawk's parser.
 * frawk has a builtin `join_fields` function that produces a string of a
   particular range of input columns.
 * frawk provides an `int` function for converting a scalar value to an integer,
-  and a `hex` function for converting a hexidecimal string to an integer. It
+  and a `hex` function for converting a hexadecimal string to an integer. It
   also supports hexadecimal numeric literals.
 * For scripts run with either of the `icsv`, `itsv` options, scripts that only
   split by whitespace, or scripts that only use one single-byte record and

--- a/info/types.md
+++ b/info/types.md
@@ -33,7 +33,7 @@ $ awk 'BEGIN { x = "0"; y = x + 2; x = y + 1; print x, y;}'
 Are perfectly valid. This one prints `3 2`. This places Awk somewhere between
 languages like Python, where one variable can be a string at one moment and a
 dictionary at the next, and languages like Rust, where one must make a new type
-to repesent a variable's ability to contain either a number or a string.
+to represent a variable's ability to contain either a number or a string.
 
 Awk arrays have string keys and have scalars as values, though some Awk
 implementations have specialized arrays to handle the case where all the keys
@@ -130,7 +130,7 @@ Into the following SSA:
 ```
 0:
     x0 = 0
-    # If x0, jump to label 1, otherise jump to label 2
+    # If x0, jump to label 1, otherwise jump to label 2
     brif x0 1: 2:
 1:
     x1 = 3

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -6,7 +6,7 @@
 //! wrapper for a couple reasons:
 //!
 //! 1. bumpalo returns a mutable reference by default, but all of the uses of arena-allocated data
-//!    in this proejct use immutable references.
+//!    in this project use immutable references.
 //! 2. For byte slices and strings, frawk's runtime has special runtime requirements, so we use the
 //!    extra wrapper to enforce those rather than passing them down to the user.
 use std::ptr;

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -373,12 +373,12 @@ impl Function {
             Contains => match incoming[0] {
                 MapIntInt | MapIntStr | MapIntFloat => (smallvec![incoming[0], Int], Int),
                 MapStrInt | MapStrStr | MapStrFloat => (smallvec![incoming[0], Str], Int),
-                _ => return err!("invalid input spec fo Contains: {:?}", incoming),
+                _ => return err!("invalid input spec for Contains: {:?}", incoming),
             },
             Delete => match incoming[0] {
                 MapIntInt | MapIntStr | MapIntFloat => (smallvec![incoming[0], Int], Int),
                 MapStrInt | MapStrStr | MapStrFloat => (smallvec![incoming[0], Str], Int),
-                _ => return err!("invalid input spec fo Delete: {:?}", incoming),
+                _ => return err!("invalid input spec for Delete: {:?}", incoming),
             },
             IncMap => {
                 let map = incoming[0];

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1711,7 +1711,7 @@ where
                     // and the result of the call to (g)sub.
                     //
                     // We do the computation, then we assign the substituted string to the
-                    // asignee expression, yielding the saved result.
+                    // assignee expression, yielding the saved result.
                     let to_set = self.fresh_local();
                     let res = self.fresh_local();
                     let last_arg = mem::replace(&mut prim_args[2], PrimVal::Var(to_set));

--- a/src/codegen/clif.rs
+++ b/src/codegen/clif.rs
@@ -48,7 +48,7 @@ const PLACEHOLDER: Ref = (compile::UNUSED, compile::Ty::Null);
 // for debugging
 const DUMP_IR: bool = false;
 
-/// After a function is declared, some additional information is required to map parameteres to
+/// After a function is declared, some additional information is required to map parameters to
 /// variables. `Prelude` contains that information.
 struct Prelude {
     /// The Cranelift-level signature for the function
@@ -953,7 +953,7 @@ impl<'a> View<'a> {
     /// are assumed to be floating point values if `is_float` and (signed, as is the case in frawk)
     /// integer values otherwise.
     ///
-    /// As with the LLVM, we use the "ordered" variants on comparsion: the ones that return false
+    /// As with the LLVM, we use the "ordered" variants on comparison: the ones that return false
     /// if either operand is NaN.
     fn cmp(&mut self, op: crate::codegen::Cmp, is_float: bool, l: Value, r: Value) -> Value {
         use crate::codegen::Cmp::*;

--- a/src/codegen/llvm/builtin_functions.rs
+++ b/src/codegen/llvm/builtin_functions.rs
@@ -1,4 +1,4 @@
-//! This module contains "function defintions" called by compiled frawk programs
+//! This module contains "function definitions" called by compiled frawk programs
 //!
 //! Unlike the intrinsics module, which exposes Rust implementations of some functionality through
 //! some standard calling convention, these "builtins" are implemented in LLVM.

--- a/src/codegen/llvm/intrinsics.rs
+++ b/src/codegen/llvm/intrinsics.rs
@@ -1,6 +1,6 @@
 //! Plumbing used to expose external functions written in rust to LLVM.
 //!
-//! The core data-structure here is [`IntrinsicMap`], which lazily decalres external functions
+//! The core data-structure here is [`IntrinsicMap`], which lazily declares external functions
 //! based on a type signature.
 use super::attr;
 use crate::codegen::FunctionAttr;

--- a/src/common.rs
+++ b/src/common.rs
@@ -262,7 +262,7 @@ impl<T: Clone + Hash + Eq> WorkList<T> {
 }
 
 /// Notification is a simple object used to synchronize multiple threads around a single event
-/// occuring.
+/// occurring.
 ///
 /// Notifications are "one-shot": they only transition from "not notified" to "notified" once.
 /// Based on the absl object of the same name.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -341,7 +341,7 @@ pub(crate) struct Typer<'a> {
     local_globals: HashSet<NumTy>,
     // Why not just store FuncInfo's fields in a Frame?
     // We access Frames one at a time (through a View); but we need access to function arity and
-    // return types across invidual views. We expose these fields in a separate type immutably to
+    // return types across individual views. We expose these fields in a separate type immutably to
     // facilitate that.
     //
     // Another option would be to pass a mutable reference to `frames` for all of bytecode-building
@@ -448,7 +448,7 @@ struct View<'a, 'b> {
     local_globals: &'b HashSet<NumTy>,
     arity: &'b HashMap<NumTy, NumTy>,
     func_info: &'b Vec<FuncInfo>,
-    // The current basic block being filled; It'll be swaped into `frame.cfg` as we translate a
+    // The current basic block being filled; It'll be swapped into `frame.cfg` as we translate a
     // given function cfg.
     stream: &'b mut Node<'a>,
 }
@@ -980,7 +980,7 @@ impl<'a> Typer<'a> {
         // functions that a given function calls.
         //
         // TODO I think the traditional technique here is to use a bit set rather than a hash set.
-        // That's probably the right choice here, because there wont be that many globals and
+        // That's probably the right choice here, because there won't be that many globals and
         // global references aren't likely to be sparse (which is the case where hash sets win).
         //
         // If this ever becomes a problem, that's the obvious optimization to make. Unions for
@@ -1364,7 +1364,7 @@ impl<'a, 'b> View<'a, 'b> {
         // builtin function at the cfg-level to a bytecode instruction. Most of it is pretty
         // mechanical. One subtlety to watch out for is the role of res_reg. reg_reg may be unused,
         // and we are careful not to leak any unused registers into the final bytecode. How to we
-        // handle an unsed result register? It depends:
+        // handle an unused result register? It depends:
         //
         // 1. If the instruction has no side-effects, we just discard the instruction.
         // 2. If the instruction has side-effects, then we allocate a fresh register and use it.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1218,7 +1218,7 @@ Hello there
 how are you
 END
 "#,
-        @input r#"This wont get printed
+        @input r#"This won't get printed
 START
 Hello there
 how are you

--- a/src/input_taint.rs
+++ b/src/input_taint.rs
@@ -2,7 +2,7 @@
 //!
 //! The goal is to detect any strings that are passed to the system shell whose content is
 //! "tainted" by user input. At a high level, we want to allow executing string constants and
-//! concatentations of multiple string constants, but we don't want to allow anything that has
+//! concatenations of multiple string constants, but we don't want to allow anything that has
 //! "touched" user input. We do this to avoid scripts being unexpectedly hijacked based on user
 //! input abusing (e.g.) shell escaping rules in an unexpected way. "tainted", a term we borrow
 //! from Perl's taint checking, essentially means "whose contents are derived from". For example:

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -532,7 +532,7 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
             return Ok(1);
         }
         // For handling the worker portion, we want to transfer the current stdin progress to a
-        // worker thread, but to withold any progress on other files open for read. We'll swap
+        // worker thread, but to withhold any progress on other files open for read. We'll swap
         // these back in when we execute the `end` block, if there is one.
         let mut old_read_files = mem::take(&mut self.read_files.inputs);
         fn wrap_error<T, S>(r: std::result::Result<Result<T>, S>) -> Result<T> {

--- a/src/runtime/splitter/batch.rs
+++ b/src/runtime/splitter/batch.rs
@@ -204,7 +204,7 @@ impl<P: ChunkProducer<Chunk = OffsetChunk>> CSVReader<P> {
         self.cur_chunk.buf = old_buf.try_unique().ok();
         if self.prod.get_chunk(&mut self.cur_chunk)? {
             // We may have received an EOF without getting any data. Increment the version so this
-            // regsiters as an EOF through the `read_state` interface.
+            // registers as an EOF through the `read_state` interface.
             self.cur_chunk.version = std::cmp::max(prev_version, 1);
             return Ok((true, false));
         }

--- a/src/runtime/str_impl.rs
+++ b/src/runtime/str_impl.rs
@@ -1,8 +1,8 @@
-/// Custom string implemenation.
+/// Custom string implementation.
 ///
 /// There is a lot of unsafe code here. Many of the features here can and were implementable in
 /// terms of safe code using enums, and various components of the standard library. We moved to
-/// this representation because it significanly improved some benchmarks in terms of time and
+/// this representation because it significantly improved some benchmarks in terms of time and
 /// space, and it also makes for more ergonomic interop with LLVM.
 ///
 /// TODO explain more about what is going on here.
@@ -377,7 +377,7 @@ impl<'a> From<Str<'a>> for UniqueStr<'a> {
     }
 }
 
-// Why UnsafeCell? We want something that wont increase the size of StrRep, but we also need to
+// Why UnsafeCell? We want something that won't increase the size of StrRep, but we also need to
 // mutate it in-place. We can *almost* just use Cell here, but we cannot implement Clone behind
 // cell.
 #[derive(Default)]

--- a/src/runtime/utf8.rs
+++ b/src/runtime/utf8.rs
@@ -1,6 +1,6 @@
 /// SIMD-accelerated UTF8 validation. A good clip faster in the ASCII fast-path,
 /// and over 3x faster when validating non-ASCII UTF-8. Only x86 is supported for now, with
-/// fallback to the standard libary string conversion routines if SSE2 is unavailable.
+/// fallback to the standard library string conversion routines if SSE2 is unavailable.
 // TODO: support AVX2 or neon?
 use std::str;
 
@@ -370,7 +370,7 @@ mod x86 {
         //
         // This computation helps check this by shifting the lengths to the right by 1 and
         // subtracting 1, then 2/by 2, then 3/by 3 and summing all 4 of the vectors. The last two can
-        // be done in one step by first summing the inital vector and the vector shifted by 1, and
+        // be done in one step by first summing the initial vector and the vector shifted by 1, and
         // then shifting that intermediate sum by 2.
         //
         //     initial = [4 0 0 0 3 0 0 1], previous = [2 1 2 1 4 3 2 1]

--- a/src/runtime/writers.rs
+++ b/src/runtime/writers.rs
@@ -79,7 +79,7 @@ pub trait FileFactory: Clone + 'static + Send + Sync {
         command_for_write(cmd)
     }
     fn build(&self, path: &str, spec: FileSpec) -> io::Result<Self::Output>;
-    // TODO maybe we shold support this returning an error.
+    // TODO maybe we should support this returning an error.
     fn stdout(&self) -> Self::Stdout;
 }
 
@@ -412,7 +412,7 @@ impl FileHandle {
 
     fn read_error(&self) -> CompileError {
         // The receiver shut down before we did. That means something went wrong: probably an IO
-        // error of some kind. In that case, the receiver thread stashed away the error it recieved
+        // error of some kind. In that case, the receiver thread stashed away the error it received
         // in raw.error for us to read it out. We don't optimize this path too aggressively because
         // IO errors in frawk scripts are fatal.
         const BAD_SHUTDOWN_MSG: &str = "internal error: (writer?) thread did not shut down cleanly";

--- a/src/types.rs
+++ b/src/types.rs
@@ -267,7 +267,7 @@
 //! string and an integer) does not change these initial guesses; so the solver would return its
 //! current solution.
 //!
-//! This sort of achitecture is inspired by classic [static analysis algorithms] that find the least
+//! This sort of architecture is inspired by classic [static analysis algorithms] that find the least
 //! fixed points of recursive equations phrased as monotone functions on some partial order with
 //! finite height, along with [Propagators]
 //!
@@ -844,7 +844,7 @@ impl<'b, 'c> TypeContext<'b, 'c> {
         }
     }
     pub(crate) fn constrain_as_map(&mut self, ix: NodeIx) {
-        // To be completely explicit, this function assigns a unique `Flows` constaint into a map
+        // To be completely explicit, this function assigns a unique `Flows` constraint into a map
         // from the constant node that "just specifies the node is a Map".
         if self.maps.insert(ix) {
             let is_map = self.constant(Some(TVar::Map {

--- a/tests/nawk_p.rs
+++ b/tests/nawk_p.rs
@@ -8,7 +8,7 @@
 //! * `length` is not syntactic sugar for `length($0)`.
 //! * frawk prints more digits on floating point values by default.
 //! * frawk's parser requires semicolons between a last statement and a `}` sometimes
-//! * frawk's rules aronud comparing strings and numbers are different, e.g. "Russia < 1" is true
+//! * frawk's rules around comparing strings and numbers are different, e.g. "Russia < 1" is true
 //!   in frawk but false in awk/mawk.
 
 use assert_cmd::Command;


### PR DESCRIPTION
Found via `codespell -S target -L crate,strat,nin,te,upto,mumber`