### PR TITLE
Improve parsing of awk programs which have omitted curly braces around s…

### DIFF
--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -321,6 +321,29 @@ fn trivial_parallel_rc() {
 }
 
 #[test]
+fn statement_closed_by_right_brace() {
+    let expected = "test\n";
+    for (prog, rc) in [
+        (r#"BEGIN { if (1 == 1) print "test" }"#, 0),
+        (r#"BEGIN { if (1 == 1) if (2==2) print "test" }"#, 0),
+        (r#"BEGIN { if (1 == 1) if (2==3) print "wrongtest"; else print "test" }"#, 0),
+        (r#"BEGIN { for (i=0; i<1; i++) print "test" }"#, 0),
+        (r#"BEGIN { print "test"; while(n-->0){}}"#, 0),
+    ] {
+        for backend_arg in BACKEND_ARGS {
+            Command::cargo_bin("frawk")
+                .unwrap()
+                .arg(String::from(*backend_arg))
+                .arg(String::from(prog))
+                .arg("-pr")
+                .assert()
+                .stdout(expected)
+                .code(rc);
+        }
+    }
+}
+
+#[test]
 fn multi_rc() {
     let mut text = String::default();
     for _ in 0..50_000 {


### PR DESCRIPTION
…ingle statements

Improve parsing of awk programs which have single statements after a `if`, `else`, `while`t or `for` block but with omitted curly braces.

Those programs could not be parsed by fawk before and would give:

    Unrecognized token `}` found at line X, column Y:line X, column Y+1
    Expected one of "\n" or ";"

In awk statements are terminated by semicolons, newlines or right braces. The current lalrpop grammar does not support parsing statements that are terminated by right braces, so a ';' gets injected before a '}' if none of the following conditions occurs:
  - Previous token is not a newline or ';'.
  - Previous token is not a '{', as "{}" should not be converted to invalid "{;}".