### PR TITLE
Remove leading space before 3 in example

### DIFF
--- a/info/overview.md
+++ b/info/overview.md
@@ -68,7 +68,7 @@ with embedded commas in some fields, such as
 ```
 Item,Quantity
 Carrot,2
-"The Deluge: The Great War, America and the Remaking of the Global Order, 1916-1931", 3
+"The Deluge: The Great War, America and the Remaking of the Global Order, 1916-1931",3
 Banana,4
 ```
 


### PR DESCRIPTION
I am not trying to be pedantic here, however, reading through the overview, I expect `frawk -i csv 'NR>1 { SUM+=$2 } END { print SUM }'` to output `9` instead of `6` (the same as `awk`), especially given the context.
I am not sure what the correct way to handle whitespace in csv columns is, but clearly, this is a bad example. It took me a good ten minutes trying to figure it out, and I am sure this will stump some beginner again in the future.